### PR TITLE
event.code er ikke støtte i IE, tar i bruk .key istedet

### DIFF
--- a/src/app/personside/visittkort/ShortcutListener.tsx
+++ b/src/app/personside/visittkort/ShortcutListener.tsx
@@ -34,9 +34,9 @@ class ShortcutListener extends React.Component<Props> {
     }
 
     private handleShortcut(event: KeyboardEvent) {
-        if (event.altKey && event.code === 'KeyB') {
+        if (event.altKey && event.key === 'b') {
             this.props.history.push(`${paths.brukerprofil}/${this.props.fødselsnummer}`);
-        } else if (event.altKey && event.code === 'KeyN') {
+        } else if (event.altKey && event.key === 'n') {
             this.props.toggleVisittkort();
         }
     }


### PR DESCRIPTION
OPP-539 
Alt+N (og Alt+B) hurtigtastene fungerte ikke i IE.