### PR TITLE
Fiks feil der det ble vist to plusstegn foran retningsnummere

### DIFF
--- a/src/app/personside/visittkort/body/kontaktinformasjon/NavKontaktinformasjon.tsx
+++ b/src/app/personside/visittkort/body/kontaktinformasjon/NavKontaktinformasjon.tsx
@@ -24,7 +24,7 @@ function Telefon({telefon, nummerFormaterer, beskrivelse}: TelefonProps) {
     const formatertNummer = nummerFormaterer(telefon.identifikator);
     return (
         <>
-            <Undertekst>{`+${telefon.retningsnummer} ${formatertNummer}`} ({beskrivelse})</Undertekst>
+            <Undertekst>{`${telefon.retningsnummer} ${formatertNummer}`} ({beskrivelse})</Undertekst>
             <EtikettMini>Endret {formatertDato} {endretAv}</EtikettMini>
         </>
     );

--- a/src/mock/kodeverk/retningsnummer-mock.ts
+++ b/src/mock/kodeverk/retningsnummer-mock.ts
@@ -5,20 +5,26 @@ export function mockRetningsnummer(): KodeverkResponse {
         kodeverk: [
             {
                 value: 'Norge',
-                kodeRef: '47',
+                kodeRef: '+47',
                 beskrivelse: 'Norge',
                 gyldig: true
             },
             {
                 value: 'Sverige',
-                kodeRef: '46',
+                kodeRef: '+46',
                 beskrivelse: 'Sverige',
                 gyldig: true
             },
             {
                 value: 'Storbritannia (UK)',
-                kodeRef: '44',
+                kodeRef: '+44',
                 beskrivelse: 'Storbritannia (UK)',
+                gyldig: true
+            },
+            {
+                value: 'Argentina',
+                kodeRef: '+54',
+                beskrivelse: 'Argentina',
                 gyldig: true
             }
         ]

--- a/src/mock/kodeverk/retningsnummer-mock.ts
+++ b/src/mock/kodeverk/retningsnummer-mock.ts
@@ -1,32 +1,21 @@
 import { KodeverkResponse } from '../../models/kodeverk';
 
-export function mockRetningsnummer(): KodeverkResponse {
+export function mockRetningsnummere(): KodeverkResponse {
     return {
         kodeverk: [
-            {
-                value: 'Norge',
-                kodeRef: '+47',
-                beskrivelse: 'Norge',
-                gyldig: true
-            },
-            {
-                value: 'Sverige',
-                kodeRef: '+46',
-                beskrivelse: 'Sverige',
-                gyldig: true
-            },
-            {
-                value: 'Storbritannia (UK)',
-                kodeRef: '+44',
-                beskrivelse: 'Storbritannia (UK)',
-                gyldig: true
-            },
-            {
-                value: 'Argentina',
-                kodeRef: '+54',
-                beskrivelse: 'Argentina',
-                gyldig: true
-            }
+            mockRetningsnummer('Norge', '+47'),
+            mockRetningsnummer('Sverige', '+46'),
+            mockRetningsnummer('Storbritannia (UK)', '+44'),
+            mockRetningsnummer('Argentina', '+54')
         ]
+    };
+}
+
+function mockRetningsnummer(value: string, kodeRef: string) {
+    return {
+        value,
+        kodeRef,
+        beskrivelse: value,
+        gyldig: true
     };
 }

--- a/src/mock/person/aremark.ts
+++ b/src/mock/person/aremark.ts
@@ -67,7 +67,7 @@ export const aremark: Person = {
         mobil: {
             sistEndret: '2014-06-21T18:44:39+02:00',
             identifikator: '99887766',
-            retningsnummer: '47',
+            retningsnummer: '+47',
             sistEndretAv: 'BRUKER'
         }
     }

--- a/src/mock/person/navKontaktinformasjon.ts
+++ b/src/mock/person/navKontaktinformasjon.ts
@@ -10,7 +10,7 @@ export function getNavKontaktinformasjon(faker: FakerStatic) {
             sistEndret: getSistOppdatert(),
             sistEndretAv: '1010800 BD03',
             identifikator: faker.phone.phoneNumber('9#######'),
-            retningsnummer: '47'
+            retningsnummer: vektetSjanse(faker, 0.3) ? '' : '+47'
         };
     }
 
@@ -19,7 +19,7 @@ export function getNavKontaktinformasjon(faker: FakerStatic) {
             sistEndret: getSistOppdatert(),
             sistEndretAv: '1010800 BD03',
             identifikator: faker.phone.phoneNumber('########'),
-            retningsnummer: '47'
+            retningsnummer: vektetSjanse(faker, 0.3) ? '' : '+47'
         };
     }
 
@@ -28,7 +28,7 @@ export function getNavKontaktinformasjon(faker: FakerStatic) {
             sistEndret: getSistOppdatert(),
             sistEndretAv: '1010800 BD03',
             identifikator: faker.phone.phoneNumber('########'),
-            retningsnummer: '47'
+            retningsnummer: vektetSjanse(faker, 0.3) ? '' : '+47'
         };
     }
 

