### PR TITLE
Håndtering av null på fornavn og etternavn for familierelasjoner

### DIFF
--- a/src/app/personside/visittkort/body/__snapshots__/VisittkortBody.test.tsx.snap
+++ b/src/app/personside/visittkort/body/__snapshots__/VisittkortBody.test.tsx.snap
@@ -288,6 +288,50 @@ exports[`viser info om bruker i visittkortbody 1`] = `
           </p>
         </div>
       </div>
+      <div
+        className="sc-gZMcBi YBfVu"
+      >
+        <div
+          className="sc-gqjmRU edlVLi"
+        >
+          <img
+            alt="Jente"
+            src="jentebarn.svg"
+            title="Jente"
+          />
+        </div>
+        <div
+          className="sc-VigVT gWFDUD"
+        >
+          <p
+            className="typo-etikett-liten"
+          >
+            <span
+              className="sc-jTzLTM eiuGtv"
+            >
+              Jente
+            </span>
+          </p>
+          <p
+            className="typo-undertekst"
+          >
+            Siri Aremark
+             (
+            17
+            ) 
+          </p>
+          <p
+            className="typo-undertekst"
+          >
+            10117100000
+          </p>
+          <p
+            className="typo-undertekst"
+          >
+            Bor ikke med bruker
+          </p>
+        </div>
+      </div>
     </div>
     <div
       className="sc-kgoBCf jnYcFc"

--- a/src/app/personside/visittkort/header/__snapshots__/VisittkortHeader.test.tsx.snap
+++ b/src/app/personside/visittkort/header/__snapshots__/VisittkortHeader.test.tsx.snap
@@ -59,7 +59,8 @@ exports[`viser info om bruker i visittkort-header 1`] = `
           <li
             title="Barn under 21 år"
           >
-            Ingen barn under 21 år
+            1
+             barn under 21 år
           </li>
         </ul>
       </span>

--- a/src/components/person/NavnOgAlder.test.tsx
+++ b/src/components/person/NavnOgAlder.test.tsx
@@ -1,0 +1,63 @@
+import * as React from 'react';
+import { shallow } from 'enzyme';
+import NavnOgAlder from './NavnOgAlder';
+import { Familierelasjon, Relasjonstype } from '../../models/person/person';
+
+const relasjon: Familierelasjon = {
+    harSammeBosted: false,
+    rolle: Relasjonstype.Barn,
+    tilPerson: {
+        navn: {
+            fornavn: 'Baruch',
+            etternavn: 'Spinoza',
+            sammensatt: 'Sammensatt',
+            mellomnavn: ''
+        },
+        alder: 15,
+        fødselsnummer: '123',
+        personstatus: {}
+    }
+};
+
+test('Fornavn, etternavn og alder vises', () => {
+    const NavnOgAlderWrapper = shallow(<NavnOgAlder relasjon={relasjon}/>);
+
+    expect(NavnOgAlderWrapper.text()).toEqual('Baruch Spinoza (15) ');
+});
+
+test('Fornavn, mellomnavn, etternavn og alder vises', () => {
+    relasjon.tilPerson.navn.mellomnavn = 'de';
+    const NavnOgAlderWrapper = shallow(<NavnOgAlder relasjon={relasjon}/>);
+
+    expect(NavnOgAlderWrapper.text()).toEqual('Baruch de Spinoza (15) ');
+});
+
+test('Navn og alder uten fornavn og etternavn defaulter til sammensatt navn', () => {
+    relasjon.tilPerson.navn.fornavn = null;
+    relasjon.tilPerson.navn.etternavn = null;
+
+    const NavnOgAlderWrapper = shallow(<NavnOgAlder relasjon={relasjon}/>);
+
+    expect(NavnOgAlderWrapper.text()).toEqual('Sammensatt (15) ');
+});
+
+test('Uten navn returnerer ukjent navn', () => {
+    relasjon.tilPerson.navn.fornavn = null;
+    relasjon.tilPerson.navn.etternavn = null;
+    relasjon.tilPerson.navn.sammensatt = '';
+
+    const NavnOgAlderWrapper = shallow(<NavnOgAlder relasjon={relasjon}/>);
+
+    expect(NavnOgAlderWrapper.text()).toEqual('Ukjent navn (15) ');
+});
+
+test('Uten fornavn, men med etternavn', () => {
+    relasjon.tilPerson.navn.fornavn = null;
+    relasjon.tilPerson.navn.mellomnavn = null;
+    relasjon.tilPerson.navn.etternavn = 'Sokrates';
+    relasjon.tilPerson.navn.sammensatt = '';
+
+    const NavnOgAlderWrapper = shallow(<NavnOgAlder relasjon={relasjon}/>);
+
+    expect(NavnOgAlderWrapper.text()).toEqual('Sokrates (15) ');
+});

