### PR TITLE
Spesifiser at miljøvariabel er påkrevd

### DIFF
--- a/app.json
+++ b/app.json
@@ -7,6 +7,9 @@
     "NPM_CONFIG_PRODUCTION": "false",
     "REACT_APP_HODE_URL": {
       "required": true
+    },
+    "REACT_APP_MOCK_ENABLED": {
+      "required": true
     }
   },
   "formation": {


### PR DESCRIPTION
Da skjønner forhåpentligvis heroku at den må hente det fra
'master'-appen