### PR TITLE
Støtter at familierelasjoner har litt manglende data pga. diskresjonskode

### DIFF
--- a/src/app/personside/visittkort/body/familie/Foreldre.tsx
+++ b/src/app/personside/visittkort/body/familie/Foreldre.tsx
@@ -25,7 +25,7 @@ export function Forelder({relasjon}: ForelderProps) {
         <VisittkortElement beskrivelse={beskrivelse} ikon={ikon}>
             <Diskresjonskode diskresjonskode={relasjon.tilPerson.diskresjonskode}/>
             <Undertekst><NavnOgAlder relasjon={relasjon}/></Undertekst>
-            <Undertekst>{relasjon.tilPerson.fødselsnummer}</Undertekst>
+            <Undertekst>{relasjon.tilPerson.fødselsnummer || ''}</Undertekst>
             <Undertekst><BorMedBruker harSammeBosted={relasjon.harSammeBosted}/></Undertekst>
         </VisittkortElement>
     );

--- a/src/app/personside/visittkort/body/familie/ListeAvBarn.tsx
+++ b/src/app/personside/visittkort/body/familie/ListeAvBarn.tsx
@@ -23,7 +23,7 @@ function Barn({barn}: BarnProps) {
         <VisittkortElement beskrivelse={beskrivelse} ikon={ikon}>
             <Diskresjonskode diskresjonskode={barn.tilPerson.diskresjonskode}/>
             <Undertekst><NavnOgAlder relasjon={barn}/></Undertekst>
-            <Undertekst>{barn.tilPerson.fødselsnummer}</Undertekst>
+            <Undertekst>{barn.tilPerson.fødselsnummer || ''}</Undertekst>
             <Undertekst><BorMedBruker harSammeBosted={barn.harSammeBosted}/></Undertekst>
         </VisittkortElement>
     );

--- a/src/app/personside/visittkort/body/familie/Sivilstand.tsx
+++ b/src/app/personside/visittkort/body/familie/Sivilstand.tsx
@@ -43,7 +43,7 @@ function Partner({relasjon, sivilstand}: PartnerProps) {
             <Undertekst><Sivilstand sivilstand={sivilstand}/></Undertekst>
             <Diskresjonskode diskresjonskode={relasjon.tilPerson.diskresjonskode}/>
             <Undertekst><NavnOgAlder relasjon={relasjon}/></Undertekst>
-            <Undertekst>{relasjon.tilPerson.fødselsnummer}</Undertekst>
+            <Undertekst>{relasjon.tilPerson.fødselsnummer || ''}</Undertekst>
             <Undertekst><BorMedBruker harSammeBosted={relasjon.harSammeBosted}/></Undertekst>
         </>
     );

--- a/src/app/personside/visittkort/body/familie/common/Diskresjonskode.tsx
+++ b/src/app/personside/visittkort/body/familie/common/Diskresjonskode.tsx
@@ -1,7 +1,5 @@
 import * as React from 'react';
 
-import Undertekst from 'nav-frontend-typografi/lib/undertekst';
-
 import { lagDiskresjonskodeEtikett } from '../../../header/Etiketter';
 import { Kodeverk } from '../../../../../../models/kodeverk';
 
@@ -10,8 +8,8 @@ export function Diskresjonskode({diskresjonskode}: {diskresjonskode?: Kodeverk |
         return null;
     }
     return (
-        <Undertekst>
+        <>
             {diskresjonskode ? lagDiskresjonskodeEtikett(diskresjonskode) : ''}
-        </Undertekst>
+        </>
     );
 }


### PR DESCRIPTION

* Diskresjonskodelablen, som rendres som en div, kan ikke være inne i en
undertekst.
* Fødselsnummer er null/undefined hvis familerelasjonen har
diskresjonskode

![](https://media.giphy.com/media/LTPvh458Wx0BO/giphy.gif)