### PR TITLE
fikser heroku url slik at man kommer rett inn i appen når man trykker "View Deployment"

### DIFF
--- a/nginx.conf
+++ b/nginx.conf
@@ -15,6 +15,13 @@ server {
         add_header Content-Type text/plain;
    }
 
+   location = / {
+      port_in_redirect off;
+      if ($host ~ .*herokuapp.*) {
+            return 301 https://$host/modiapersonoversikt/;
+      }
+   }
+
    location /modiapersonoversikt/ {
         if (!-e $request_filename) {
              rewrite ^(.*)$ /modiapersonoversikt/ break;


### PR DESCRIPTION
da slipper man å skrive `/modiapersonoversikt/` manuelt i adressefeltet