### PR TITLE
Kontonr fra tavla

### DIFF
--- a/src/app/brukerprofil/kontonummer/EndreKontonummerForm.tsx
+++ b/src/app/brukerprofil/kontonummer/EndreKontonummerForm.tsx
@@ -149,7 +149,7 @@ class EndreKontonummerForm extends React.Component<Props, State> {
 
     handleRadioChange(event: React.SyntheticEvent<EventTarget>, value: string) {
         this.setState({
-            ...this.getInitialState(),
+            bankkontoInput: tomBankkonto,
             norskKontoRadio: value === bankEnum.erNorsk
         });
     }
@@ -157,8 +157,7 @@ class EndreKontonummerForm extends React.Component<Props, State> {
     tilbakestill() {
         this.props.resetEndreKontonummerReducer();
         this.setState({
-            ...this.getInitialState(),
-            norskKontoRadio: this.state.norskKontoRadio
+            ...this.getInitialState()
         });
     }
 

--- a/src/app/brukerprofil/kontonummer/UtenlandskKontonummerInputs.tsx
+++ b/src/app/brukerprofil/kontonummer/UtenlandskKontonummerInputs.tsx
@@ -30,7 +30,7 @@ interface DispatchProps {
 }
 
 interface StateProps {
-    valuttaKodeverkReducer: RestReducer<KodeverkResponse>;
+    valutaKodeverkReducer: RestReducer<KodeverkResponse>;
     landKodeverkReducer: RestReducer<KodeverkResponse>;
 }
 
@@ -41,7 +41,7 @@ class UtenlandskKontonrInputs extends React.Component<Props, State> {
     constructor(props: Props) {
         super(props);
 
-        if (this.props.valuttaKodeverkReducer.status === STATUS.NOT_STARTED) {
+        if (this.props.valutaKodeverkReducer.status === STATUS.NOT_STARTED) {
             this.props.hentValutaKodeverk();
         }
 
@@ -53,7 +53,7 @@ class UtenlandskKontonrInputs extends React.Component<Props, State> {
     render() {
         return (
             <Innholdslaster
-                avhengigheter={[this.props.valuttaKodeverkReducer, this.props.landKodeverkReducer]}
+                avhengigheter={[this.props.valutaKodeverkReducer, this.props.landKodeverkReducer]}
             >
                 <Inputs {...this.props} />
             </Innholdslaster>
@@ -138,7 +138,7 @@ function Inputs(props: Props) {
                 onChange={event => props.updateBankkontoInputsState({ bankkode: event.target.value })}
                 feil={validering.bankkode.skjemafeil}
             />
-            <VelgValutta {...props} />
+            <VelgValuta {...props} />
         </>
     );
 }
@@ -166,20 +166,20 @@ function VelgLand(props: Props) {
     );
 }
 
-function VelgValutta(props: Props) {
-    const options = props.valuttaKodeverkReducer.data.kodeverk
+function VelgValuta(props: Props) {
+    const options = props.valutaKodeverkReducer.data.kodeverk
         .sort(sorterKodeverkAlfabetisk)
-        .map((valuttakodeverk: Kodeverk) => {
+        .map((valutakodeverk: Kodeverk) => {
             return (
-                <option key={valuttakodeverk.kodeRef} value={valuttakodeverk.kodeRef}>
-                    {valuttakodeverk.beskrivelse}
+                <option key={valutakodeverk.kodeRef} value={valutakodeverk.kodeRef}>
+                    {valutakodeverk.beskrivelse}
                 </option>
             );
         });
     return (
         <Select
-            label="Velg valutta"
-            id="Velg valutta"
+            label="Velg valuta"
+            id="Velg valuta"
             value={props.bankkonto.valuta.kodeRef}
             onChange={event => handleValutaChange(props, event)}
         >
@@ -202,7 +202,7 @@ function handleLandChange(props: Props, event: ChangeEvent<HTMLSelectElement>) {
 }
 
 function handleValutaChange(props: Props, event: ChangeEvent<HTMLSelectElement>) {
-        const valgtKodeverk: Kodeverk = props.valuttaKodeverkReducer.data.kodeverk
+        const valgtKodeverk: Kodeverk = props.valutaKodeverkReducer.data.kodeverk
                 .find(kodeverk => kodeverk.kodeRef === event.target.value)
             || { kodeRef: '', beskrivelse: '' };
 
@@ -218,7 +218,7 @@ const mapDispatchToProps = (dispatch: Dispatch<Action>): DispatchProps => {
 
 const mapStateToProps = (state: AppState): StateProps => {
     return ({
-        valuttaKodeverkReducer: state.valuttaReducer,
+        valutaKodeverkReducer: state.valutaReducer,
         landKodeverkReducer: state.landReducer
     });
 };

--- a/src/app/brukerprofil/kontonummer/norskKontoValidator.ts
+++ b/src/app/brukerprofil/kontonummer/norskKontoValidator.ts
@@ -1,14 +1,20 @@
 import { EndreBankkontoState, removeWhitespaceAndDot, validerKontonummer } from './kontonummerUtils';
 import { default as FormValidator, Valideringsregel } from '../../../utils/forms/FormValidator';
 
+function erTomStreng(streng: string): boolean {
+    return streng.length === 0;
+}
+
 const regler: Valideringsregel<EndreBankkontoState>[] = [{
     felt: 'kontonummer',
     feilmelding: 'Kontonummer må være elleve tall',
-    validator: (konto: EndreBankkontoState) => removeWhitespaceAndDot(konto.kontonummer).length === 11
+    validator: (konto: EndreBankkontoState) => erTomStreng(konto.kontonummer)
+        || removeWhitespaceAndDot(konto.kontonummer).length === 11
 }, {
     felt: 'kontonummer',
     feilmelding: 'Kontonummer er ikke gyldig',
-    validator: (konto: EndreBankkontoState) => validerKontonummer(removeWhitespaceAndDot(konto.kontonummer))
+    validator: (konto: EndreBankkontoState) => erTomStreng(konto.kontonummer)
+        || validerKontonummer(removeWhitespaceAndDot(konto.kontonummer))
 }];
 
 export function validerNorskBankKonto(bankkonto: EndreBankkontoState) {

--- a/src/redux/reducer.ts
+++ b/src/redux/reducer.ts
@@ -14,7 +14,7 @@ import veilederRollerReducer from './veilederRoller';
 import retningsnummereReducer from './kodeverk/retningsnummereReducer';
 import tilrettelagtKommunikasjonKodeverkReducer from './kodeverk/tilrettelagtKommunikasjonReducer';
 import endreKontaktinformasjonReducer from './brukerprofil/kontaktinformasjon';
-import valuttaKodeverkReducer from './kodeverk/valutaKodeverk';
+import valutaKodeverkReducer from './kodeverk/valutaKodeverk';
 import endreAdresseReducer from './brukerprofil/endreAdresseReducer';
 import landKodeverkReducer from './kodeverk/landKodeverk';
 import postnummerReducer from './kodeverk/postnummerReducer';
@@ -46,7 +46,7 @@ export interface AppState {
     endreKontaktinformasjonReducer: RestReducer<{}>;
     postnummerReducer: RestReducer<KodeverkResponse>;
     endreAdresseReducer: RestReducer<{}>;
-    valuttaReducer: RestReducer<KodeverkResponse>;
+    valutaReducer: RestReducer<KodeverkResponse>;
     landReducer: RestReducer<KodeverkResponse>;
 }
 
@@ -67,7 +67,7 @@ export default combineReducers<AppState>({
     endreKontaktinformasjonReducer: endreKontaktinformasjonReducer,
     postnummerReducer: postnummerReducer,
     endreAdresseReducer,
-    valuttaReducer: valuttaKodeverkReducer,
+    valutaReducer: valutaKodeverkReducer,
     landReducer: landKodeverkReducer
 });
 


### PR DESCRIPTION
feil fra tavla:
* retter skrivefeil
* formen tømmes når man bytter mellom norsk/utenlandsk kontonummer
* tom streng er nå akseptert som kontonummer. Det vil si å sette brukers kontonummer til "ikke registrert"