### PR TITLE
skriver vekk ThemeProvider fra styled-components

### DIFF
--- a/src/app/App.tsx
+++ b/src/app/App.tsx
@@ -2,13 +2,11 @@ import * as React from 'react';
 import { Provider } from 'react-redux';
 import { applyMiddleware, createStore } from 'redux';
 import thunkMiddleware from 'redux-thunk';
-import { ThemeProvider } from 'styled-components';
 import { BrowserRouter } from 'react-router-dom';
 
 import Routing from './routes/routing';
 import UnderArbeid from '../components/underarbeid/UnderArbeid';
 import { setupMock } from '../mock/setup-mock';
-import { personOversiktTheme } from '../themes/personOversiktTheme';
 import reducers from '../redux/reducers';
 import { mockEnabled } from '../api/config';
 import AppWrapper, { Content } from './AppWrapper';
@@ -32,18 +30,16 @@ class App extends React.Component<{}> {
     render() {
         return (
             <Provider store={store}>
-                <ThemeProvider theme={personOversiktTheme}>
-                    <AppWrapper>
-                        <nav id="header" />
-                        <BrowserRouter>
-                            <Content>
-                                <Eventlistener/>
-                                <Routing/>
-                            </Content>
-                        </BrowserRouter>
-                        <UnderArbeid />
-                    </AppWrapper>
-                </ThemeProvider>
+                <AppWrapper>
+                    <nav id="header"/>
+                    <BrowserRouter>
+                        <Content>
+                            <Eventlistener/>
+                            <Routing/>
+                        </Content>
+                    </BrowserRouter>
+                    <UnderArbeid/>
+                </AppWrapper>
             </Provider>
         );
     }

--- a/src/app/AppWrapper.ts
+++ b/src/app/AppWrapper.ts
@@ -1,11 +1,11 @@
 import styled from 'styled-components';
-import { styles } from '../styles/personOversiktStyles';
+import { theme } from '../styles/personOversiktTheme';
 
 const AppWrapper = styled.div`
   height: 100vh;
   display: flex;
   flex-flow: column nowrap;
-  background-color: ${styles.color.bakgrunn};
+  background-color: ${theme.color.bakgrunn};
 `;
 
 export const Content = styled.div`

--- a/src/app/AppWrapper.ts
+++ b/src/app/AppWrapper.ts
@@ -1,10 +1,11 @@
 import styled from 'styled-components';
+import { styles } from '../styles/personOversiktStyles';
 
 const AppWrapper = styled.div`
   height: 100vh;
   display: flex;
   flex-flow: column nowrap;
-  background-color: ${(props) => props.theme.color.bakgrunn};
+  background-color: ${styles.color.bakgrunn};
 `;
 
 export const Content = styled.div`

--- a/src/app/brukerprofil/BrukerprofilSide.tsx
+++ b/src/app/brukerprofil/BrukerprofilSide.tsx
@@ -16,7 +16,7 @@ import { getVeilederRoller } from '../../redux/restReducers/veilederRoller';
 import { STATUS } from '../../redux/restReducers/utils';
 import Sidetittel from 'nav-frontend-typografi/lib/sidetittel';
 import { RestReducer } from '../../redux/restReducers/restReducer';
-import { styles } from '../../styles/personOversiktStyles';
+import { theme } from '../../styles/personOversiktTheme';
 
 const BrukerprofilWrapper = styled.section`
   flex-grow: 1;
@@ -25,10 +25,10 @@ const BrukerprofilWrapper = styled.section`
   width: 90%;
   display: flex;
   flex-flow: column nowrap;
-  animation: ${styles.animation.fadeIn};
+  animation: ${theme.animation.fadeIn};
   > *:not(:first-child):not(:nth-child(2)) {
     background-color: white;
-    border-radius: ${styles.borderRadius.layout};
+    border-radius: ${theme.borderRadius.layout};
     margin: 1em 0;
     padding: 2em;
   }

--- a/src/app/brukerprofil/BrukerprofilSide.tsx
+++ b/src/app/brukerprofil/BrukerprofilSide.tsx
@@ -16,6 +16,7 @@ import { getVeilederRoller } from '../../redux/restReducers/veilederRoller';
 import { STATUS } from '../../redux/restReducers/utils';
 import Sidetittel from 'nav-frontend-typografi/lib/sidetittel';
 import { RestReducer } from '../../redux/restReducers/restReducer';
+import { styles } from '../../styles/personOversiktStyles';
 
 const BrukerprofilWrapper = styled.section`
   flex-grow: 1;
@@ -24,10 +25,10 @@ const BrukerprofilWrapper = styled.section`
   width: 90%;
   display: flex;
   flex-flow: column nowrap;
-  animation: ${props => props.theme.animation.fadeIn};
+  animation: ${styles.animation.fadeIn};
   > *:not(:first-child):not(:nth-child(2)) {
     background-color: white;
-    border-radius: ${props => props.theme.borderRadius.layout};
+    border-radius: ${styles.borderRadius.layout};
     margin: 1em 0;
     padding: 2em;
   }

--- a/src/app/personside/MainLayoutStyles.tsx
+++ b/src/app/personside/MainLayoutStyles.tsx
@@ -1,9 +1,10 @@
 import styled from 'styled-components';
+import { styles } from '../../styles/personOversiktStyles';
 
 export const LayoutWrapper = styled.div`
     width: 100vw;
     flex-grow: 1;
-    animation: ${props => props.theme.animation.fadeIn};
+    animation: ${styles.animation.fadeIn};
     display: flex;
     flex-flow: row nowrap;
     > * {
@@ -14,10 +15,10 @@ export const LayoutWrapper = styled.div`
 
 export const VenstreKolonne = styled<{ dialogPanelEkspandert?: boolean; }, 'section'>('section')`
     width: ${props => props.dialogPanelEkspandert ? '50%' : '70%' };
-    padding: ${props => props.theme.margin.layout};
+    padding: ${styles.margin.layout};
     > * {
-      margin-bottom: ${props => props.theme.margin.layout};
-      border-radius: ${props => props.theme.borderRadius.layout};
+      margin-bottom: ${styles.margin.layout};
+      border-radius: ${styles.borderRadius.layout};
     }
 `;
 
@@ -27,7 +28,7 @@ export const HøyreKolonne = styled<{ dialogPanelEkspandert?: boolean; }, 'secti
     display: flex;
     flex-flow: column nowrap;
     > * {
-        padding: ${props => props.theme.margin.layout};
+        padding: ${styles.margin.layout};
         flex-shrink: 0;
     }
 `;

--- a/src/app/personside/MainLayoutStyles.tsx
+++ b/src/app/personside/MainLayoutStyles.tsx
@@ -1,10 +1,10 @@
 import styled from 'styled-components';
-import { styles } from '../../styles/personOversiktStyles';
+import { theme } from '../../styles/personOversiktTheme';
 
 export const LayoutWrapper = styled.div`
     width: 100vw;
     flex-grow: 1;
-    animation: ${styles.animation.fadeIn};
+    animation: ${theme.animation.fadeIn};
     display: flex;
     flex-flow: row nowrap;
     > * {
@@ -15,10 +15,10 @@ export const LayoutWrapper = styled.div`
 
 export const VenstreKolonne = styled<{ dialogPanelEkspandert?: boolean; }, 'section'>('section')`
     width: ${props => props.dialogPanelEkspandert ? '50%' : '70%' };
-    padding: ${styles.margin.layout};
+    padding: ${theme.margin.layout};
     > * {
-      margin-bottom: ${styles.margin.layout};
-      border-radius: ${styles.borderRadius.layout};
+      margin-bottom: ${theme.margin.layout};
+      border-radius: ${theme.borderRadius.layout};
     }
 `;
 
@@ -28,7 +28,7 @@ export const HøyreKolonne = styled<{ dialogPanelEkspandert?: boolean; }, 'secti
     display: flex;
     flex-flow: column nowrap;
     > * {
-        padding: ${styles.margin.layout};
+        padding: ${theme.margin.layout};
         flex-shrink: 0;
     }
 `;

--- a/src/app/personside/dialogpanel/DialogPanel.tsx
+++ b/src/app/personside/dialogpanel/DialogPanel.tsx
@@ -2,7 +2,7 @@ import * as React from 'react';
 import styled from 'styled-components';
 import Undertekst from 'nav-frontend-typografi/lib/undertekst';
 import Undertittel from 'nav-frontend-typografi/lib/undertittel';
-import { styles } from '../../../styles/personOversiktStyles';
+import { theme } from '../../../styles/personOversiktTheme';
 
 const border = 'rgba(0, 0, 0, 0.1) 1px solid';
 
@@ -12,7 +12,7 @@ const DialogPanelWrapper = styled.div`
   border-bottom: ${border};
   flex-grow: 1;
   > *:not(:last-child) {
-    margin-bottom: ${styles.margin.layout};
+    margin-bottom: ${theme.margin.layout};
   }
 `;
 

--- a/src/app/personside/dialogpanel/DialogPanel.tsx
+++ b/src/app/personside/dialogpanel/DialogPanel.tsx
@@ -2,6 +2,7 @@ import * as React from 'react';
 import styled from 'styled-components';
 import Undertekst from 'nav-frontend-typografi/lib/undertekst';
 import Undertittel from 'nav-frontend-typografi/lib/undertittel';
+import { styles } from '../../../styles/personOversiktStyles';
 
 const border = 'rgba(0, 0, 0, 0.1) 1px solid';
 
@@ -11,7 +12,7 @@ const DialogPanelWrapper = styled.div`
   border-bottom: ${border};
   flex-grow: 1;
   > *:not(:last-child) {
-    margin-bottom: ${props => props.theme.margin.layout};
+    margin-bottom: ${styles.margin.layout};
   }
 `;
 

--- a/src/app/personside/infotabs/TabKnapper.tsx
+++ b/src/app/personside/infotabs/TabKnapper.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import { INFOTABS } from './InfoTabEnum';
 import styled from 'styled-components';
-import { styles } from '../../../styles/personOversiktStyles';
+import { theme } from '../../../styles/personOversiktTheme';
 
 interface TabPanelProps {
     onTabChange: Function;
@@ -36,13 +36,13 @@ const TabKnapp = styled<TabKnappProps, 'button'>('button')`
     padding-top: 0.5em;
     margin-top: 0.5em;
     border: none;
-    border-bottom: 4px solid ${props => props.valgt ? styles.color.selectedLink : 'transparent'};
+    border-bottom: 4px solid ${props => props.valgt ? theme.color.selectedLink : 'transparent'};
     text-align: center;
     cursor: pointer;
     transition: 0.5s;
     font-weight: bold;
     &:hover {
-      border-bottom: 4px solid ${styles.color.hoverLink};
+      border-bottom: 4px solid ${theme.color.hoverLink};
     }
 `;
 

--- a/src/app/personside/infotabs/TabKnapper.tsx
+++ b/src/app/personside/infotabs/TabKnapper.tsx
@@ -1,6 +1,7 @@
 import * as React from 'react';
 import { INFOTABS } from './InfoTabEnum';
 import styled from 'styled-components';
+import { styles } from '../../../styles/personOversiktStyles';
 
 interface TabPanelProps {
     onTabChange: Function;
@@ -35,13 +36,13 @@ const TabKnapp = styled<TabKnappProps, 'button'>('button')`
     padding-top: 0.5em;
     margin-top: 0.5em;
     border: none;
-    border-bottom: 4px solid ${props => props.valgt ? props.theme.color.selectedLink : 'transparent'};
+    border-bottom: 4px solid ${props => props.valgt ? styles.color.selectedLink : 'transparent'};
     text-align: center;
     cursor: pointer;
     transition: 0.5s;
     font-weight: bold;
     &:hover {
-      border-bottom: 4px solid ${props => props.theme.color.hoverLink};
+      border-bottom: 4px solid ${styles.color.hoverLink};
     }
 `;
 

--- a/src/app/personside/visittkort/Visittkort.test.tsx
+++ b/src/app/personside/visittkort/Visittkort.test.tsx
@@ -6,21 +6,17 @@ import VisittkortBody from './body/VisittkortBody';
 import { Provider } from 'react-redux';
 import { testStore } from '../../../test/setupTests';
 import { personinformasjonActionNames } from '../../../redux/restReducers/personinformasjon';
-import { ThemeProvider } from 'styled-components';
-import { personOversiktTheme } from '../../../themes/personOversiktTheme';
 import { aremark } from '../../../mock/person/aremark';
 import { StaticRouter } from 'react-router';
 
-testStore.dispatch({ type: personinformasjonActionNames.FINISHED, data: aremark });
+testStore.dispatch({type: personinformasjonActionNames.FINISHED, data: aremark});
 
 const visittkort = mount((
-    <ThemeProvider theme={personOversiktTheme}>
-        <Provider store={testStore}>
-            <StaticRouter context={{}}>
-                <Visittkort/>
-            </StaticRouter>
-        </Provider>
-    </ThemeProvider>
+    <Provider store={testStore}>
+        <StaticRouter context={{}}>
+            <Visittkort/>
+        </StaticRouter>
+    </Provider>
 ));
 
 test('viser visittkortheader når visittkort først rendres', () => {

--- a/src/app/personside/visittkort/VisittkortContainer.tsx
+++ b/src/app/personside/visittkort/VisittkortContainer.tsx
@@ -11,7 +11,7 @@ import ErrorBoundary from '../../../components/ErrorBoundary';
 import ShortcutListener from './ShortcutListener';
 import { AppState } from '../../../redux/reducers';
 import { toggleVisittkort, UIState } from '../../../redux/uiReducers/UIReducer';
-import { styles } from '../../../styles/personOversiktStyles';
+import { theme } from '../../../styles/personOversiktTheme';
 
 interface StateProps {
     UI: UIState;
@@ -25,7 +25,7 @@ interface DispatchProps {
 const VisittKortDiv = styled.article`
   .ekspanderbartPanel__hode {
       // For å lage en "strek" mellom visittkorthode og visittkortkropp:
-      border-bottom: ${styles.color.bakgrunn} 2px solid;
+      border-bottom: ${theme.color.bakgrunn} 2px solid;
       &:hover { color: inherit; }
   }
 `;

--- a/src/app/personside/visittkort/VisittkortContainer.tsx
+++ b/src/app/personside/visittkort/VisittkortContainer.tsx
@@ -11,6 +11,7 @@ import ErrorBoundary from '../../../components/ErrorBoundary';
 import ShortcutListener from './ShortcutListener';
 import { AppState } from '../../../redux/reducers';
 import { toggleVisittkort, UIState } from '../../../redux/uiReducers/UIReducer';
+import { styles } from '../../../styles/personOversiktStyles';
 
 interface StateProps {
     UI: UIState;
@@ -24,7 +25,7 @@ interface DispatchProps {
 const VisittKortDiv = styled.article`
   .ekspanderbartPanel__hode {
       // For å lage en "strek" mellom visittkorthode og visittkortkropp:
-      border-bottom: ${props => props.theme.color.bakgrunn} 2px solid;
+      border-bottom: ${styles.color.bakgrunn} 2px solid;
       &:hover { color: inherit; }
   }
 `;

--- a/src/app/startbilde/StartBildeLayout.ts
+++ b/src/app/startbilde/StartBildeLayout.ts
@@ -1,4 +1,5 @@
 import styled from 'styled-components';
+import { styles } from '../../styles/personOversiktStyles';
 
 const StartBildeLayout = styled.div`
     margin-top: 7em;
@@ -6,7 +7,7 @@ const StartBildeLayout = styled.div`
     flex-grow: 1;
     flex-flow: column wrap;
     align-items: center;
-    animation: ${props => props.theme.animation.fadeIn};
+    animation: ${styles.animation.fadeIn};
     > * {
         margin-bottom: 2em;
         min-width: 20em;

--- a/src/app/startbilde/StartBildeLayout.ts
+++ b/src/app/startbilde/StartBildeLayout.ts
@@ -1,5 +1,5 @@
 import styled from 'styled-components';
-import { styles } from '../../styles/personOversiktStyles';
+import { theme } from '../../styles/personOversiktTheme';
 
 const StartBildeLayout = styled.div`
     margin-top: 7em;
@@ -7,7 +7,7 @@ const StartBildeLayout = styled.div`
     flex-grow: 1;
     flex-flow: column wrap;
     align-items: center;
-    animation: ${styles.animation.fadeIn};
+    animation: ${theme.animation.fadeIn};
     > * {
         margin-bottom: 2em;
         min-width: 20em;

--- a/src/components/FillCenterAndFadeIn.ts
+++ b/src/components/FillCenterAndFadeIn.ts
@@ -1,11 +1,12 @@
 import styled from 'styled-components';
+import { styles } from '../styles/personOversiktStyles';
 
 const FillCenterAndFadeIn = styled.div`
     flex-grow: 1;
     display: flex;
     justify-content: center;
     align-items: center;
-    animation: ${props => props.theme.animation.fadeIn};
+    animation: ${styles.animation.fadeIn};
 `;
 
 export default FillCenterAndFadeIn;

--- a/src/components/FillCenterAndFadeIn.ts
+++ b/src/components/FillCenterAndFadeIn.ts
@@ -1,12 +1,12 @@
 import styled from 'styled-components';
-import { styles } from '../styles/personOversiktStyles';
+import { theme } from '../styles/personOversiktTheme';
 
 const FillCenterAndFadeIn = styled.div`
     flex-grow: 1;
     display: flex;
     justify-content: center;
     align-items: center;
-    animation: ${styles.animation.fadeIn};
+    animation: ${theme.animation.fadeIn};
 `;
 
 export default FillCenterAndFadeIn;

--- a/src/components/pilknapp.tsx
+++ b/src/components/pilknapp.tsx
@@ -1,5 +1,6 @@
 import * as React from 'react';
 import styled from 'styled-components';
+import { styles } from '../styles/personOversiktStyles';
 
 interface StyleProps {
     width?: string;
@@ -24,7 +25,7 @@ const KnappWrapper = styled<StyleProps, 'button'>('button')`
     opacity: 0.8;
   }
   &:focus {
-    ${props => props.theme.focus}
+    ${styles.focus}
   }
   svg {
     stroke: #3E3832;

--- a/src/components/pilknapp.tsx
+++ b/src/components/pilknapp.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import styled from 'styled-components';
-import { styles } from '../styles/personOversiktStyles';
+import { theme } from '../styles/personOversiktTheme';
 
 interface StyleProps {
     width?: string;
@@ -25,7 +25,7 @@ const KnappWrapper = styled<StyleProps, 'button'>('button')`
     opacity: 0.8;
   }
   &:focus {
-    ${styles.focus}
+    ${theme.focus}
   }
   svg {
     stroke: #3E3832;

--- a/src/components/standalone/HentOppgaveKnapp.tsx
+++ b/src/components/standalone/HentOppgaveKnapp.tsx
@@ -1,11 +1,9 @@
 import * as React from 'react';
 import { Provider } from 'react-redux';
-import { ThemeProvider } from 'styled-components';
 import { applyMiddleware, createStore } from 'redux';
 import thunkMiddleware from 'redux-thunk';
 import { StaticRouter } from 'react-router';
 
-import { personOversiktTheme } from '../../themes/personOversiktTheme';
 import reducers from '../../redux/reducers';
 import { mockEnabled } from '../../api/config';
 import { setupMock } from '../../mock/setup-mock';
@@ -27,11 +25,9 @@ class HentOppgaveKnappStandalone extends React.Component {
         return (
             <ErrorBoundary>
                 <Provider store={store}>
-                    <ThemeProvider theme={personOversiktTheme}>
-                        <StaticRouter>
-                            <HentOppgaveKnapp />
-                        </StaticRouter>
-                    </ThemeProvider>
+                    <StaticRouter>
+                        <HentOppgaveKnapp/>
+                    </StaticRouter>
                 </Provider>
             </ErrorBoundary>
         );

--- a/src/components/standalone/VisittKort.tsx
+++ b/src/components/standalone/VisittKort.tsx
@@ -1,11 +1,9 @@
 import * as React from 'react';
 import { Provider } from 'react-redux';
-import { ThemeProvider } from 'styled-components';
 import { applyMiddleware, createStore } from 'redux';
 import thunkMiddleware from 'redux-thunk';
 import { MemoryRouter, Route, Switch } from 'react-router';
 
-import { personOversiktTheme } from '../../themes/personOversiktTheme';
 import reducers from '../../redux/reducers';
 import VisittkortLaster from './VisittKortLaster';
 import { mockEnabled } from '../../api/config';
@@ -33,14 +31,12 @@ class VisittkortStandAlone extends React.Component<Props> {
         return (
             <ErrorBoundary>
                 <Provider store={store}>
-                    <ThemeProvider theme={personOversiktTheme}>
-                        <MemoryRouter>
-                            <Switch>
-                                <Route path={`${paths.brukerprofil}/:fodselsnummer/`} component={Brukerprofilside}/>
-                                <Route render={() => <VisittkortLaster fødselsnummer={this.props.fødselsnummer} />} />
-                            </Switch>
-                        </MemoryRouter>
-                    </ThemeProvider>
+                    <MemoryRouter>
+                        <Switch>
+                            <Route path={`${paths.brukerprofil}/:fodselsnummer/`} component={Brukerprofilside}/>
+                            <Route render={() => <VisittkortLaster fødselsnummer={this.props.fødselsnummer}/>}/>
+                        </Switch>
+                    </MemoryRouter>
                 </Provider>
             </ErrorBoundary>
         );

--- a/src/styles/personOversiktStyles.ts
+++ b/src/styles/personOversiktStyles.ts
@@ -1,11 +1,10 @@
-/* GLOBAL STYLING - STYLED COMPONENTS THEME */
 import { keyframes } from 'styled-components';
 
 const fadeIn = keyframes`
     from { opacity: 0 }
 `;
 
-export const personOversiktTheme = {
+export const styles = {
     color: {
         selectedLink: '#66CBEC',
         hoverLink: '#C6C2BF',
@@ -30,3 +29,5 @@ export const personOversiktTheme = {
     },
     focus: 'outline: none; box-shadow: 0 0 0px 3px #FFBD66;'
 };
+
+export default styles;

--- a/src/styles/personOversiktTheme.ts
+++ b/src/styles/personOversiktTheme.ts
@@ -4,7 +4,7 @@ const fadeIn = keyframes`
     from { opacity: 0 }
 `;
 
-export const styles = {
+export const theme = {
     color: {
         selectedLink: '#66CBEC',
         hoverLink: '#C6C2BF',
@@ -30,4 +30,4 @@ export const styles = {
     focus: 'outline: none; box-shadow: 0 0 0px 3px #FFBD66;'
 };
 
-export default styles;
+export default theme;

--- a/src/test/Testprovider.tsx
+++ b/src/test/Testprovider.tsx
@@ -1,23 +1,19 @@
 import * as React from 'react';
-import { personOversiktTheme } from '../themes/personOversiktTheme';
 import { testStore } from './setupTests';
 import { Provider } from 'react-redux';
 import { StaticRouter } from 'react-router';
-import { ThemeProvider } from 'styled-components';
 import { ReactNode } from 'react';
 
 interface Props {
     children: ReactNode;
 }
 
-function TestProvider({ children }: Props) {
+function TestProvider({children}: Props) {
     return (
         <Provider store={testStore}>
-            <ThemeProvider theme={personOversiktTheme}>
-                <StaticRouter context={{}}>
-                    {children}
-                </StaticRouter>
-            </ThemeProvider>
+            <StaticRouter context={{}}>
+                {children}
+            </StaticRouter>
         </Provider>
     );
 }


### PR DESCRIPTION
ble ikke brukt. Globale stiler kan nå hentes fra javascript-objekt i personOversiktStyles istedenfor. Skaper mer lesbar kode og bedre autocomplete