### PR TITLE
Pil navigerings fiks

### DIFF
--- a/src/app/personside/infotabs/utbetalinger/HandleUtbetalingerArrowKeys.tsx
+++ b/src/app/personside/infotabs/utbetalinger/HandleUtbetalingerArrowKeys.tsx
@@ -1,0 +1,83 @@
+import * as React from 'react';
+import { Utbetaling, Ytelse } from '../../../../models/utbetalinger';
+import { flatMapYtelser } from './utils/utbetalingerUtils';
+import { Dispatch } from 'redux';
+import { settNyYtelseIFokus } from '../../../../redux/utbetalinger/utbetalingerStateReducer';
+import { AppState } from '../../../../redux/reducers';
+import { connect } from 'react-redux';
+
+interface OwnProps {
+    children: React.ReactNode;
+    utbetalinger: Utbetaling[];
+}
+
+interface DispatchProps {
+    settYtelseIFokus: (ytelse: Ytelse) => void;
+}
+
+interface StateProps {
+    ytelseIFokus: Ytelse | null;
+}
+
+type Props = DispatchProps & OwnProps & StateProps;
+
+class HandleUtbetalingerArrowKeys extends React.Component<Props, {}> {
+
+    constructor(props: Props) {
+        super(props);
+        this.handleKeyDown = this.handleKeyDown.bind(this);
+    }
+
+    handleKeyDown(event: React.KeyboardEvent) {
+        this.handlePilknapper(event);
+        this.handleEnter(event);
+    }
+
+    handlePilknapper(event: React.KeyboardEvent) {
+        if (event.key === 'ArrowDown') {
+            this.props.settYtelseIFokus(this.finnNesteYtelse());
+        } else if (event.key === 'ArrowUp') {
+            this.props.settYtelseIFokus(this.finnForrigeYtelse());
+        }
+    }
+
+    finnNesteYtelse() {
+        const ytelser: Ytelse[] = flatMapYtelser(this.props.utbetalinger);
+        const currentIndex = this.props.ytelseIFokus ? ytelser.indexOf(this.props.ytelseIFokus) : -1;
+        return ytelser[currentIndex + 1] || ytelser[0];
+    }
+
+    finnForrigeYtelse() {
+        const ytelser: Ytelse[] = flatMapYtelser(this.props.utbetalinger);
+        const currentIndex = this.props.ytelseIFokus ? ytelser.indexOf(this.props.ytelseIFokus) : ytelser.length;
+        return ytelser[currentIndex - 1] || ytelser[ytelser.length - 1];
+    }
+
+    handleEnter(event: React.KeyboardEvent) {
+        if (event.key === 'Enter') {
+            // TODO åpne og lukke yteslesdetaljer herfra med redux
+        }
+    }
+
+    render() {
+        return (
+            <div onKeyDown={this.handleKeyDown}>
+                {this.props.children}
+            </div>
+        );
+    }
+}
+
+function mapDispatchToProps(dispatch: Dispatch<{}>): DispatchProps {
+    return {
+        settYtelseIFokus: ytelse => dispatch(settNyYtelseIFokus(ytelse))
+    };
+}
+
+function mapStateToProps(state: AppState): StateProps {
+    return {
+        ytelseIFokus: state.utbetalinger.ytelseIFokus
+    };
+}
+
+export default connect(mapStateToProps, mapDispatchToProps)(HandleUtbetalingerArrowKeys);

--- a/src/app/personside/infotabs/utbetalinger/HandleUtbetalingerHotKeys.tsx
+++ b/src/app/personside/infotabs/utbetalinger/HandleUtbetalingerHotKeys.tsx
@@ -2,7 +2,10 @@ import * as React from 'react';
 import { Utbetaling, Ytelse } from '../../../../models/utbetalinger';
 import { flatMapYtelser } from './utils/utbetalingerUtils';
 import { Dispatch } from 'redux';
-import { settNyYtelseIFokus } from '../../../../redux/utbetalinger/utbetalingerStateReducer';
+import {
+    setEkspanderYtelse,
+    setNyYtelseIFokus
+} from '../../../../redux/utbetalinger/utbetalingerStateReducer';
 import { AppState } from '../../../../redux/reducers';
 import { connect } from 'react-redux';
 
