### PR TITLE
Oppsett for lokal utvikling for navigasjonsmeny

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3780,6 +3780,19 @@
       "integrity": "sha1-Z29us8OZl8LuGsOpJP1hJHSPV40=",
       "dev": true
     },
+    "copyfiles": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/copyfiles/-/copyfiles-1.2.0.tgz",
+      "integrity": "sha1-qNo6xBqiIgrim9PFi2mEKU8sWTw=",
+      "requires": {
+        "glob": "7.1.2",
+        "ltcdr": "2.2.1",
+        "minimatch": "3.0.4",
+        "mkdirp": "0.5.1",
+        "noms": "0.0.0",
+        "through2": "2.0.3"
+      }
+    },
     "core-js": {
       "version": "1.2.7",
       "resolved": "https://registry.npmjs.org/core-js/-/core-js-1.2.7.tgz",
@@ -8265,6 +8278,11 @@
         "yallist": "2.1.2"
       }
     },
+    "ltcdr": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/ltcdr/-/ltcdr-2.2.1.tgz",
+      "integrity": "sha1-Wrh60dTB2rjowIu/A37gwZAih88="
+    },
     "macaddress": {
       "version": "0.2.8",
       "resolved": "https://registry.npmjs.org/macaddress/-/macaddress-0.2.8.tgz",
@@ -8747,6 +8765,38 @@
         "semver": "5.5.0",
         "shellwords": "0.1.1",
         "which": "1.3.0"
+      }
+    },
+    "noms": {
+      "version": "0.0.0",
+      "resolved": "https://registry.npmjs.org/noms/-/noms-0.0.0.tgz",
+      "integrity": "sha1-2o69nzr51nYJGbJ9nNyAkqczKFk=",
+      "requires": {
+        "inherits": "2.0.3",
+        "readable-stream": "1.0.34"
+      },
+      "dependencies": {
+        "isarray": {
+          "version": "0.0.1",
+          "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+          "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8="
+        },
+        "readable-stream": {
+          "version": "1.0.34",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
+          "integrity": "sha1-Elgg40vIQtLyqq+v5MKRbuMsFXw=",
+          "requires": {
+            "core-util-is": "1.0.2",
+            "inherits": "2.0.3",
+            "isarray": "0.0.1",
+            "string_decoder": "0.10.31"
+          }
+        },
+        "string_decoder": {
+          "version": "0.10.31",
+          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+          "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ="
+        }
       }
     },
     "normalize-package-data": {
@@ -12403,7 +12453,6 @@
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/through2/-/through2-2.0.3.tgz",
       "integrity": "sha1-AARWmzfHx0ujnEPzzteNGtlBQL4=",
-      "dev": true,
       "requires": {
         "readable-stream": "2.3.4",
         "xtend": "4.0.1"

--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "dependencies": {
     "@types/storybook__react": "^3.0.7",
     "classnames": "^2.2.5",
+    "copyfiles": "^1.2.0",
     "nav-frontend-core": "^4.0.5",
     "nav-frontend-typografi": "^2.0.2",
     "nav-frontend-typografi-style": "^1.0.7",
@@ -14,8 +15,8 @@
     "react-scripts-ts": "2.13.0"
   },
   "scripts": {
-    "start": "react-scripts-ts start",
-    "build": "npm run build:less && react-scripts-ts build",
+    "start": "copyfiles -u 3 src/index/dev/index.html public/ && react-scripts-ts start",
+    "build": "copyfiles -u 3 src/index/prod/index.html public/ && npm run build:less && react-scripts-ts build",
     "test": "react-scripts-ts test --env=jsdom",
     "eject": "react-scripts-ts eject",
     "storybook": "start-storybook -p 6006",

--- a/public/.gitignore
+++ b/public/.gitignore
@@ -1,0 +1,1 @@
+index.html

--- a/src/index/dev/index.html
+++ b/src/index/dev/index.html
@@ -16,7 +16,7 @@
     <link rel="manifest" href="%PUBLIC_URL%/manifest.json">
     <link rel="shortcut icon" href="%PUBLIC_URL%/favicon.ico">
     <link rel="stylesheet" href="index.css">
-    <script src="https://app-t6.adeo.no/internarbeidsflatedecorator/js/head.min.js"></script>
+    <script src="https://navikt.github.io/internarbeidsflatedecorator/js/head.min.js"></script>
 
     <!--
       Notice the use of %PUBLIC_URL% in the tags above.

--- a/src/index/prod/index.html
+++ b/src/index/prod/index.html
@@ -1,0 +1,48 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
+    <meta name="theme-color" content="#222222">
+    <meta name="author" content="NAV">
+    <meta property="og:title" content="Modia Personoversikt">
+    <meta property="og:site_name" content="NAV Modia Personoversikt">
+    <meta property="og:description"
+          content="Intern arbeidsflate. Brukes som personoppslag og dialogverktøy av veiledere og saksbehandlere i NAV">
+    <!--
+      manifest.json provides metadata used when your web app is added to the
+      homescreen on Android. See https://developers.google.com/web/fundamentals/engage-and-retain/web-app-manifest/
+    -->
+    <link rel="manifest" href="%PUBLIC_URL%/manifest.json">
+    <link rel="shortcut icon" href="%PUBLIC_URL%/favicon.ico">
+    <link rel="stylesheet" href="index.css">
+    <script src="/internarbeidsflatedecorator/js/head.min.js"></script>
+
+    <!--
+      Notice the use of %PUBLIC_URL% in the tags above.
+      It will be replaced with the URL of the `public` folder during the build.
+      Only files inside the `public` folder can be referenced from the HTML.
+
+      Unlike "/favicon.ico" or "favicon.ico", "%PUBLIC_URL%/favicon.ico" will
+      work correctly both with client-side routing and a non-root public URL.
+      Learn how to configure a non-root public URL by running `npm run build`.
+    -->
+    <title>Ny Personoversikt</title>
+</head>
+<body>
+<noscript>
+    You need to enable JavaScript to run this app.
+</noscript>
+<div id="root"></div>
+<!--
+  This HTML file is a template.
+  If you open it directly in the browser, you will see an empty page.
+
+  You can add webfonts, meta tags, or analytics to this file.
+  The build step will place the bundled scripts into the <body> tag.
+
+  To begin the development, run `npm start` or `yarn start`.
+  To create a production bundle, use `npm run build` or `yarn build`.
+-->
+</body>
+</html>


### PR DESCRIPTION
Istedenfor å ejecte fra create-react-script setter vi opp to versjoner
av index.html som kopieres inn i public mappen. En dev versjon referer
til navigasjonsmenyen på Github pages, mens den for prod refererer til
en relativt i miljø. Det kopieres inn før build eller npm start blir
kjørt.