--- a/src/components/person/NavnOgAlder.tsx
+++ b/src/components/person/NavnOgAlder.tsx
@@ -5,8 +5,23 @@ interface Props {
     relasjon: Familierelasjon;
 }
 
-function getNavn(navn: Navn) {
-    return navn.fornavn + ' ' + (navn.mellomnavn ? navn.mellomnavn + ' ' : '') + navn.etternavn;
+function getNavn({fornavn, mellomnavn, etternavn, sammensatt}: Navn) {
+    if (!fornavn && !etternavn) {
+        return sammensatt || 'Ukjent navn';
+    }
+
+    let navn = [];
+    if (fornavn) {
+        navn.push(fornavn);
+    }
+    if (mellomnavn) {
+        navn.push(mellomnavn);
+    }
+    if (etternavn) {
+        navn.push(etternavn);
+    }
+
+    return navn.join(' ');
 }
 
 function NavnOgAlder({relasjon}: Props) {

--- a/src/mock/kontaktinformasjon-mock.ts
+++ b/src/mock/kontaktinformasjon-mock.ts
@@ -33,8 +33,10 @@ export function getMockKontaktinformasjon(fødselsnummer: string): Kontaktinform
 }
 
 function getEpost(personData: Person) {
+    const fornavn = personData.navn.fornavn || '';
+    const etternavn = personData.navn.etternavn || '';
     return {
-        value: faker.internet.email(personData.navn.fornavn, personData.navn.etternavn),
+        value: faker.internet.email(fornavn, etternavn),
         sistOppdatert: getSistOppdatert()
     };
 }

--- a/src/mock/person/aremark.ts
+++ b/src/mock/person/aremark.ts
@@ -1,5 +1,5 @@
 import { Diskresjonskoder, TilrettelagtKommunikasjonsTyper } from '../../konstanter';
-import { Kjønn, Person, SivilstandTyper } from '../../models/person/person';
+import { Kjønn, Person, Relasjonstype, SivilstandTyper } from '../../models/person/person';
 
 export const aremark: Person = {
     fødselsnummer: '10108000398',
@@ -29,7 +29,22 @@ export const aremark: Person = {
         beskrivelse: 'Gift',
         fraOgMed: '2005-12-12'
     },
-    familierelasjoner: [],
+    familierelasjoner: [{
+        harSammeBosted: false,
+        rolle: Relasjonstype.Barn,
+        tilPerson: {
+            navn: {
+                sammensatt: '',
+                fornavn: 'Siri',
+                mellomnavn: null,
+                etternavn: 'Aremark'
+            },
+            alder: 17,
+            fødselsnummer: '10117100000',
+            personstatus: {}
+        }
+
+    }],
     kontaktinformasjon: {
         mobil: {
             sistEndret: '2014-06-21T18:44:39+02:00',

--- a/src/models/person/person.ts
+++ b/src/models/person/person.ts
@@ -24,9 +24,9 @@ export interface Person {
 
 export interface Navn {
     sammensatt: string;
-    fornavn: string;
-    mellomnavn: string;
-    etternavn: string;
+    fornavn: string | null;
+    mellomnavn: string | null;
+    etternavn: string | null;
 }
 
 export interface Bankkonto {


### PR DESCRIPTION
Det viser seg at navn på familierelasjoner noen ganger har null satt til
fornavn og etternavn, men at de har et sammensatt navn. Innfører derfor
sjekker på det for å unngå navn som (null null).