@@ -13,15 +16,17 @@ interface OwnProps {
 
 interface DispatchProps {
     settYtelseIFokus: (ytelse: Ytelse) => void;
+    ekspanderYtelse: (ytelse: Ytelse, ekspander: boolean) => void;
 }
 
 interface StateProps {
     ytelseIFokus: Ytelse | null;
+    ekspanderteYtelser: Ytelse[];
 }
 
 type Props = DispatchProps & OwnProps & StateProps;
 
-class HandleUtbetalingerArrowKeys extends React.Component<Props, {}> {
+class HandleUtbetalingerHotKeys extends React.Component<Props> {
 
     constructor(props: Props) {
         super(props);
@@ -29,6 +34,10 @@ class HandleUtbetalingerArrowKeys extends React.Component<Props, {}> {
     }
 
     handleKeyDown(event: React.KeyboardEvent) {
+        const eventTargetIsButton = event.target instanceof HTMLButtonElement;
+        if (eventTargetIsButton) {
+            return;
+        }
         this.handlePilknapper(event);
         this.handleEnter(event);
     }
@@ -55,8 +64,17 @@ class HandleUtbetalingerArrowKeys extends React.Component<Props, {}> {
 
     handleEnter(event: React.KeyboardEvent) {
         if (event.key === 'Enter') {
-            // TODO åpne og lukke yteslesdetaljer herfra med redux
+            this.toggleEkspanderYtelseIFokus();
         }
+    }
+
+    toggleEkspanderYtelseIFokus() {
+        const ytelseIFokus = this.props.ytelseIFokus;
+        if (!ytelseIFokus) {
+            return;
+        }
+        const erEkspandert = this.props.ekspanderteYtelser.includes(ytelseIFokus);
+        this.props.ekspanderYtelse(ytelseIFokus, !erEkspandert);
     }
 
     render() {
@@ -70,14 +88,16 @@ class HandleUtbetalingerArrowKeys extends React.Component<Props, {}> {
 
 function mapDispatchToProps(dispatch: Dispatch<{}>): DispatchProps {
     return {
-        settYtelseIFokus: ytelse => dispatch(settNyYtelseIFokus(ytelse))
+        settYtelseIFokus: ytelse => dispatch(setNyYtelseIFokus(ytelse)),
+        ekspanderYtelse: (ytelse: Ytelse, ekspander: boolean) => dispatch(setEkspanderYtelse(ytelse, ekspander))
     };
 }
 
 function mapStateToProps(state: AppState): StateProps {
     return {
-        ytelseIFokus: state.utbetalinger.ytelseIFokus
+        ytelseIFokus: state.utbetalinger.ytelseIFokus,
+        ekspanderteYtelser: state.utbetalinger.ekspanderteYtelser
     };
 }
 
-export default connect(mapStateToProps, mapDispatchToProps)(HandleUtbetalingerArrowKeys);
+export default connect(mapStateToProps, mapDispatchToProps)(HandleUtbetalingerHotKeys);

--- a/src/app/personside/infotabs/utbetalinger/MånedsGruppe.tsx
+++ b/src/app/personside/infotabs/utbetalinger/MånedsGruppe.tsx
@@ -1,0 +1,46 @@
+import * as React from 'react';
+import styled from 'styled-components';
+import theme from '../../../../styles/personOversiktTheme';
+import { ArrayGroup } from '../../../../utils/groupArray';
+import { Normaltekst } from 'nav-frontend-typografi';
+import { Bold, Uppercase } from '../../../../components/common-styled-components';
+import { getGjeldendeDatoForUtbetaling } from './utils/utbetalingerUtils';
+import UtbetalingsKomponent from './utbetaling/Utbetaling';
+import { Utbetaling } from '../../../../models/utbetalinger';
+
+interface MånedsgruppeProps {
+    gruppe: ArrayGroup<Utbetaling>;
+}
+
+const MånedGruppeStyle = styled.li`
+  > *:first-child {
+    background-color: ${theme.color.kategori};
+    padding: .2rem ${theme.margin.px20};
+  }
+  ol {
+    padding: 0;
+    margin: 0;
+  }
+  ol > *:not(:first-child) {
+    border-top: ${theme.border.skille};
+  }
+`;
+
+function Månedsgruppe({gruppe}: MånedsgruppeProps) {
+    const utbetalingsKomponenter = gruppe.array.map(utbetaling => (
+        <UtbetalingsKomponent
+            key={getGjeldendeDatoForUtbetaling(utbetaling) + utbetaling.nettobeløp}
+            utbetaling={utbetaling}
+        />
+    ));
+    return (
+        <MånedGruppeStyle>
+            <Normaltekst tag={'h3'}><Bold><Uppercase>{gruppe.category}</Uppercase></Bold></Normaltekst>
+            <ol>
+                {utbetalingsKomponenter}
+            </ol>
+        </MånedGruppeStyle>
+    );
+}
+
+export default Månedsgruppe;

--- a/src/app/personside/infotabs/utbetalinger/MånedsGruppe.tsx
+++ b/src/app/personside/infotabs/utbetalinger/MånedsGruppe.tsx
@@ -8,11 +8,11 @@ import { getGjeldendeDatoForUtbetaling } from './utils/utbetalingerUtils';
 import UtbetalingsKomponent from './utbetaling/Utbetaling';
 import { Utbetaling } from '../../../../models/utbetalinger';
 
-interface MånedsgruppeProps {
+interface Props {
     gruppe: ArrayGroup<Utbetaling>;
 }
 
-const MånedGruppeStyle = styled.li`
+const Wrapper = styled.li`
   > *:first-child {
     background-color: ${theme.color.kategori};
     padding: .2rem ${theme.margin.px20};
@@ -26,7 +26,7 @@ const MånedGruppeStyle = styled.li`
   }
 `;
 
-function Månedsgruppe({gruppe}: MånedsgruppeProps) {
+function Månedsgruppe({gruppe}: Props) {
     const utbetalingsKomponenter = gruppe.array.map(utbetaling => (
         <UtbetalingsKomponent
             key={getGjeldendeDatoForUtbetaling(utbetaling) + utbetaling.nettobeløp}
@@ -34,12 +34,12 @@ function Månedsgruppe({gruppe}: MånedsgruppeProps) {
         />
     ));
     return (
-        <MånedGruppeStyle>
+        <Wrapper>
             <Normaltekst tag={'h3'}><Bold><Uppercase>{gruppe.category}</Uppercase></Bold></Normaltekst>
             <ol>
                 {utbetalingsKomponenter}
             </ol>
-        </MånedGruppeStyle>
+        </Wrapper>
     );
 }
 

--- a/src/app/personside/infotabs/utbetalinger/Utbetalinger.tsx
+++ b/src/app/personside/infotabs/utbetalinger/Utbetalinger.tsx
@@ -1,41 +1,21 @@
 import * as React from 'react';
-import { Utbetaling, UtbetalingerPeriode, Ytelse } from '../../../../models/utbetalinger';
+import { Utbetaling, UtbetalingerPeriode } from '../../../../models/utbetalinger';
 import styled from 'styled-components';
 import theme from '../../../../styles/personOversiktTheme';
-import { Normaltekst, Undertittel } from 'nav-frontend-typografi';
+import { Undertittel } from 'nav-frontend-typografi';
 import { FilterState } from './filter/Filter';
 import TotaltUtbetalt from './totalt utbetalt/TotaltUtbetalt';
-import { Bold, Uppercase } from '../../../../components/common-styled-components';
 import { ArrayGroup, groupArray, GroupedArray } from '../../../../utils/groupArray';
 import {
-    getGjeldendeDatoForUtbetaling,
     getTypeFromYtelse,
     månedOgÅrForUtbetaling,
     reduceUtbetlingerTilYtelser,
     utbetalingDatoComparator,
     utbetaltTilBruker
 } from './utils/utbetalingerUtils';
-import UtbetalingKomponent from './utbetaling/Utbetaling';
 import { AlertStripeInfo } from 'nav-frontend-alertstriper';
-
-export interface FokusProps {
-    ytelseIFokus: Ytelse | null;
-    updateYtelseIFokus: (ytelse: Ytelse) => void;
-}
-
-const MånedGruppeStyle = styled.li`
-  > *:first-child {
-    background-color: ${theme.color.kategori};
-    padding: .2rem ${theme.margin.px20};
-  }
-  ol {
-    padding: 0;
-    margin: 0;
-  }
-  ol > *:not(:first-child) {
-    border-top: ${theme.border.skille};
-  }
-`;
+import Månedsgruppe from './MånedsGruppe';
+import HandleUtbetalingerArrowKeys from './HandleUtbetalingerArrowKeys';
 
 const UtbetalingerArticle = styled.article`
   background-color: white;
@@ -81,30 +61,6 @@ export const UtbetalingTabellStyling = styled.div`
     }
   `;
 
-interface MånedsgruppeUniqueProps {
-    gruppe: ArrayGroup<Utbetaling>;
-}
-
-type MånedsgruppeProps = MånedsgruppeUniqueProps & FokusProps;
-
-function Månedsgruppe({gruppe, ...props}: MånedsgruppeProps) {
-    const utbetalingsKomponenter = gruppe.array.map(utbetaling => (
-        <UtbetalingKomponent
-            key={getGjeldendeDatoForUtbetaling(utbetaling) + utbetaling.nettobeløp}
-            utbetaling={utbetaling}
-            {...props}
-        />
-    ));
-    return (
-        <MånedGruppeStyle>
-            <Normaltekst tag={'h3'}><Bold><Uppercase>{gruppe.category}</Uppercase></Bold></Normaltekst>
-            <ol>
-                {utbetalingsKomponenter}
-            </ol>
-        </MånedGruppeStyle>
-    );
-}
-
 export function getFiltrerteUtbetalinger(utbetalinger: Utbetaling[], filter: FilterState) {
     return utbetalinger
         .filter(utbetaling => filtrerPaUtbetaltTilValg(utbetaling, filter))
@@ -129,24 +85,13 @@ function fjernTommeUtbetalinger(utbetaling: Utbetaling) {
     return utbetaling.ytelser && utbetaling.ytelser.length > 0;
 }
 
-function addPilknappListener(handleShortcut: (event: KeyboardEvent) => void) {
-    return () => window.addEventListener('keydown', handleShortcut);
-}
-
-function removePilknappListener(handleShortcut: (event: KeyboardEvent) => void) {
-    return () => window.removeEventListener('keydown', handleShortcut);
-}
-
-interface UtbetalingerUniqueProps {
+interface UtbetalingerProps {
     utbetalinger: Utbetaling[];
     utbetalingerPeriode: UtbetalingerPeriode;
     filter: FilterState;
-    handleShortcut: (event: KeyboardEvent) => void;
 }
 
-type UtbetalingerProps = UtbetalingerUniqueProps & FokusProps;
-
-function Utbetalinger({filter, handleShortcut, ...props}: UtbetalingerProps) {
+function Utbetalinger({filter, ...props}: UtbetalingerProps) {
     const filtrerteUtbetalinger = getFiltrerteUtbetalinger(props.utbetalinger, filter);
     if (filtrerteUtbetalinger.length === 0) {
         return (
@@ -172,15 +117,14 @@ function Utbetalinger({filter, handleShortcut, ...props}: UtbetalingerProps) {
     return (
         <Wrapper>
             <TotaltUtbetalt utbetalinger={filtrerteUtbetalinger} periode={props.utbetalingerPeriode}/>
-            <UtbetalingerArticle>
-                <Undertittel>Utbetalinger</Undertittel>
-                <UtbetalingerListe
-                    onFocus={addPilknappListener(handleShortcut)}
-                    onBlur={removePilknappListener(handleShortcut)}
-                >
-                    {månedsGrupper}
-                </UtbetalingerListe>
-            </UtbetalingerArticle>
+            <HandleUtbetalingerArrowKeys utbetalinger={filtrerteUtbetalinger}>
+                <UtbetalingerArticle>
+                    <Undertittel>Utbetalinger</Undertittel>
+                    <UtbetalingerListe>
+                        {månedsGrupper}
+                    </UtbetalingerListe>
+                </UtbetalingerArticle>
+            </HandleUtbetalingerArrowKeys>
         </Wrapper>
     );
 }

--- a/src/app/personside/infotabs/utbetalinger/Utbetalinger.tsx
+++ b/src/app/personside/infotabs/utbetalinger/Utbetalinger.tsx
@@ -15,7 +15,7 @@ import {
 } from './utils/utbetalingerUtils';
 import { AlertStripeInfo } from 'nav-frontend-alertstriper';
 import Månedsgruppe from './MånedsGruppe';
-import HandleUtbetalingerArrowKeys from './HandleUtbetalingerArrowKeys';
+import HandleUtbetalingerArrowKeys from './HandleUtbetalingerHotKeys';
 
 const UtbetalingerArticle = styled.article`
   background-color: white;
@@ -36,30 +36,6 @@ const Wrapper = styled.div`
     list-style: none;
   }
 `;
-
-export const UtbetalingTabellStyling = styled.div`
-    table {
-        width: 100%;
-        text-align: right;
-        border-spacing: 0;
-        * {
-          padding: 0;
-          margin: 0;
-        }
-        tr {
-          > * {
-            padding: 0.1rem;
-            text-align: right;
-          }
-          > *:first-child {
-            text-align: left;
-          }
-          > *:not(:first-child) {
-            width: 6rem;
-          }
-        }
-    }
-  `;
 
 export function getFiltrerteUtbetalinger(utbetalinger: Utbetaling[], filter: FilterState) {
     return utbetalinger

--- a/src/app/personside/infotabs/utbetalinger/UtbetalingerContainer.tsx
+++ b/src/app/personside/infotabs/utbetalinger/UtbetalingerContainer.tsx
@@ -3,13 +3,13 @@ import Utbetalinger from './Utbetalinger';
 import { AppState } from '../../../../redux/reducers';
 import { connect } from 'react-redux';
 import { RestReducer } from '../../../../redux/restReducers/restReducer';
-import { UtbetalingerResponse, Ytelse } from '../../../../models/utbetalinger';
+import { UtbetalingerResponse } from '../../../../models/utbetalinger';
 import Innholdslaster from '../../../../components/Innholdslaster';
 import { STATUS } from '../../../../redux/restReducers/utils';
 import { Action, Dispatch } from 'redux';
 import { hentUtbetalinger, reloadUtbetalinger } from '../../../../redux/restReducers/utbetalinger';
 import { default as Filtrering, FilterState, PeriodeValg } from './filter/Filter';
-import { flatMapYtelser, getFraDateFromFilter, getTilDateFromFilter } from './utils/utbetalingerUtils';
+import { getFraDateFromFilter, getTilDateFromFilter } from './utils/utbetalingerUtils';
 import theme from '../../../../styles/personOversiktTheme';
 import styled from 'styled-components';
 import { Undertittel } from 'nav-frontend-typografi';
@@ -20,7 +20,6 @@ import moment = require('moment');
 
 interface State {
     filter: FilterState;
-    ytelseIFokus: Ytelse | null;
 }
 
 const initialState: State = {
@@ -34,8 +33,7 @@ const initialState: State = {
         },
         utbetaltTil: [],
         ytelser: []
-    },
-    ytelseIFokus: null
+    }
 };
 
 interface StateProps {
@@ -84,8 +82,6 @@ class UtbetalingerContainer extends React.Component<Props, State> {
         this.state = {...initialState};
         this.onFilterChange = this.onFilterChange.bind(this);
         this.reloadUtbetalinger = this.reloadUtbetalinger.bind(this);
-        this.handlePilknapper = this.handlePilknapper.bind(this);
-        this.updateYtelseIFokus = this.updateYtelseIFokus.bind(this);
         loggEvent('Sidevisning', 'Utbetalinger');
     }
 
@@ -118,32 +114,6 @@ class UtbetalingerContainer extends React.Component<Props, State> {
         }
     }
 
-    updateYtelseIFokus(nyYtelse: Ytelse | null) {
-        this.setState({
-            ytelseIFokus: nyYtelse
-        });
-    }
-
-    handlePilknapper(event: KeyboardEvent) {
-        if (event.key === 'ArrowDown') {
-            this.updateYtelseIFokus(this.finnNesteYtelse());
-        } else if (event.key === 'ArrowUp') {
-            this.updateYtelseIFokus(this.finnForrigeYtelse());
-        }
-    }
-
-    finnNesteYtelse() {
-        const ytelser: Ytelse[] = flatMapYtelser(this.props.utbetalingerReducer.data.utbetalinger);
-        const currentIndex = this.state.ytelseIFokus ? ytelser.indexOf(this.state.ytelseIFokus) : -1;
-        return ytelser[currentIndex + 1] || ytelser[0];
-    }
-
-    finnForrigeYtelse() {
-        const ytelser: Ytelse[] = flatMapYtelser(this.props.utbetalingerReducer.data.utbetalinger);
-        const currentIndex = this.state.ytelseIFokus ? ytelser.indexOf(this.state.ytelseIFokus) : ytelser.length;
-        return ytelser[currentIndex - 1] || ytelser[ytelser.length - 1];
-    }
-
     render() {
         return (
             <ErrorBoundary>
@@ -165,10 +135,7 @@ class UtbetalingerContainer extends React.Component<Props, State> {
                             <Utbetalinger
                                 utbetalinger={this.props.utbetalingerReducer.data.utbetalinger}
                                 utbetalingerPeriode={this.props.utbetalingerReducer.data.periode}
-                                ytelseIFokus={this.state.ytelseIFokus}
                                 filter={this.state.filter}
-                                handleShortcut={this.handlePilknapper}
-                                updateYtelseIFokus={this.updateYtelseIFokus}
                             />
                         </Innholdslaster>
                     </UtbetalingerSection>

--- a/src/app/personside/infotabs/utbetalinger/__snapshots__/UtbetalingerContainer.test.tsx.snap
+++ b/src/app/personside/infotabs/utbetalinger/__snapshots__/UtbetalingerContainer.test.tsx.snap
@@ -171,6 +171,30 @@ exports[`Viser utbetalingercontainer med alt innhold 1`] = `
   padding: 1.25rem;
 }
 
+.c11 table {
+  width: 100%;
+  text-align: right;
+  border-spacing: 0;
+}
+
+.c11 table * {
+  padding: 0;
+  margin: 0;
+}
+
+.c11 table tr > * {
+  padding: 0.1rem;
+  text-align: right;
+}
+
+.c11 table tr > *:first-child {
+  text-align: left;
+}
+
+.c11 table tr > *:not(:first-child) {
+  width: 6rem;
+}
+
 .c10 {
   background-color: white;
   border-radius: .25rem;
@@ -199,6 +223,8 @@ exports[`Viser utbetalingercontainer med alt innhold 1`] = `
 
 .c25 {
   cursor: pointer;
+  -webkit-transition: .3s;
+  transition: .3s;
 }
 
 .c25:focus {
@@ -261,30 +287,6 @@ exports[`Viser utbetalingercontainer med alt innhold 1`] = `
 
 .c9 ol {
   list-style: none;
-}
-
-.c11 table {
-  width: 100%;
-  text-align: right;
-  border-spacing: 0;
-}
-
-.c11 table * {
-  padding: 0;
-  margin: 0;
-}
-
-.c11 table tr > * {
-  padding: 0.1rem;
-  text-align: right;
-}
-
-.c11 table tr > *:first-child {
-  text-align: left;
-}
-
-.c11 table tr > *:not(:first-child) {
-  width: 6rem;
 }
 
 .c0 {
@@ -678,175 +680,176 @@ exports[`Viser utbetalingercontainer med alt innhold 1`] = `
           </div>
         </div>
       </article>
-      <article
-        className="c20"
+      <div
+        onKeyDown={[Function]}
       >
-        <h2
-          className="typo-undertittel"
+        <article
+          className="c20"
         >
-          Utbetalinger
-        </h2>
-        <ol
-          className="c21"
-          onBlur={[Function]}
-          onFocus={[Function]}
-        >
-          <li
-            className="c22"
+          <h2
+            className="typo-undertittel"
           >
-            <h3
-              className="typo-normal"
+            Utbetalinger
+          </h2>
+          <ol
+            className="c21"
+          >
+            <li
+              className="c22"
             >
-              <span
-                className="c23"
+              <h3
+                className="typo-normal"
               >
                 <span
-                  className="c24"
+                  className="c23"
                 >
-                  Mars 2017
+                  <span
+                    className="c24"
+                  >
+                    Mars 2017
+                  </span>
                 </span>
-              </span>
-            </h3>
-            <ol>
-              <div
-                className="c11"
-              >
-                <li
-                  className="c25"
-                  onBlur={[Function]}
-                  onClick={[Function]}
-                  onFocus={[Function]}
-                  tabIndex={0}
+              </h3>
+              <ol>
+                <div
+                  className="c11"
                 >
-                  <div
-                    className="c26"
+                  <li
+                    className="c25"
+                    onClick={[Function]}
+                    onFocus={[Function]}
+                    tabIndex={0}
                   >
                     <div
-                      className="c27"
+                      className="c26"
                     >
-                      <h4
-                        className="typo-normal"
+                      <div
+                        className="c27"
                       >
-                        <span
-                          className="c23"
-                        >
-                          Sykepenger
-                        </span>
-                      </h4>
-                      <p
-                        className="typo-normal"
-                      >
-                        <span
-                          className="c23"
-                        >
-                          11,386.00
-                        </span>
-                      </p>
-                    </div>
-                    <p
-                      className="typo-normal order-first"
-                    >
-                      29. Mars 2017
-                       / 
-                      <span
-                        className="c23"
-                      >
-                        Utbetalt
-                      </span>
-                    </p>
-                    <div
-                      className="c27"
-                    >
-                      <p
-                        className="typo-normal"
-                      >
-                        09.11.2016 - 31.10.2017
-                      </p>
-                      <p
-                        className="typo-normal"
-                      >
-                        
-                      </p>
-                    </div>
-                    <div
-                      className="c27"
-                    >
-                      <p
-                        className="typo-normal"
-                      >
-                        Utbetaling til: 
-                        AREMARK TESTFAMILIEN
-                      </p>
-                      <span>
-                        <button
-                          aria-label="Skriv ut"
-                          className="c15"
-                          onClick={[Function]}
+                        <h4
+                          className="typo-normal"
                         >
                           <span
-                            className="typo-normal"
+                            className="c23"
                           >
-                            Skriv ut
+                            Sykepenger
                           </span>
-                           
-                          <svg
-                            viewBox="0 0 17 16"
-                            xmlns="http://www.w3.org/2000/svg"
-                            xmlnsXlink="http://www.w3.org/1999/xlink"
+                        </h4>
+                        <p
+                          className="typo-normal"
+                        >
+                          <span
+                            className="c23"
                           >
-                            <path
-                              d="M14.8,4.9H2.2c-0.9,0-1.7,0.7-1.7,1.7v4c0,0.9,0.7,1.7,1.7,1.7h1.7v3c0,0.2,0.1,0.3,0.3,0.3h8.7	c0.2,0,0.3-0.1,0.3-0.3v-3h1.7c0.9,0,1.7-0.7,1.7-1.7v-4C16.5,5.6,15.8,4.9,14.8,4.9z M4.5,14.9h8v-4.7h-8V14.9z"
-                              fill="#0067C5"
-                              fillRule="evenodd"
-                            />
-                            <path
-                              d="M4.9,0.9h7.1c0.6,0,1,0.4,1,1v1.4c0,0.6-0.4,1-1,1H4.9c-0.6,0-1-0.4-1-1V1.9C3.9,1.3,4.4,0.9,4.9,0.9z"
-                              fill="#0067C5"
-                            />
-                          </svg>
-                        </button>
-                      </span>
+                            11,386.00
+                          </span>
+                        </p>
+                      </div>
+                      <p
+                        className="typo-normal order-first"
+                      >
+                        29. Mars 2017
+                         / 
+                        <span
+                          className="c23"
+                        >
+                          Utbetalt
+                        </span>
+                      </p>
+                      <div
+                        className="c27"
+                      >
+                        <p
+                          className="typo-normal"
+                        >
+                          09.11.2016 - 31.10.2017
+                        </p>
+                        <p
+                          className="typo-normal"
+                        >
+                          
+                        </p>
+                      </div>
+                      <div
+                        className="c27"
+                      >
+                        <p
+                          className="typo-normal"
+                        >
+                          Utbetaling til: 
+                          AREMARK TESTFAMILIEN
+                        </p>
+                        <span>
+                          <button
+                            aria-label="Skriv ut"
+                            className="c15"
+                            onClick={[Function]}
+                          >
+                            <span
+                              className="typo-normal"
+                            >
+                              Skriv ut
+                            </span>
+                             
+                            <svg
+                              viewBox="0 0 17 16"
+                              xmlns="http://www.w3.org/2000/svg"
+                              xmlnsXlink="http://www.w3.org/1999/xlink"
+                            >
+                              <path
+                                d="M14.8,4.9H2.2c-0.9,0-1.7,0.7-1.7,1.7v4c0,0.9,0.7,1.7,1.7,1.7h1.7v3c0,0.2,0.1,0.3,0.3,0.3h8.7	c0.2,0,0.3-0.1,0.3-0.3v-3h1.7c0.9,0,1.7-0.7,1.7-1.7v-4C16.5,5.6,15.8,4.9,14.8,4.9z M4.5,14.9h8v-4.7h-8V14.9z"
+                                fill="#0067C5"
+                                fillRule="evenodd"
+                              />
+                              <path
+                                d="M4.9,0.9h7.1c0.6,0,1,0.4,1,1v1.4c0,0.6-0.4,1-1,1H4.9c-0.6,0-1-0.4-1-1V1.9C3.9,1.3,4.4,0.9,4.9,0.9z"
+                                fill="#0067C5"
+                              />
+                            </svg>
+                          </button>
+                        </span>
+                      </div>
                     </div>
-                  </div>
-                  <div
-                    className="c16"
-                    open={false}
-                  >
                     <div
-                      className="c17"
+                      className="c16"
                       open={false}
-                    />
-                    <div
-                      className="c14"
                     >
-                      <button
-                        aria-expanded={false}
-                        className="c18"
-                        onClick={[Function]}
+                      <div
+                        className="c17"
                         open={false}
+                      />
+                      <div
+                        className="c14"
                       >
-                        <span
-                          className="c19"
+                        <button
+                          aria-expanded={false}
+                          className="c18"
+                          onClick={[Function]}
+                          open={false}
                         >
                           <span
-                            className="typo-normal"
+                            className="c19"
                           >
-                            Vis
-                             detaljer
+                            <span
+                              className="typo-normal"
+                            >
+                              Vis
+                               detaljer
+                            </span>
                           </span>
-                        </span>
-                        <i
-                          className="nav-frontend-chevron chevronboks chevron--ned"
-                        />
-                      </button>
+                          <i
+                            className="nav-frontend-chevron chevronboks chevron--ned"
+                          />
+                        </button>
+                      </div>
                     </div>
-                  </div>
-                </li>
-              </div>
-            </ol>
-          </li>
-        </ol>
-      </article>
+                  </li>
+                </div>
+              </ol>
+            </li>
+          </ol>
+        </article>
+      </div>
     </div>
   </section>
 </article>

--- a/src/app/personside/infotabs/utbetalinger/totalt utbetalt/TotaltUtbetalt.tsx
+++ b/src/app/personside/infotabs/utbetalinger/totalt utbetalt/TotaltUtbetalt.tsx
@@ -15,9 +15,9 @@ import TotaltUtbetaltDetaljer from './TotaltUtbetaltDetaljer';
 import theme from '../../../../../styles/personOversiktTheme';
 import { cancelIfHighlighting } from '../../../../../utils/functionUtils';
 import { FlexEnd } from '../../../../../components/common-styled-components';
-import { UtbetalingTabellStyling } from '../Utbetalinger';
 import Printer from '../../../../../utils/Printer';
 import { loggEvent } from '../../../../../utils/frontendLogger';
+import { UtbetalingTabellStyling } from '../utils/CommonStyling';
 
 export interface TotaltUtbetaltProps {
     utbetalinger: Utbetaling[];

--- a/src/app/personside/infotabs/utbetalinger/utbetaling/DelUtbetaling.tsx
+++ b/src/app/personside/infotabs/utbetalinger/utbetaling/DelUtbetaling.tsx
@@ -25,8 +25,8 @@ interface StateProps {
 }
 
 interface DispatchProps {
-    settYtelseIFokus: (ytelse: Ytelse) => void;
-    ekspanderYtelse: (ytelse: Ytelse, ekspander: boolean) => void;
+    settYtelseIFokus: () => void;
+    ekspanderYtelse: (ekspander: boolean) => void;
 }
 
 type Props = DispatchProps & OwnProps & StateProps;
@@ -72,7 +72,7 @@ class DelUtbetaling extends React.PureComponent<Props> {
     }
 
     toggleVisDetaljer() {
-        this.props.ekspanderYtelse(this.props.ytelse, !this.props.erEkspandert);
+        this.props.ekspanderYtelse(!this.props.erEkspandert);
     }
 
     render() {
@@ -95,7 +95,7 @@ class DelUtbetaling extends React.PureComponent<Props> {
                 onClick={() => cancelIfHighlighting(this.toggleVisDetaljer)}
                 innerRef={this.ytelseRef}
                 tabIndex={0}
-                onFocus={() => this.props.settYtelseIFokus(this.props.ytelse)}
+                onFocus={this.props.settYtelseIFokus}
             >
                 <DetaljerCollapse
                     open={this.props.erEkspandert}
@@ -119,10 +119,10 @@ function mapStateToProps(state: AppState, ownProps: OwnProps): StateProps {
     };
 }
 
-function mapDispatchToProps(dispatch: Dispatch<{}>): DispatchProps {
+function mapDispatchToProps(dispatch: Dispatch<{}>, ownProps: OwnProps): DispatchProps {
     return {
-        settYtelseIFokus: ytelse => dispatch(setNyYtelseIFokus(ytelse)),
-        ekspanderYtelse: (ytelse: Ytelse, ekspander: boolean) => dispatch(setEkspanderYtelse(ytelse, ekspander))
+        settYtelseIFokus: () => dispatch(setNyYtelseIFokus(ownProps.ytelse)),
+        ekspanderYtelse: (ekspander: boolean) => dispatch(setEkspanderYtelse(ownProps.ytelse, ekspander))
     };
 }
 

--- a/src/app/personside/infotabs/utbetalinger/utbetaling/DelUtbetaling.tsx
+++ b/src/app/personside/infotabs/utbetalinger/utbetaling/DelUtbetaling.tsx
@@ -8,16 +8,28 @@ import theme from '../../../../../styles/personOversiktTheme';
 import { cancelIfHighlighting } from '../../../../../utils/functionUtils';
 import { Normaltekst } from 'nav-frontend-typografi';
 import DetaljerCollapse from '../DetaljerCollapse';
+import { Dispatch } from 'redux';
+import { setEkspanderYtelse, setNyYtelseIFokus } from '../../../../../redux/utbetalinger/utbetalingerStateReducer';
+import { connect } from 'react-redux';
+import { AppState } from '../../../../../redux/reducers';
 
-export interface Props {
+export interface OwnProps {
     ytelse: Ytelse;
     konto: string | undefined;
     melding: string | undefined;
-    toggleVisDetaljer: (ytelse: Ytelse) => void;
-    visDetaljer: boolean;
-    erIFokus: boolean;
-    updateYtelseIFokus: (ytelse: Ytelse) => void;
 }
+
+interface StateProps {
+    erEkspandert: boolean;
+    erIFokus: boolean;
+}
+
+interface DispatchProps {
+    settYtelseIFokus: (ytelse: Ytelse) => void;
+    ekspanderYtelse: (ytelse: Ytelse, ekspander: boolean) => void;
+}
+
+type Props = DispatchProps & OwnProps & StateProps;
 
 const DelUtbetalingStyle = styled.li`
   transition: 0.3s;
@@ -49,45 +61,25 @@ class DelUtbetaling extends React.PureComponent<Props> {
 
     constructor(props: Props) {
         super(props);
-        this.handleEnter = this.handleEnter.bind(this);
-        this.setTilYtelseIFokus = this.setTilYtelseIFokus.bind(this);
-        this.removeEnterListener = this.removeEnterListener.bind(this);
-    }
-
-    handleEnter(event: KeyboardEvent) {
-        if (event.key === 'Enter' && !event.repeat) {
-            this.props.toggleVisDetaljer(this.props.ytelse);
-        }
+        this.toggleVisDetaljer = this.toggleVisDetaljer.bind(this);
     }
 
     componentDidUpdate(prevProps: Props) {
         const fikkFokus = this.props.erIFokus && !prevProps.erIFokus;
-        const mistetFokus = !this.props.erIFokus && prevProps.erIFokus;
         if (fikkFokus && this.ytelseRef.current) {
             this.ytelseRef.current.focus();
-            this.addEnterListener();
-        } else if (mistetFokus) {
-            this.removeEnterListener();
         }
     }
 
-    removeEnterListener() {
-        window.removeEventListener('keydown', this.handleEnter);
-    }
-
-    addEnterListener() {
-        window.addEventListener('keydown', this.handleEnter);
-    }
-
-    setTilYtelseIFokus() {
-        this.props.updateYtelseIFokus(this.props.ytelse);
+    toggleVisDetaljer() {
+        this.props.ekspanderYtelse(this.props.ytelse, !this.props.erEkspandert);
     }
 
     render() {
         const ytelse = this.props.ytelse;
         const periode = periodeStringFromYtelse(ytelse);
         const header = (
-            <BulletPoint show={!this.props.visDetaljer}>
+            <BulletPoint show={!this.props.erEkspandert}>
                 <SpaceBetween>
                     <Normaltekst><Bold>{ytelse.type}</Bold></Normaltekst>
                     <Normaltekst><Bold>{formaterNOK(ytelse.nettobeløp)}</Bold></Normaltekst>
@@ -100,15 +92,14 @@ class DelUtbetaling extends React.PureComponent<Props> {
 
         return (
             <DelUtbetalingStyle
-                onClick={() => cancelIfHighlighting(() => this.props.toggleVisDetaljer(this.props.ytelse))}
+                onClick={() => cancelIfHighlighting(this.toggleVisDetaljer)}
                 innerRef={this.ytelseRef}
                 tabIndex={0}
-                onFocus={this.setTilYtelseIFokus}
-                onBlur={this.removeEnterListener}
+                onFocus={() => this.props.settYtelseIFokus(this.props.ytelse)}
             >
                 <DetaljerCollapse
-                    open={this.props.visDetaljer}
-                    toggle={() => this.props.toggleVisDetaljer(this.props.ytelse)}
+                    open={this.props.erEkspandert}
+                    toggle={this.toggleVisDetaljer}
                     header={header}
                 >
                     <UtbetalingsDetaljer
@@ -121,4 +112,18 @@ class DelUtbetaling extends React.PureComponent<Props> {
     }
 }
 
-export default DelUtbetaling;
+function mapStateToProps(state: AppState, ownProps: OwnProps): StateProps {
+    return {
+        erEkspandert: state.utbetalinger.ekspanderteYtelser.includes(ownProps.ytelse),
+        erIFokus: state.utbetalinger.ytelseIFokus === ownProps.ytelse
+    };
+}
+
+function mapDispatchToProps(dispatch: Dispatch<{}>): DispatchProps {
+    return {
+        settYtelseIFokus: ytelse => dispatch(setNyYtelseIFokus(ytelse)),
+        ekspanderYtelse: (ytelse: Ytelse, ekspander: boolean) => dispatch(setEkspanderYtelse(ytelse, ekspander))
+    };
+}
+
+export default connect(mapStateToProps, mapDispatchToProps)(DelUtbetaling);

--- a/src/app/personside/infotabs/utbetalinger/utbetaling/DelUtbetaling.tsx
+++ b/src/app/personside/infotabs/utbetalinger/utbetaling/DelUtbetaling.tsx
@@ -55,7 +55,7 @@ class DelUtbetaling extends React.PureComponent<Props> {
     }
 
     handleEnter(event: KeyboardEvent) {
-        if (event.key === 'Enter') {
+        if (event.key === 'Enter' && !event.repeat) {
             this.props.toggleVisDetaljer(this.props.ytelse);
         }
     }

--- a/src/app/personside/infotabs/utbetalinger/utbetaling/EnkelUtbetaling.tsx
+++ b/src/app/personside/infotabs/utbetalinger/utbetaling/EnkelUtbetaling.tsx
@@ -28,8 +28,8 @@ interface OwnProps {
 }
 
 interface DispatchProps {
-    setYtelseIFokus: (ytelse: Ytelse) => void;
-    setEkspanderYtelse: (ytelse: Ytelse, ekspander: boolean) => void;
+    setYtelseIFokus: () => void;
+    setEkspanderYtelse: (ekspander: boolean) => void;
 }
 
 interface StateProps {
@@ -84,12 +84,12 @@ class EnkelUtbetaling extends React.PureComponent<Props> {
     }
 
     toggleVisDetaljer() {
-        this.props.setEkspanderYtelse(this.props.ytelse, !this.props.visDetaljer);
+        this.props.setEkspanderYtelse(!this.props.visDetaljer);
     }
 
     handlePrint() {
         loggEvent('EnkeltUtbetaling', 'Printer');
-        this.props.setEkspanderYtelse(this.props.ytelse, true);
+        this.props.setEkspanderYtelse(true);
         this.print();
     }
 
@@ -124,7 +124,7 @@ class EnkelUtbetaling extends React.PureComponent<Props> {
                             cancelIfHighlighting(() => this.handleClickOnUtbetaling(event))}
                         innerRef={this.utbetalingRef}
                         tabIndex={0}
-                        onFocus={() => this.props.setYtelseIFokus(ytelse)}
+                        onFocus={this.props.setYtelseIFokus}
                     >
                         <UtbetalingHeaderStyle>
                             <SpaceBetween>
@@ -162,10 +162,10 @@ class EnkelUtbetaling extends React.PureComponent<Props> {
     }
 }
 
-function mapDispatchToProps(dispatch: Dispatch<{}>): DispatchProps {
+function mapDispatchToProps(dispatch: Dispatch<{}>, ownProps: OwnProps): DispatchProps {
     return {
-        setYtelseIFokus: ytelse => dispatch(setNyYtelseIFokus(ytelse)),
-        setEkspanderYtelse: (ytelse: Ytelse, ekspander: boolean) => dispatch(setEkspanderYtelse(ytelse, ekspander))
+        setYtelseIFokus: () => dispatch(setNyYtelseIFokus(ownProps.ytelse)),
+        setEkspanderYtelse: (ekspander: boolean) => dispatch(setEkspanderYtelse(ownProps.ytelse, ekspander))
     };
 }
 

--- a/src/app/personside/infotabs/utbetalinger/utbetaling/EnkelUtbetaling.tsx
+++ b/src/app/personside/infotabs/utbetalinger/utbetaling/EnkelUtbetaling.tsx
@@ -100,16 +100,14 @@ class EnkelUtbetaling extends React.Component<Props, State> {
         if (this.buttonWrapperRef.current) {
             const knappTrykket = (event.target instanceof Node)
                 && this.buttonWrapperRef.current.contains(event.target);
-
             if (!knappTrykket) {
                 this.toggleVisDetaljer();
             }
-
         }
     }
 
     handleEnter(event: KeyboardEvent) {
-        if (event.key === 'Enter') {
+        if (event.key === 'Enter' && !event.repeat) {
             this.toggleVisDetaljer();
         }
     }

--- a/src/app/personside/infotabs/utbetalinger/utbetaling/EnkelUtbetaling.tsx
+++ b/src/app/personside/infotabs/utbetalinger/utbetaling/EnkelUtbetaling.tsx
@@ -54,7 +54,7 @@ const UtbetalingHeaderStyle = styled.div`
 
 class EnkelUtbetaling extends React.Component<Props, State> {
 
-    private buttonWrapperRef = React.createRef<HTMLElement>();
+    private printButtonWrapperRef = React.createRef<HTMLElement>();
     private utbetalingRef = React.createRef<HTMLDivElement>();
     private print: () => void;
 
@@ -63,11 +63,9 @@ class EnkelUtbetaling extends React.Component<Props, State> {
         this.state = {
             visDetaljer: false
         };
-        this.toggleVisDetaljer = this.toggleVisDetaljer.bind(this);
+        this.setVisDetaljer = this.setVisDetaljer.bind(this);
         this.handlePrint = this.handlePrint.bind(this);
-        this.handleEnter = this.handleEnter.bind(this);
-        this.setTilYtelseIFokus = this.setTilYtelseIFokus.bind(this);
-        this.removeEnterListener = this.removeEnterListener.bind(this);
+        this.handleKeyPress = this.handleKeyPress.bind(this);
     }
 
     shouldComponentUpdate(prevProps: Props, prevState: State) {
@@ -80,9 +78,9 @@ class EnkelUtbetaling extends React.Component<Props, State> {
         return false;
     }
 
-    toggleVisDetaljer() {
+    setVisDetaljer(vis: boolean) {
         this.setState({
-            visDetaljer: !this.state.visDetaljer
+            visDetaljer: vis
         });
     }
 
@@ -97,42 +95,20 @@ class EnkelUtbetaling extends React.Component<Props, State> {
     }
 
     handleClickOnUtbetaling(event: React.MouseEvent<HTMLElement>) {
-        if (this.buttonWrapperRef.current) {
-            const knappTrykket = (event.target instanceof Node)
-                && this.buttonWrapperRef.current.contains(event.target);
-            if (!knappTrykket) {
-                this.toggleVisDetaljer();
-            }
+        if (!this.printButtonWrapperRef.current) {
+            return;
+        }
+        const printKnappTrykket = (event.target instanceof Node)
+            && this.printButtonWrapperRef.current.contains(event.target);
+        if (!printKnappTrykket) {
+            this.setVisDetaljer(!this.state.visDetaljer);
         }
     }
 
-    handleEnter(event: KeyboardEvent) {
+    handleKeyPress(event: React.KeyboardEvent) {
         if (event.key === 'Enter' && !event.repeat) {
-            this.toggleVisDetaljer();
+            this.setVisDetaljer(!this.state.visDetaljer);
         }
-    }
-
-    componentDidUpdate(prevProps: Props) {
-        const fikkFokus = this.props.erIFokus && !prevProps.erIFokus;
-        const mistetFokus = !this.props.erIFokus && prevProps.erIFokus;
-        if (fikkFokus && this.utbetalingRef.current) {
-            this.utbetalingRef.current.focus();
-            this.addEnterListener();
-        } else if (mistetFokus) {
-            this.removeEnterListener();
-        }
-    }
-
-    removeEnterListener() {
-        window.removeEventListener('keydown', this.handleEnter);
-    }
-
-    addEnterListener() {
-        window.addEventListener('keydown', this.handleEnter);
-    }
-
-    setTilYtelseIFokus(ytelse: Ytelse) {
-        this.props.updateYtelseIFokus(ytelse);
     }
 
     render() {
@@ -156,10 +132,10 @@ class EnkelUtbetaling extends React.Component<Props, State> {
                     <UtbetalingStyle
                         onClick={(event: React.MouseEvent<HTMLElement>) =>
                             cancelIfHighlighting(() => this.handleClickOnUtbetaling(event))}
+                        onKeyPress={this.handleKeyPress}
                         innerRef={this.utbetalingRef}
                         tabIndex={0}
-                        onFocus={() => this.setTilYtelseIFokus(ytelse)}
-                        onBlur={this.removeEnterListener}
+                        onFocus={() => this.props.updateYtelseIFokus(ytelse)}
                     >
                         <UtbetalingHeaderStyle>
                             <SpaceBetween>
@@ -175,14 +151,14 @@ class EnkelUtbetaling extends React.Component<Props, State> {
                             </SpaceBetween>
                             <SpaceBetween>
                                 <Normaltekst>Utbetaling til: {utbetaling.utbetaltTil}</Normaltekst>
-                                <span ref={this.buttonWrapperRef}>
+                                <span ref={this.printButtonWrapperRef}>
                                     <PrintKnapp onClick={this.handlePrint}/>
                                 </span>
                             </SpaceBetween>
                         </UtbetalingHeaderStyle>
                         <DetaljerCollapse
                             open={this.state.visDetaljer}
-                            toggle={this.toggleVisDetaljer}
+                            toggle={() => this.setVisDetaljer(!this.state.visDetaljer)}
                         >
                             <UtbetalingsDetaljer
                                 ytelse={ytelse}

--- a/src/app/personside/infotabs/utbetalinger/utbetaling/EnkelUtbetaling.tsx
+++ b/src/app/personside/infotabs/utbetalinger/utbetaling/EnkelUtbetaling.tsx
@@ -52,7 +52,7 @@ const UtbetalingHeaderStyle = styled.div`
   }
 `;
 
-class EnkelUtbetaling extends React.Component<Props, State> {
+class EnkelUtbetaling extends React.PureComponent<Props, State> {
 
     private printButtonWrapperRef = React.createRef<HTMLElement>();
     private utbetalingRef = React.createRef<HTMLDivElement>();
@@ -68,14 +68,11 @@ class EnkelUtbetaling extends React.Component<Props, State> {
         this.handleKeyPress = this.handleKeyPress.bind(this);
     }
 
-    shouldComponentUpdate(prevProps: Props, prevState: State) {
-        if (
-            prevProps.erIFokus !== this.props.erIFokus ||
-            prevState !== this.state ||
-            JSON.stringify(prevProps.utbetaling) !== JSON.stringify(this.props.utbetaling)) {
-            return true;
+    componentDidUpdate(prevProps: Props) {
+        const fikkFokus = this.props.erIFokus && !prevProps.erIFokus;
+        if (fikkFokus && this.utbetalingRef.current) {
+            this.utbetalingRef.current.focus();
         }
-        return false;
     }
 
     setVisDetaljer(vis: boolean) {

--- a/src/app/personside/infotabs/utbetalinger/utbetaling/SammensattUtbetaling.tsx
+++ b/src/app/personside/infotabs/utbetalinger/utbetaling/SammensattUtbetaling.tsx
@@ -11,20 +11,23 @@ import PrintKnapp from '../../../../../components/PrintKnapp';
 import { Normaltekst } from 'nav-frontend-typografi';
 import { Utbetaling, Ytelse } from '../../../../../models/utbetalinger';
 import theme from '../../../../../styles/personOversiktTheme';
-import { UtbetalingTabellStyling } from '../Utbetalinger';
 import DelUtbetaling from './DelUtbetaling';
 import Printer from '../../../../../utils/Printer';
 import { loggEvent } from '../../../../../utils/frontendLogger';
+import { connect } from 'react-redux';
+import { setEkspanderYtelse } from '../../../../../redux/utbetalinger/utbetalingerStateReducer';
+import { UtbetalingTabellStyling } from '../utils/CommonStyling';
+import { Dispatch } from 'redux';
 
-interface Props {
+interface OwnProps {
     utbetaling: Utbetaling;
-    ytelseIFokus: Ytelse | null;
-    updateYtelseIFokus: (ytelse: Ytelse) => void;
 }
 
-interface State {
-    åpnedeYtelser: Ytelse[];
+interface DispatchProps {
+    ekspanderYtelse: (ytelse: Ytelse) => void;
 }
+
+type Props = DispatchProps & OwnProps;
 
 const SammensattUtbetalingStyle = styled.li`
   padding: ${theme.margin.px20};
@@ -53,41 +56,24 @@ const YtelsesListe = styled.ul`
   }
 `;
 
-class SammensattUtbetaling extends React.PureComponent<Props, State> {
+class SammensattUtbetaling extends React.PureComponent<Props> {
 
     private print: () => void;
 
     constructor(props: Props) {
         super(props);
-
-        this.state = {
-            åpnedeYtelser: []
-        };
-
-        this.toggleVisDetaljer = this.toggleVisDetaljer.bind(this);
         this.visDetaljerAndPrint = this.visDetaljerAndPrint.bind(this);
     }
 
     visDetaljerAndPrint() {
-        loggEvent('SammensattUtbetaling', 'Printer');
-        this.setState(
-            {
-                åpnedeYtelser: this.props.utbetaling.ytelser != null ? [ ...this.props.utbetaling.ytelser ] : []
-            },
-            this.print
-        );
-    }
+        const ytelser = this.props.utbetaling.ytelser;
 
-    toggleVisDetaljer(ytelse: Ytelse) {
-        if (this.state.åpnedeYtelser.includes(ytelse)) {
-            this.setState({
-                åpnedeYtelser: this.state.åpnedeYtelser.filter((y: Ytelse) => ytelse !== y)
-            });
-        } else {
-            this.setState({
-                åpnedeYtelser: [ ...this.state.åpnedeYtelser, ytelse ]
-            });
+        if (!ytelser) {
+            return;
         }
+        ytelser.forEach(ytelse => this.props.ekspanderYtelse(ytelse));
+        this.print();
+        loggEvent('SammensattUtbetaling', 'Printer');
     }
 
     render() {
@@ -107,10 +93,6 @@ class SammensattUtbetaling extends React.PureComponent<Props, State> {
                 konto={utbetaling.konto}
                 melding={utbetaling.melding}
                 key={index}
-                toggleVisDetaljer={this.toggleVisDetaljer}
-                visDetaljer={this.state.åpnedeYtelser.includes(ytelse)}
-                erIFokus={this.props.ytelseIFokus === ytelse}
-                updateYtelseIFokus={this.props.updateYtelseIFokus}
             />
         ));
 
@@ -142,4 +124,11 @@ class SammensattUtbetaling extends React.PureComponent<Props, State> {
     }
 }
 
-export default SammensattUtbetaling;
+export default connect(
+    null,
+    (dispatch: Dispatch<{}>): DispatchProps => {
+        return {
+            ekspanderYtelse: ytelse => dispatch(setEkspanderYtelse(ytelse, true))
+        };
+    }
+)(SammensattUtbetaling);

--- a/src/app/personside/infotabs/utbetalinger/utbetaling/SammensattUtbetaling.tsx
+++ b/src/app/personside/infotabs/utbetalinger/utbetaling/SammensattUtbetaling.tsx
@@ -11,16 +11,16 @@ import PrintKnapp from '../../../../../components/PrintKnapp';
 import { Normaltekst } from 'nav-frontend-typografi';
 import { Utbetaling, Ytelse } from '../../../../../models/utbetalinger';
 import theme from '../../../../../styles/personOversiktTheme';
-import { FokusProps, UtbetalingTabellStyling } from '../Utbetalinger';
+import { UtbetalingTabellStyling } from '../Utbetalinger';
 import DelUtbetaling from './DelUtbetaling';
 import Printer from '../../../../../utils/Printer';
 import { loggEvent } from '../../../../../utils/frontendLogger';
 
-interface OwnProps {
+interface Props {
     utbetaling: Utbetaling;
+    ytelseIFokus: Ytelse | null;
+    updateYtelseIFokus: (ytelse: Ytelse) => void;
 }
-
-type Props = OwnProps & FokusProps;
 
 interface State {
     åpnedeYtelser: Ytelse[];

--- a/src/app/personside/infotabs/utbetalinger/utbetaling/Utbetaling.tsx
+++ b/src/app/personside/infotabs/utbetalinger/utbetaling/Utbetaling.tsx
@@ -1,27 +1,13 @@
 import * as React from 'react';
-import { Utbetaling as UtbetalingInterface, Ytelse } from '../../../../../models/utbetalinger';
+import { Utbetaling as UtbetalingInterface } from '../../../../../models/utbetalinger';
 import { AlertStripeInfo } from 'nav-frontend-alertstriper';
 import SammensattUtbetaling from './SammensattUtbetaling';
 
 import EnkelUtbetaling from './EnkelUtbetaling';
-import { Dispatch } from 'redux';
-import { settNyYtelseIFokus } from '../../../../../redux/utbetalinger/utbetalingerStateReducer';
-import { AppState } from '../../../../../redux/reducers';
-import { connect } from 'react-redux';
 
-interface OwnProps {
+interface Props {
     utbetaling: UtbetalingInterface;
 }
-
-interface DispatchProps {
-    settYtelseIFokus: (ytelse: Ytelse) => void;
-}
-
-interface StateProps {
-    ytelseIFokus: Ytelse | null;
-}
-
-type Props = OwnProps & StateProps & DispatchProps;
 
 function Utbetaling(props: Props) {
     const utbetaling = props.utbetaling;
@@ -32,32 +18,20 @@ function Utbetaling(props: Props) {
 
     const enkeltYtelse = utbetaling.ytelser.length === 1;
 
-    return enkeltYtelse
-        ? (
+    if (enkeltYtelse) {
+        const ytelse = utbetaling.ytelser[0];
+        return (
             <EnkelUtbetaling
                 utbetaling={utbetaling}
-                updateYtelseIFokus={props.settYtelseIFokus}
-                erIFokus={props.ytelseIFokus === utbetaling.ytelser[0]}
-            />)
-        : (
+                ytelse={ytelse}
+            />);
+    } else {
+        return (
             <SammensattUtbetaling
-                updateYtelseIFokus={props.settYtelseIFokus}
                 utbetaling={utbetaling}
-                ytelseIFokus={props.ytelseIFokus}
             />
         );
+    }
 }
 
-function mapDispatchToProps(dispatch: Dispatch<{}>): DispatchProps {
-    return {
-        settYtelseIFokus: ytelse => dispatch(settNyYtelseIFokus(ytelse))
-    };
-}
-
-function mapStateToProps(state: AppState): StateProps {
-    return {
-        ytelseIFokus: state.utbetalinger.ytelseIFokus
-    };
-}
-
-export default connect(mapStateToProps, mapDispatchToProps)(Utbetaling);
+export default Utbetaling;

--- a/src/app/personside/infotabs/utbetalinger/utbetaling/Utbetaling.tsx
+++ b/src/app/personside/infotabs/utbetalinger/utbetaling/Utbetaling.tsx
@@ -1,16 +1,27 @@
 import * as React from 'react';
-import { Utbetaling as UtbetalingInterface } from '../../../../../models/utbetalinger';
+import { Utbetaling as UtbetalingInterface, Ytelse } from '../../../../../models/utbetalinger';
 import { AlertStripeInfo } from 'nav-frontend-alertstriper';
 import SammensattUtbetaling from './SammensattUtbetaling';
 
 import EnkelUtbetaling from './EnkelUtbetaling';
-import { FokusProps } from '../Utbetalinger';
+import { Dispatch } from 'redux';
+import { settNyYtelseIFokus } from '../../../../../redux/utbetalinger/utbetalingerStateReducer';
+import { AppState } from '../../../../../redux/reducers';
+import { connect } from 'react-redux';
 
 interface OwnProps {
     utbetaling: UtbetalingInterface;
 }
 
-type Props = OwnProps & FokusProps;
+interface DispatchProps {
+    settYtelseIFokus: (ytelse: Ytelse) => void;
+}
+
+interface StateProps {
+    ytelseIFokus: Ytelse | null;
+}
+
+type Props = OwnProps & StateProps & DispatchProps;
 
 function Utbetaling(props: Props) {
     const utbetaling = props.utbetaling;
@@ -25,10 +36,28 @@ function Utbetaling(props: Props) {
         ? (
             <EnkelUtbetaling
                 utbetaling={utbetaling}
-                updateYtelseIFokus={props.updateYtelseIFokus}
+                updateYtelseIFokus={props.settYtelseIFokus}
                 erIFokus={props.ytelseIFokus === utbetaling.ytelser[0]}
             />)
-        : <SammensattUtbetaling {...props}/>;
+        : (
+            <SammensattUtbetaling
+                updateYtelseIFokus={props.settYtelseIFokus}
+                utbetaling={utbetaling}
+                ytelseIFokus={props.ytelseIFokus}
+            />
+        );
 }
 
-export default Utbetaling;
+function mapDispatchToProps(dispatch: Dispatch<{}>): DispatchProps {
+    return {
+        settYtelseIFokus: ytelse => dispatch(settNyYtelseIFokus(ytelse))
+    };
+}
+
+function mapStateToProps(state: AppState): StateProps {
+    return {
+        ytelseIFokus: state.utbetalinger.ytelseIFokus
+    };
+}
+
+export default connect(mapStateToProps, mapDispatchToProps)(Utbetaling);

--- a/src/app/personside/infotabs/utbetalinger/utils/CommonStyling.tsx
+++ b/src/app/personside/infotabs/utbetalinger/utils/CommonStyling.tsx
@@ -1,0 +1,25 @@
+import styled from 'styled-components';
+
+export const UtbetalingTabellStyling = styled.div`
+    table {
+        width: 100%;
+        text-align: right;
+        border-spacing: 0;
+        * {
+          padding: 0;
+          margin: 0;
+        }
+        tr {
+          > * {
+            padding: 0.1rem;
+            text-align: right;
+          }
+          > *:first-child {
+            text-align: left;
+          }
+          > *:not(:first-child) {
+            width: 6rem;
+          }
+        }
+    }
+`;

--- a/src/redux/reducers.ts
+++ b/src/redux/reducers.ts
@@ -2,15 +2,18 @@ import { combineReducers } from 'redux';
 import RestEndepunkterReducers, { RestEndepunkter } from './restReducers/restReducers';
 import UiReducer, { UIState } from './uiReducers/UIReducer';
 import temagruppeReducer from './temagruppe';
+import { UtbetalingerReducerState, utbetalingerStateReducer } from './utbetalinger/utbetalingerStateReducer';
 
 export interface AppState {
     restEndepunkter: RestEndepunkter;
     ui: UIState;
     valgtTemagruppe: string;
+    utbetalinger: UtbetalingerReducerState;
 }
 
 export default combineReducers<AppState>({
     restEndepunkter: RestEndepunkterReducers,
     ui: UiReducer,
     valgtTemagruppe: temagruppeReducer,
+    utbetalinger: utbetalingerStateReducer
 });

--- a/src/redux/utbetalinger/utbetalingerStateReducer.ts
+++ b/src/redux/utbetalinger/utbetalingerStateReducer.ts
@@ -2,29 +2,46 @@ import { Ytelse } from '../../models/utbetalinger';
 
 export interface UtbetalingerReducerState {
     ytelseIFokus: Ytelse | null;
+    ekspanderteYtelser: Ytelse[];
 }
 
 const initialState: UtbetalingerReducerState = {
-    ytelseIFokus: null
+    ytelseIFokus: null,
+    ekspanderteYtelser: []
 };
 
 enum actionKeys {
-    SettYtelseIFokus = 'SettYtelseIFokus'
+    SettYtelseIFokus = 'SettYtelseIFokus',
+    SetEkspanderYtelse = 'SetEkspanderYtelse'
 }
 
-interface SettNyYtelseIFokus {
+interface SetNyYtelseIFokus {
     type: actionKeys.SettYtelseIFokus;
     ytelse: Ytelse | null;
 }
 
-export function settNyYtelseIFokus(ytelse: Ytelse): SettNyYtelseIFokus {
+interface SetEkspanderYtelse {
+    type: actionKeys.SetEkspanderYtelse;
+    ekspander: boolean;
+    ytelse: Ytelse;
+}
+
+export function setNyYtelseIFokus(ytelse: Ytelse): SetNyYtelseIFokus {
     return {
         type: actionKeys.SettYtelseIFokus,
         ytelse: ytelse
     };
 }
 
-export type Actions = SettNyYtelseIFokus;
+export function setEkspanderYtelse(ytelse: Ytelse, ekspander: boolean): SetEkspanderYtelse {
+    return {
+        type: actionKeys.SetEkspanderYtelse,
+        ekspander: ekspander,
+        ytelse: ytelse
+    };
+}
+
+export type Actions = SetNyYtelseIFokus | SetEkspanderYtelse;
 
 export function utbetalingerStateReducer(state: UtbetalingerReducerState = initialState, action: Actions)
     : UtbetalingerReducerState {
@@ -34,6 +51,18 @@ export function utbetalingerStateReducer(state: UtbetalingerReducerState = initi
                 ...state,
                 ytelseIFokus: action.ytelse
             };
+        case actionKeys.SetEkspanderYtelse:
+            if (action.ekspander) {
+                return {
+                    ...state,
+                    ekspanderteYtelser: [...state.ekspanderteYtelser, action.ytelse]
+                };
+            } else {
+                return {
+                    ...state,
+                    ekspanderteYtelser: state.ekspanderteYtelser.filter(y => y !== action.ytelse)
+                };
+            }
         default:
             return state;
     }

--- a/src/redux/utbetalinger/utbetalingerStateReducer.ts
+++ b/src/redux/utbetalinger/utbetalingerStateReducer.ts
@@ -1,0 +1,40 @@
+import { Ytelse } from '../../models/utbetalinger';
+
+export interface UtbetalingerReducerState {
+    ytelseIFokus: Ytelse | null;
+}
+
+const initialState: UtbetalingerReducerState = {
+    ytelseIFokus: null
+};
+
+enum actionKeys {
+    SettYtelseIFokus = 'SettYtelseIFokus'
+}
+
+interface SettNyYtelseIFokus {
+    type: actionKeys.SettYtelseIFokus;
+    ytelse: Ytelse | null;
+}
+
+export function settNyYtelseIFokus(ytelse: Ytelse): SettNyYtelseIFokus {
+    return {
+        type: actionKeys.SettYtelseIFokus,
+        ytelse: ytelse
+    };
+}
+
+export type Actions = SettNyYtelseIFokus;
+
+export function utbetalingerStateReducer(state: UtbetalingerReducerState = initialState, action: Actions)
+    : UtbetalingerReducerState {
+    switch (action.type) {
+        case actionKeys.SettYtelseIFokus:
+            return {
+                ...state,
+                ytelseIFokus: action.ytelse
+            };
+        default:
+            return state;
+    }
+}


### PR DESCRIPTION
Prøver å fikse rapportert heng og treghet i nye utbetalinger ved å ta i bruk redux og PureComponent for å sørge for færre re-renders. Dette ga ganske stor ytelsesforbedring.