### PR TITLE
Fiks feil der vi dispatchet henter person to ganger

### DIFF
--- a/src/components/standalone/VisittKort.tsx
+++ b/src/components/standalone/VisittKort.tsx
@@ -7,7 +7,6 @@ import { MemoryRouter, Route, Switch } from 'react-router';
 
 import { personOversiktTheme } from '../../themes/personOversiktTheme';
 import reducers from '../../redux/reducers';
-import { hentAllPersonData } from '../../redux/restReducers/personinformasjon';
 import VisittkortLaster from './VisittKortLaster';
 import { mockEnabled } from '../../api/config';
 import { setupMock } from '../../mock/setup-mock';
@@ -29,10 +28,6 @@ if (mockEnabled === 'true') {
 }
 
 class VisittkortStandAlone extends React.Component<Props> {
-
-    componentWillMount() {
-        hentAllPersonData(store.dispatch, this.props.fødselsnummer);
-    }
 
     render() {
         return (


### PR DESCRIPTION
Dette førte til en feil med reloading-funksjonaliten som førte til
undefined person. Årsaksforløp:

personreducer -> Loading
personreducer -> Reloading (uten at det første kallet gikk igjen)
Innholdslasteren venter ikke på reloading noe som førte til umiddelbar
rendring av personinformasjon som aldri var blitt loadet. Og da kræasjet
det.