### PR TITLE
Legg til babel-polyfill for regenratorruntime

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8919,6 +8919,16 @@
       "resolved": "https://registry.npmjs.org/nav-frontend-ekspanderbartpanel-style/-/nav-frontend-ekspanderbartpanel-style-0.3.8.tgz",
       "integrity": "sha512-n+rHb8uhY0dlxViygvd2FNZPtQa+pSQB7+TLpVfqlX5AC8LWaJPjE7d8CUer1+fr4uXIDaWc5IwGkIjC4pacoA=="
     },
+    "nav-frontend-etiketter": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/nav-frontend-etiketter/-/nav-frontend-etiketter-1.0.3.tgz",
+      "integrity": "sha512-cJTEPUy1zYrL/7CL4GAgEIAzxl4SNZeY1Oc929hKYkFtmc4DRuRfQP44xdhoeAvtRVdwwpcoMN6A+ng/ZfzVCg=="
+    },
+    "nav-frontend-etiketter-style": {
+      "version": "0.3.4",
+      "resolved": "https://registry.npmjs.org/nav-frontend-etiketter-style/-/nav-frontend-etiketter-style-0.3.4.tgz",
+      "integrity": "sha512-AgPHBG0qAMPyWh4XByM9s1q1ddS0SCb8fMWluIJSrW2oIk48Z/p3yGpYfQLR+xq2d9+xK7qtprUoiiBBEx9baA=="
+    },
     "nav-frontend-ikoner-assets": {
       "version": "0.2.27",
       "resolved": "https://registry.npmjs.org/nav-frontend-ikoner-assets/-/nav-frontend-ikoner-assets-0.2.27.tgz",

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -1,5 +1,7 @@
 import * as React from 'react';
 import * as ReactDOM from 'react-dom';
+import 'babel-polyfill';
+
 import App from './app/App';
 import './index.css';
 import renderDecoratorHead from './menyConfig';


### PR DESCRIPTION
Fikk en runtime-feil fordi regenratorruntime ikke var definert når
fnr-genrator modulen ble kjørt. Legger til en import på babel-polyfill.

https://stackoverflow.com/questions/33527653/babel-6-regeneratorruntime-is-not-defined?utm_medium=organic&utm_source=google_rich_qa&utm_campaign=google_rich_qa