### PR TITLE
Lagt til diffrensiering i endretAv-metode for Folkeregisteret vs Skatt

### DIFF
--- a/src/utils/endretAvUtil.test.ts
+++ b/src/utils/endretAvUtil.test.ts
@@ -35,6 +35,13 @@ it('Formaterer endretAv ident (med liten bokstav) + BD06 tekst til ønsket visni
     expect(formatertTekst).toEqual('av NAV');
 });
 
+it('Formaterer endretAv gammel type ident + IT00 (Infotrygd-app - NAV) tekst til ønsket visningsformat', () => {
+    const rawString = 'AAH1234, IT00';
+    const formatertTekst =  endretAvTekst(rawString);
+
+    expect(formatertTekst).toEqual('av NAV');
+});
+
 it('Formaterer endretAv ident + PP01 (modiabrukerdialog-app - NAV) tekst til ønsket visningsformat', () => {
     const rawString = 'srvPensjon, PP01';
     const formatertTekst =  endretAvTekst(rawString);
@@ -54,4 +61,11 @@ it('Formaterer endretAv tekst + SKD (Skatt/Folkeregisteret) tekst til ønsket vi
     const formatertTekst =  endretAvTekst(rawString);
 
     expect(formatertTekst).toEqual('i Folkeregisteret');
+});
+
+it('Formaterer endretAv tekst + SKD (Skatt/Folkeregisteret) tekst til ønsket visningsformat', () => {
+    const rawString = 'AAA2101, SKD';
+    const formatertTekst =  endretAvTekst(rawString);
+
+    expect(formatertTekst).toEqual('av Skatteetaten');
 });

--- a/src/utils/endretAvUtil.ts
+++ b/src/utils/endretAvUtil.ts
@@ -3,6 +3,8 @@ export function endretAvTekst(rawString: string): string {
         return 'av bruker';
     } else if (endretIFagsystem(rawString) || endretIPesys(rawString) ) {
         return 'av NAV';
+    } else if (rawString.match('AAA2101, SKD')) {
+        return 'av Skatteetaten';
     } else if (rawString.match('SKD')) {
         return 'i Folkeregisteret';
     } else {
@@ -11,7 +13,15 @@ export function endretAvTekst(rawString: string): string {
 }
 
 function endretIFagsystem(rawString: string) {
-    return rawString && rawString.toUpperCase().match('[A-Z][0-9]{6}');
+    return rawString && (endretAvNyTypeIdent(rawString) || endretAvGammelTypeIdent(rawString));
+}
+
+function endretAvNyTypeIdent(rawString: string) {
+    return rawString.toUpperCase().match('[A-Z][0-9]{6}');
+}
+
+function endretAvGammelTypeIdent(rawString: string) {
+    return rawString.toUpperCase().match('[A-Z]{3}[0-9]{4}, [A-Z]{2}[0-9]{2}');
 }
 
 function endretIPSelv(rawString: string) {


### PR DESCRIPTION
I tilegg lagt støtte for eldre typer identer i NAV som hadde 3 bokstaver og 4 tall.

OPP-396