### PR TITLE
Fiks feil forårsaket av lite eksplisitt import

### DIFF
--- a/src/app/personside/visittkort/body/VisittkortElement.tsx
+++ b/src/app/personside/visittkort/body/VisittkortElement.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import styled from 'styled-components';
-import { EtikettLiten } from 'nav-frontend-typografi';
+import EtikettLiten from 'nav-frontend-typografi/lib/etikett-liten';
 
 interface ElementProps {
     children: string | JSX.Element | JSX.Element[];

--- a/src/components/EtikettMini.tsx
+++ b/src/components/EtikettMini.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { EtikettLiten } from 'nav-frontend-typografi';
+import EtikettLiten from 'nav-frontend-typografi/lib/etikett-liten';
 import styled from 'styled-components';
 
 interface Props {


### PR DESCRIPTION
I testene, pluss i gamle modiabrukerdialog med nytt visittkort, fikk vi
denne feilen:

Error: Element type is invalid: expected a string (for built-in
components) or a class/function (for composite components) but got:
undefined. You likely forgot to export your component from the file it's
defined in, or you might have mixed up default and named imports.

Løste seg i test ved å spesifisere importen mer nøyaktig