--- a/src/mock/person/navKontaktinformasjon.ts
+++ b/src/mock/person/navKontaktinformasjon.ts
@@ -6,32 +6,25 @@ export function getNavKontaktinformasjon(faker: FakerStatic) {
     let kontaktinformasjon: NavKontaktinformasjon = {};
 
     if (vektetSjanse(faker, 0.7)) {
-        kontaktinformasjon.mobil = {
-            sistEndret: getSistOppdatert(),
-            sistEndretAv: '1010800 BD03',
-            identifikator: faker.phone.phoneNumber('9#######'),
-            retningsnummer: vektetSjanse(faker, 0.3) ? '' : '+47'
-        };
+        kontaktinformasjon.mobil = getMockTelefon(faker, faker.phone.phoneNumber('9#######'));
     }
 
     if (vektetSjanse(faker, 0.3)) {
-        kontaktinformasjon.jobb = {
-            sistEndret: getSistOppdatert(),
-            sistEndretAv: '1010800 BD03',
-            identifikator: faker.phone.phoneNumber('########'),
-            retningsnummer: vektetSjanse(faker, 0.3) ? '' : '+47'
-        };
+        kontaktinformasjon.jobb = getMockTelefon(faker, faker.phone.phoneNumber('########'));
     }
 
     if (vektetSjanse(faker, 0.3)) {
-        kontaktinformasjon.hjem = {
-            sistEndret: getSistOppdatert(),
-            sistEndretAv: '1010800 BD03',
-            identifikator: faker.phone.phoneNumber('########'),
-            retningsnummer: vektetSjanse(faker, 0.3) ? '' : '+47'
-        };
+        kontaktinformasjon.hjem = getMockTelefon(faker, faker.phone.phoneNumber('########'));
     }
 
     return kontaktinformasjon;
+}
 
+function getMockTelefon(faker: FakerStatic, identifikator: string) {
+    return {
+        sistEndret: getSistOppdatert(),
+        sistEndretAv: '1010800 BD03',
+        identifikator: identifikator,
+        retningsnummer: vektetSjanse(faker, 0.3) ? '' : '+47'
+    };
 }

--- a/src/mock/setup-mock.ts
+++ b/src/mock/setup-mock.ts
@@ -8,7 +8,7 @@ import { getMockNavKontor } from './navkontor-mock';
 import { erEgenAnsatt } from './egenansatt-mock';
 import { mockVergemal } from './vergemal-mocks';
 import { getMockVeilederRoller } from './veilderRoller-mock';
-import { mockRetningsnummer } from './kodeverk/retningsnummer-mock';
+import { mockRetningsnummere } from './kodeverk/retningsnummer-mock';
 import { mockTilrettelagtKommunikasjon } from './kodeverk/tilrettelagt-kommunikasjon-kodeverk-mock';
 
 const STATUS_OK = () => 200;
@@ -86,7 +86,7 @@ function setupRetningsnummerKodeverkMock(mock: FetchMock) {
     mock.get(apiBaseUri + '/kodeverk/Retningsnummer', withDelayedResponse(
         700,
         STATUS_OK,
-        () => mockRetningsnummer()));
+        () => mockRetningsnummere()));
 }
 
 function setupTilrettelagtKommunikasjonKodeverkMock(mock: FetchMock) {


### PR DESCRIPTION
Skyldes at koderefen for et retningsnummer allerede inneholder et
plusstegn.