### PR TITLE
Fjerner bruk av miljøvariabler på nais.

### DIFF
--- a/app-config.yaml
+++ b/app-config.yaml
@@ -6,5 +6,3 @@ fasitResources:
       resourceType: loadbalancerconfig
     - alias: iadecorator-js
       resourceType: restservice
-    - alias: personoversiktAPI
-      resourceType: restservice

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -2,7 +2,7 @@
 
 
 sed -i s,%REACT_APP_HODE_URL%,${IADECORATOR_JS_URL:-$REACT_APP_HODE_URL}, /usr/share/nginx/html/modiapersonoversikt/index.html
-sed -i s,%REACT_APP_MODIA_URL%,${PERSONOVERSIKTAPI_URL:-$REACT_APP_MODIA_URL}, /usr/share/nginx/html/modiapersonoversikt/index.html
+sed -i s,%REACT_APP_MODIA_URL%,${REACT_APP_MODIA_URL:-"/modiabrukerdialog/rest"}, /usr/share/nginx/html/modiapersonoversikt/index.html
 sed -i s,%REACT_APP_MOCK_ENABLED%,$REACT_APP_MOCK_ENABLED, /usr/share/nginx/html/modiapersonoversikt/index.html
 sed -i s,%DOCKER_PORT%,${PORT:-80}, /etc/nginx/conf.d/default.conf
 


### PR DESCRIPTION
Requester til backend går til /modiabrukerdialog, da de kjører på samme
domene.

Det er derfor ikke _nødvendig_  å konsumere denne fasit-variablen. Vi
beholder imidlertidig muligheten for å sette den, slik at vi i f.eks kan
kjøre på heroku mot en backend på et annet domene.