### PR TITLE
Setter opp arkitektur for form-validation i adresse-form

### DIFF
--- a/src/api/brukerprofil/adresse-api.ts
+++ b/src/api/brukerprofil/adresse-api.ts
@@ -1,6 +1,7 @@
 import { apiBaseUri } from '../config';
 import { post } from '../api';
-import { Gateadresse, Matrikkeladresse } from '../../models/personadresse';
+import { Matrikkeladresse } from '../../models/personadresse';
+import { GateadresseSkjemainput } from '../../app/brukerprofil/adresse/GateadresseForm';
 
 export interface EndreAdresseRequest {
     norskAdresse: {
@@ -24,20 +25,18 @@ function postEndreAdresse(fødselsnummer: string, request: EndreAdresseRequest):
     return post(`${apiBaseUri}/brukerprofil/${fødselsnummer}/adresse/`, request);
 }
 
-function getGyldigTil(gateadresse: Gateadresse) {
-    if (!gateadresse.periode) {
-        throw 'Ugyldig periode for endring av adresse';
-    }
-    return gateadresse.periode.til;
-}
-
-export function postEndreNorskGateadresse(fødselsnummer: string, gateadresse: Gateadresse) {
-    const {poststed, periode, ...mappedGateadresse} = gateadresse;
+export function postEndreNorskGateadresse(fødselsnummer: string, gateadresse: GateadresseSkjemainput) {
     const request: EndreAdresseRequest = {
         norskAdresse: {
             gateadresse: {
-                ...mappedGateadresse,
-                gyldigTil: getGyldigTil(gateadresse)},
+                gatenavn: gateadresse.gatenavn.value,
+                bolignummer: gateadresse.bolignummer.value,
+                husbokstav: gateadresse.husbokstav.value,
+                husnummer: gateadresse.husnummer.value,
+                postnummer: gateadresse.postnummer.value,
+                gyldigTil: gateadresse.gyldigTil.value,
+                tilleggsadresse: gateadresse.tilleggsadresse.value
+            },
             matrikkeladresse: null
         }
     };

--- a/src/app/brukerprofil/adresse/AdresseContainer.tsx
+++ b/src/app/brukerprofil/adresse/AdresseContainer.tsx
@@ -10,7 +10,7 @@ import { hentPostnummere } from '../../../redux/kodeverk/postnummerReducer';
 import { STATUS } from '../../../redux/utils';
 import AdresseForm from './AdresseForm';
 import { endreNorskGateadresse } from '../../../redux/brukerprofil/endreAdresseReducer';
-import { Gateadresse } from '../../../models/personadresse';
+import { GateadresseSkjemainput } from './GateadresseForm';
 
 interface StateProps {
     postnummerReducer: RestReducer<KodeverkResponse>;
@@ -19,7 +19,7 @@ interface StateProps {
 
 interface DispatchProps {
     hentPostnummerKodeverk: () => void;
-    endreNorskGateadresse: (fødselsnummer: string, gateadresse: Gateadresse) => void;
+    endreNorskGateadresse: (fødselsnummer: string, gateadresse: GateadresseSkjemainput) => void;
 }
 
 class AdresseFormContainer extends React.Component<StateProps & DispatchProps & {person: Person}> {
@@ -53,7 +53,7 @@ const mapStateToProps = (state: AppState): StateProps => {
 function mapDispatchToProps(dispatch: Dispatch<Action>): DispatchProps {
     return {
         hentPostnummerKodeverk: () => dispatch(hentPostnummere()),
-        endreNorskGateadresse: (fødselsnummer: string, gateadresse: Gateadresse) =>
+        endreNorskGateadresse: (fødselsnummer: string, gateadresse: GateadresseSkjemainput) =>
             dispatch(endreNorskGateadresse(fødselsnummer, gateadresse))
     };
 }

--- a/src/app/brukerprofil/adresse/AdresseForm.tsx
+++ b/src/app/brukerprofil/adresse/AdresseForm.tsx
@@ -5,19 +5,19 @@ import Undertittel from 'nav-frontend-typografi/lib/undertittel';
 import KnappBase from 'nav-frontend-knapper';
 
 import { Person } from '../../../models/person/person';
-import { Gateadresse, Personadresse } from '../../../models/personadresse';
+import { Personadresse } from '../../../models/personadresse';
 import { FormKnapperWrapper } from '../BrukerprofilForm';
 import { STATUS } from '../../../redux/utils';
 import { RestReducer } from '../../../redux/reducer';
 import RequestTilbakemelding from '../RequestTilbakemelding';
 import MidlertidigAdresseNorge, {
-    getOrDefaultGateadresse,
-    getOrDefaultMatrikkeladresse,
     MidlertidigeAdresserNorgeInput,
     MidlertidigeAdresserNorgeInputValg
 } from './MidlertidigAdresseNorge';
 import FolkeregistrertAdresse from './FolkeregistrertAdresse';
 import { AdresseValg } from './AdresseValg';
+import { GateadresseSkjemainput, getOrDefaultGateadresse } from './GateadresseForm';
+import { getOrDefaultMatrikkeladresse } from './MatrikkeladresseForm';
 
 function Tilbakemelding(props: {formErEndret: boolean, status: STATUS}) {
     if (!props.formErEndret) {
@@ -35,7 +35,7 @@ function Tilbakemelding(props: {formErEndret: boolean, status: STATUS}) {
 
 interface Props {
     person: Person;
-    endreNorskGateadresse: (fødselsnummer: string, gateadresse: Gateadresse) => void;
+    endreNorskGateadresse: (fødselsnummer: string, gateadresse: GateadresseSkjemainput) => void;
     endreAdresseReducer: RestReducer<{}>;
 }
 

--- a/src/app/brukerprofil/adresse/GateadresseForm.tsx
+++ b/src/app/brukerprofil/adresse/GateadresseForm.tsx
@@ -1,92 +1,110 @@
 import * as React from 'react';
-import { ChangeEvent } from 'react';
 import styled from 'styled-components';
 
-import Input from 'nav-frontend-skjema/lib/input';
 import Datovelger from 'nav-datovelger';
-import PoststedVelger, { PoststedInformasjon } from './PoststedVelger';
-import { Gateadresse } from '../../../models/personadresse';
+
+import PoststedVelger from './PoststedVelger';
 import { formaterTilISO8601Date } from '../../../utils/dateUtils';
+import { Skjemainput } from './InputFelt';
+import { Gateadresse } from '../../../models/personadresse';
+import { defaultSkjemainput, stringTilSkjemainput, validatorer } from '../formUtils';
 
 interface Props {
-    onChange: (gateadresse: Gateadresse) => void;
-    gateadresse: Gateadresse;
+    onChange: (partial: Partial<GateadresseSkjemainput>) => void;
+    gateadresse: GateadresseSkjemainput;
+}
+
+export interface GateadresseSkjemainput {
+    gatenavn: Skjemainput;
+    postnummer: Skjemainput;
+    gyldigTil: Skjemainput;
+    tilleggsadresse: Skjemainput;
+    husnummer: Skjemainput;
+    husbokstav: Skjemainput;
+    bolignummer: Skjemainput;
+}
+
+export function getOrDefaultGateadresse(gateadresse?: Gateadresse): GateadresseSkjemainput {
+    if (!gateadresse) {
+        return {
+            gatenavn: defaultSkjemainput,
+            postnummer: defaultSkjemainput,
+            gyldigTil: defaultSkjemainput,
+            tilleggsadresse: defaultSkjemainput,
+            husnummer: defaultSkjemainput,
+            husbokstav: defaultSkjemainput,
+            bolignummer: defaultSkjemainput,
+        };
+    }
+    const gyldigTil = gateadresse.periode ? gateadresse.periode.til : formaterTilISO8601Date(new Date());
+    return {
+        gatenavn: stringTilSkjemainput(gateadresse.gatenavn),
+        postnummer: stringTilSkjemainput(gateadresse.postnummer),
+        gyldigTil: stringTilSkjemainput(gyldigTil),
+        tilleggsadresse: stringTilSkjemainput(gateadresse.tilleggsadresse),
+        husnummer: stringTilSkjemainput(gateadresse.husnummer),
+        bolignummer: stringTilSkjemainput(gateadresse.bolignummer),
+        husbokstav: stringTilSkjemainput(gateadresse.husbokstav)
+    };
 }
 
 const InputLinje = styled.div`
   display: flex;
 `;
 
-function onPostinformasjonChange(props: Props) {
-    return ({poststed, postnummer}: PoststedInformasjon) => {
-        props.onChange({...props.gateadresse, postnummer, poststed});
-    };
-}
-
-function onGyldigTilChange(props: Props) {
-    return (gyldigTil: Date) => {
-        const periode = {
-            fra: formaterTilISO8601Date(new Date()),
-            til: formaterTilISO8601Date(gyldigTil)
-        };
-        props.onChange({...props.gateadresse, periode});
-    };
-}
-
 function GateadresseForm(props: Props) {
-
-    const {postnummer, poststed} = props.gateadresse;
-
-    const gyldigTil = props.gateadresse.periode ? new Date(props.gateadresse.periode.til) : new Date();
+    const {onChange} = props;
+    const gyldigTilDate = new Date(props.gateadresse.gyldigTil.value);
 
     return (
         <>
-            <Input
+            <Skjemainput
                 bredde={'XXL'}
                 label="Merkes med C/O"
-                defaultValue={props.gateadresse.tilleggsadresse}
-                onChange={(event: ChangeEvent<HTMLInputElement>) =>
-                    props.onChange({...props.gateadresse, tilleggsadresse: event.target.value})}
+                skjemainput={props.gateadresse.tilleggsadresse}
+                onSkjemainput={(tilleggsadresse) => onChange({tilleggsadresse})}
             />
             <InputLinje>
                 <div style={{flex: 4, marginRight: 15}} >
-                    <Input
+                    <Skjemainput
                         bredde={'XXL'}
                         label="Gateadresse"
-                        defaultValue={props.gateadresse.gatenavn}
-                        onChange={(event: ChangeEvent<HTMLInputElement>) =>
-                            props.onChange({...props.gateadresse, gatenavn: event.target.value})}
+                        skjemainput={props.gateadresse.gatenavn}
+                        validatorer={[validatorer.erIkkeTomStreng]}
+                        onSkjemainput={(gatenavn) => onChange({gatenavn})}
                     />
                 </div>
-                <Input
+                <Skjemainput
                     bredde={'S'}
                     label="Husnummer"
-                    defaultValue={props.gateadresse.husnummer}
-                    onChange={(event: ChangeEvent<HTMLInputElement>) =>
-                        props.onChange({...props.gateadresse, husnummer: event.target.value})}
+                    skjemainput={props.gateadresse.husnummer}
+                    onSkjemainput={(husnummer) => onChange({husnummer})}
                 />
-                <Input
+                <Skjemainput
                     bredde={'S'}
                     label="Husbokstav"
-                    defaultValue={props.gateadresse.husbokstav}
-                    onChange={(event: ChangeEvent<HTMLInputElement>) =>
-                        props.onChange({...props.gateadresse, husbokstav: event.target.value})}
+                    skjemainput={props.gateadresse.husbokstav}
+                    onSkjemainput={(husbokstav) => onChange({husbokstav})}
                 />
-                <Input
+                <Skjemainput
                     bredde={'S'}
                     label="Bolignummer"
-                    defaultValue={props.gateadresse.bolignummer}
-                    onChange={(event: ChangeEvent<HTMLInputElement>) =>
-                        props.onChange({...props.gateadresse, bolignummer: event.target.value})}
+                    skjemainput={props.gateadresse.bolignummer}
+                    onSkjemainput={(bolignummer) => onChange({bolignummer})}
                 />
             </InputLinje>
-            <PoststedVelger poststedInformasjon={{postnummer, poststed}} onChange={onPostinformasjonChange(props)} />
+            <PoststedVelger
+                postnummer={props.gateadresse.postnummer}
+                onChange={(postnummer) => onChange({postnummer})}
+            />
             <>
                 <label className={'skjemaelement__label'}>Gyldig til</label>
                 <Datovelger
-                    dato={gyldigTil}
+                    dato={gyldigTilDate}
                     id={'gateform-datovelger'}
-                    onChange={onGyldigTilChange(props)}
+                    onChange={(date) => onChange({gyldigTil: {
+                        value: formaterTilISO8601Date(date), skjemafeil: []
+                    }})}
                 />
             </>
         </>

--- a/src/app/brukerprofil/adresse/InputFelt.tsx
+++ b/src/app/brukerprofil/adresse/InputFelt.tsx
@@ -1,0 +1,53 @@
+import * as React from 'react';
+import { ChangeEvent } from 'react';
+
+import Input, { NavFrontendInputProps } from 'nav-frontend-skjema/lib/input';
+
+interface Props extends NavFrontendInputProps {
+    skjemainput: Skjemainput;
+    onSkjemainput: (skjemainput: Skjemainput) => void;
+    validatorer?: ((input: string) => string | null)[];
+}
+
+export interface Skjemainput {
+    value: string;
+    skjemafeil: string[];
+}
+
+function onChange(value: string, props: Props) {
+    if (!props.validatorer) {
+        props.onSkjemainput({value, skjemafeil: []});
+        return;
+    }
+
+    let skjemafeil = [];
+    for (let i = 0; i < props.validatorer.length; i++) {
+        let validationResult = props.validatorer[i](value);
+        if (validationResult) {
+            skjemafeil.push(validationResult);
+        }
+    }
+
+    props.onSkjemainput({value, skjemafeil});
+}
+
+function lagFeilmelding(skjemafeil: string[]) {
+    return {feilmelding: skjemafeil.join(', ')};
+}
+
+export function Skjemainput(props: Props) {
+    const {skjemainput, onSkjemainput, validatorer, ...rest} = props;
+
+    const feilmelding = skjemainput.skjemafeil.length > 0 ? lagFeilmelding(skjemainput.skjemafeil) : undefined;
+
+    return (
+        <Input
+            {...rest}
+            defaultValue={props.skjemainput.value}
+            onChange={(event: ChangeEvent<HTMLInputElement>) =>
+                onChange(event.target.value, props)
+            }
+            feil={feilmelding}
+        />
+    );
+}

--- a/src/app/brukerprofil/adresse/MidlertidigAdresseNorge.tsx
+++ b/src/app/brukerprofil/adresse/MidlertidigAdresseNorge.tsx
@@ -2,18 +2,16 @@ import * as React from 'react';
 import { ChangeEvent } from 'react';
 
 import Select from 'nav-frontend-skjema/lib/select';
-
-import { Gateadresse, Matrikkeladresse } from '../../../models/personadresse';
-import GateadresseForm from './GateadresseForm';
-import MatrikkeladresseForm from './MatrikkeladresseForm';
+import GateadresseForm, { GateadresseSkjemainput } from './GateadresseForm';
+import MatrikkeladresseForm, { MatrikkeladresseSkjemainput } from './MatrikkeladresseForm';
 
 export enum MidlertidigeAdresserNorgeInputValg {
     GATEADRESSE, MATRIKKELADRESSE
 }
 
 export interface MidlertidigeAdresserNorgeInput {
-    gateadresse: Gateadresse;
-    matrikkeladresse: Matrikkeladresse;
+    gateadresse: GateadresseSkjemainput;
+    matrikkeladresse: MatrikkeladresseSkjemainput;
     valg: MidlertidigeAdresserNorgeInputValg;
 }
 
@@ -33,32 +31,13 @@ function getValgtAdressetype(value: string): MidlertidigeAdresserNorgeInputValg 
     }
 }
 
-export function getOrDefaultGateadresse(gateadresse?: Gateadresse): Gateadresse {
-    if (!gateadresse) {
-        return {
-            gatenavn: '',
-            poststed: '',
-            postnummer: ''
-        };
-    }
-    return gateadresse;
-}
-
-export function getOrDefaultMatrikkeladresse(matrikkeladresse?: Matrikkeladresse): Matrikkeladresse {
-    if (!matrikkeladresse) {
-        return {
-            poststed: '',
-            postnummer: ''
-        };
-    }
-    return matrikkeladresse;
-}
-
 class MidlertidigAdresseNorge extends React.Component<Props> {
 
     constructor(props: Props) {
         super(props);
         this.onAdresseTypeChange = this.onAdresseTypeChange.bind(this);
+        this.onGateadresseInputChange = this.onGateadresseInputChange.bind(this);
+        this.onMatrikkeladresseInputChange = this.onMatrikkeladresseInputChange.bind(this);
     }
 
     onAdresseTypeChange(event: ChangeEvent<HTMLSelectElement>) {
@@ -69,12 +48,24 @@ class MidlertidigAdresseNorge extends React.Component<Props> {
         });
     }
 
-    onGateadresseInputChange(gateadresse: Gateadresse ) {
-        this.props.onChange({...this.props.midlertidigAdresseNorge, gateadresse});
+    onGateadresseInputChange(partial: Partial<GateadresseSkjemainput> ) {
+        this.props.onChange({
+            ...this.props.midlertidigAdresseNorge,
+            gateadresse: {
+                ...this.props.midlertidigAdresseNorge.gateadresse,
+                ...partial
+            }
+        });
     }
 
-    onMatrikkeladresseInputChange(matrikkeladresse: Matrikkeladresse) {
-        this.props.onChange({...this.props.midlertidigAdresseNorge, matrikkeladresse});
+    onMatrikkeladresseInputChange(partial: Partial<MatrikkeladresseSkjemainput> ) {
+        this.props.onChange({
+            ...this.props.midlertidigAdresseNorge,
+            matrikkeladresse: {
+                ...this.props.midlertidigAdresseNorge.matrikkeladresse,
+                ...partial
+            }
+        });
     }
 
     render() {
@@ -102,14 +93,15 @@ class MidlertidigAdresseNorge extends React.Component<Props> {
                         Områdeadresse (uten veinavn)
                     </option>
                 </Select>
-                {valg === MidlertidigeAdresserNorgeInputValg.GATEADRESSE && <GateadresseForm
-                    onChange={(gateadresseInput: Gateadresse) => this.onGateadresseInputChange(gateadresseInput)}
+                {valg === MidlertidigeAdresserNorgeInputValg.GATEADRESSE &&
+                <GateadresseForm
+                    onChange={this.onGateadresseInputChange}
                     gateadresse={gateadresse}
                 />}
-                {valg === MidlertidigeAdresserNorgeInputValg.MATRIKKELADRESSE && <MatrikkeladresseForm
-                    onChange={(matrikkeladresseInput: Matrikkeladresse) =>
-                        this.onMatrikkeladresseInputChange(matrikkeladresseInput)}
-                    matrikkeladresse={getOrDefaultMatrikkeladresse(matrikkeladresse)}
+                {valg === MidlertidigeAdresserNorgeInputValg.MATRIKKELADRESSE &&
+                <MatrikkeladresseForm
+                    onChange={this.onMatrikkeladresseInputChange}
+                    matrikkeladresse={matrikkeladresse}
                 />}
             </>
         );

--- a/src/app/brukerprofil/formUtils.tsx
+++ b/src/app/brukerprofil/formUtils.tsx
@@ -1,3 +1,5 @@
+import { removeWhitespace } from '../../utils/string-utils';
+
 export interface InputState {
     input: string;
     feilmelding: string | null;
@@ -12,3 +14,17 @@ export function getSkjemafeil(state: InputState) {
         return undefined;
     }
 }
+
+function erIkkeTomStreng(input: string) {
+    if (removeWhitespace(input).length === 0) {
+        return 'Kan ikke være tom';
+    }
+    return null;
+}
+
+export const validatorer = {
+    erIkkeTomStreng
+};
+
+export const stringTilSkjemainput = (value: string | undefined) => ({value: value ? value : '', skjemafeil: []});
+export const defaultSkjemainput = {value: '', skjemafeil: []};

--- a/src/redux/brukerprofil/endreAdresseReducer.ts
+++ b/src/redux/brukerprofil/endreAdresseReducer.ts
@@ -1,10 +1,10 @@
 import { createActionsAndReducer } from '../restReducer';
 import { postEndreNorskGateadresse } from '../../api/brukerprofil/adresse-api';
-import { Gateadresse } from '../../models/personadresse';
+import { GateadresseSkjemainput } from '../../app/brukerprofil/adresse/GateadresseForm';
 
 const { reducer, action, tilbakestillReducer, actionNames } = createActionsAndReducer('endreadresse');
 
-export function endreNorskGateadresse(fødselsnummer: string, gateadresse: Gateadresse) {
+export function endreNorskGateadresse(fødselsnummer: string, gateadresse: GateadresseSkjemainput) {
     return action(() => postEndreNorskGateadresse(fødselsnummer, gateadresse));
 }
 


### PR DESCRIPTION
En variant av form-validation. Er ikke helt ferdig enda, og vet ikke helt om jeg lander på denne måten å gjøre det på. Så dette er mer et proof-of-concept. Lager PR så kan dere se på det hvis dere vil.

Konseptuelt så innfører jeg at state-objektet må være på følgende format:
```
interface MittSkjema{
  email: Skjemainput;
  navn: Skjemainput;
}

interface Skjemainput {
  value: string;
  valideringsfeil: string[]
}


render() {
  <input label='Navn' onChange={(value)=> props.onChange{value, valideringsfeil: validerNavn(value)} }/>
}
```