### PR TITLE
gridlayout i stroybook

### DIFF
--- a/src/stories/grid-layout/GridLayout.tsx
+++ b/src/stories/grid-layout/GridLayout.tsx
@@ -1,0 +1,14 @@
+import * as React from 'react';
+import './gridStyle.css';
+
+function GridLayout() {
+    return(
+        <div id="application">
+            <div className="header">Header</div>
+            <div className="left-column">Venstre</div>
+            <div className="right-column">Høyre</div>
+        </div>
+    );
+}
+
+export default GridLayout;

--- a/src/stories/grid-layout/gridStyle.css
+++ b/src/stories/grid-layout/gridStyle.css
@@ -1,0 +1,24 @@
+#application {
+    display: -ms-grid;
+    display: grid;
+    grid-template: "head head" "left right";
+    -ms-grid-rows: min-content auto;
+    grid-template-rows: -webkit-min-content auto;
+    grid-template-rows: min-content auto;
+    -ms-grid-columns: 2fr 1fr;
+    grid-template-columns: 2fr 1fr;
+    overflow: hidden;
+}
+.left-column {
+    grid-area: left;
+    overflow-y: auto;
+    background-color: aliceblue;
+}
+.right-column {
+    grid-area: right;
+    background-color: papayawhip;
+}
+.header{
+    grid-area: head;
+    background-color: lightgoldenrodyellow;
+}

--- a/src/stories/index.stories.tsx
+++ b/src/stories/index.stories.tsx
@@ -6,11 +6,11 @@ import { Person } from '../models/person';
 import ComponentPlaceholder from '../components/component-placeholder/ComponentPlaceHolder';
 import { aremark } from '../mock/person-mock';
 import styled from 'styled-components';
+import GridLayout from './grid-layout/GridLayout';
 
 const mockPerson: Person = aremark;
 
 const NiceContainer = styled.div`
-  margin: 1em;
   box-shadow: 0 2px 6px rgba(0,0,0,0.5);
 `;
 
@@ -37,3 +37,9 @@ storiesOf('Component Placeholder', module)
             </NiceContainer>
         )
     );
+
+storiesOf('Layout', module).add('GridTest, virker ikke i ie11', () => (
+        <NiceContainer>
+            <GridLayout />
+        </NiceContainer>
+));


### PR DESCRIPTION
nicklas vil gjerne at vi tar ibruk css-grid i personoversikten. Her er en story med grid-layout, men den funker desverre ikke i ie11 slik den er nå. Ta gjerne tak i det hvis noen føler seg inspirert ;-)

chrome:
![image](https://user-images.githubusercontent.com/29202094/38353226-23e95b96-38b6-11e8-8aa8-61cdd374891b.png)

ie11:
![image](https://user-images.githubusercontent.com/29202094/38353184-fb6ca6a0-38b5-11e8-8d43-f4bc871956a3.png)
