### PR TITLE
Pleiepenger fixes

### DIFF
--- a/src/app/personside/infotabs/TabKnapper.tsx
+++ b/src/app/personside/infotabs/TabKnapper.tsx
@@ -55,7 +55,7 @@ function TabKnapper(props: TabPanelProps) {
     const knapper = Object.keys(INFOTABS).map(key => {
         const erValgt = INFOTABS[key] === props.openTab;
         return (
-            <KnappWrapper key={key} role="tablist">
+            <KnappWrapper key={key}>
                 <TabKnapp role="tab" aria-selected={erValgt} valgt={erValgt} onClick={() => props.onTabChange(key)}>
                     {INFOTABS[key]}
                 </TabKnapp>
@@ -64,7 +64,7 @@ function TabKnapper(props: TabPanelProps) {
     });
 
     return (
-        <TabKnapperNav aria-label="Tabpanel">
+        <TabKnapperNav role="tablist" aria-label="Tabpanel">
             {knapper}
         </TabKnapperNav>
     );

--- a/src/app/personside/infotabs/ytelser/YtelserContainer.tsx
+++ b/src/app/personside/infotabs/ytelser/YtelserContainer.tsx
@@ -3,12 +3,16 @@ import ForeldrePengerContainer from './foreldrepenger/ForeldrePengerContainer';
 import styled from 'styled-components';
 import PleiePengerContainer from './pleiepenger/PleiePengerContainer';
 import SykePengerContainer from './sykepenger/SykePengerContainer';
+import { pxToRem } from '../../../../styles/personOversiktTheme';
 
 interface Props {
     fødselsnummer: string;
 }
 
 const Styling = styled.section`
+  max-width: ${pxToRem(900)};
+  width: 100%;
+  align-self: center;
   > * {
     margin-bottom: .5rem;
   }

--- a/src/app/personside/infotabs/ytelser/pleiepenger/Oversikt.tsx
+++ b/src/app/personside/infotabs/ytelser/pleiepenger/Oversikt.tsx
@@ -67,6 +67,19 @@ function Oversikt({pleiepenger, visAlleArbeidsforhold, toggleVisAlleArbeidsforho
         'Annen forelder': pleiepenger.andreOmsorgsperson
     };
 
+    const tidligereArbeidsforholdCollapse = tidligereArbeidsforhold.length > 0 && (
+        <DetaljerCollapse
+            open={visAlleArbeidsforhold}
+            toggle={toggleVisAlleArbeidsforhold}
+            tittel="alle arbeidsforhold"
+        >
+            <ArbeidsForholdListeStyle aria-label="Andre arbeidsforhold">
+                {tidligereArbeidsforhold.map((arbForhold, index) =>
+                    <li key={index}><ArbeidsForhold arbeidsforhold={arbForhold}/></li>)}
+            </ArbeidsForholdListeStyle>
+        </DetaljerCollapse>
+    );
+
     return (
         <OversiktStyling>
             <YtelserInfoGruppe tittel="Om pleiepengeretten">
@@ -74,16 +87,7 @@ function Oversikt({pleiepenger, visAlleArbeidsforhold, toggleVisAlleArbeidsforho
             </YtelserInfoGruppe>
             <YtelserInfoGruppe tittel="Arbeidssituasjon">
                 <ArbeidsForhold arbeidsforhold={gjeldendeArbeidsforhold}/>
-                <DetaljerCollapse
-                    open={visAlleArbeidsforhold}
-                    toggle={toggleVisAlleArbeidsforhold}
-                    tittel="alle arbeidsforhold"
-                >
-                    <ArbeidsForholdListeStyle aria-label="Andre arbeidsforhold">
-                        {tidligereArbeidsforhold.map((arbForhold, index) =>
-                            <li key={index}><ArbeidsForhold arbeidsforhold={arbForhold}/></li>)}
-                    </ArbeidsForholdListeStyle>
-                </DetaljerCollapse>
+                {tidligereArbeidsforholdCollapse}
             </YtelserInfoGruppe>
         </OversiktStyling>);
 }

--- a/src/app/personside/infotabs/ytelser/pleiepenger/Oversikt.tsx
+++ b/src/app/personside/infotabs/ytelser/pleiepenger/Oversikt.tsx
@@ -60,9 +60,9 @@ function Oversikt({pleiepenger, visAlleArbeidsforhold, toggleVisAlleArbeidsforho
     const [gjeldendeArbeidsforhold, ...tidligereArbeidsforhold] = getAlleArbiedsforholdSortert(pleiepenger);
 
     const omPleiepengerettenEntries = {
-        'Fra og med': formaterDato(gjeldeneVedtak.periode.fom),
-        'Til og med': formaterDato(gjeldeneVedtak.periode.tom),
-        Pleiepengegrad: gjeldeneVedtak.pleiepengegrad + '%',
+        'Fra og med': gjeldeneVedtak ? formaterDato(gjeldeneVedtak.periode.fom) : '',
+        'Til og med': gjeldeneVedtak ? formaterDato(gjeldeneVedtak.periode.tom) : '',
+        Pleiepengegrad: gjeldeneVedtak ? gjeldeneVedtak.pleiepengegrad + '%' : '',
         ['Barnet (' + kjønn + ')']: pleiepenger.barnet,
         'Annen forelder': pleiepenger.andreOmsorgsperson
     };

--- a/src/app/personside/infotabs/ytelser/pleiepenger/Oversikt.tsx
+++ b/src/app/personside/infotabs/ytelser/pleiepenger/Oversikt.tsx
@@ -67,7 +67,7 @@ function Oversikt({pleiepenger, visAlleArbeidsforhold, toggleVisAlleArbeidsforho
         'Annen forelder': pleiepenger.andreOmsorgsperson
     };
 
-    const tidligereArbeidsforholdCollapse = tidligereArbeidsforhold.length > 0 && (
+    const tidligereArbeidsforholdCollapse = (
         <DetaljerCollapse
             open={visAlleArbeidsforhold}
             toggle={toggleVisAlleArbeidsforhold}
@@ -87,7 +87,7 @@ function Oversikt({pleiepenger, visAlleArbeidsforhold, toggleVisAlleArbeidsforho
             </YtelserInfoGruppe>
             <YtelserInfoGruppe tittel="Arbeidssituasjon">
                 <ArbeidsForhold arbeidsforhold={gjeldendeArbeidsforhold}/>
-                {tidligereArbeidsforholdCollapse}
+                {tidligereArbeidsforhold.length > 0 && tidligereArbeidsforholdCollapse}
             </YtelserInfoGruppe>
         </OversiktStyling>);
 }

--- a/src/app/personside/infotabs/ytelser/pleiepenger/Pleiepenger.tsx
+++ b/src/app/personside/infotabs/ytelser/pleiepenger/Pleiepenger.tsx
@@ -13,14 +13,14 @@ function Pleiepenger(props: Props) {
     const sortertePerioder = props.pleiepenger.perioder.sort(genericAscendingDateComparator(p => p.fom)).reverse();
 
     return (
-        <div>
+        <article>
             <Oversikt pleiepenger={props.pleiepenger}/>
             <ol>
                 {sortertePerioder.map((periode, index) =>
                     <Pleiepengerperiode periodeNummer={sortertePerioder.length - index} key={index} periode={periode}/>
                 )}
             </ol>
-        </div>
+        </article>
     );
 }
 

--- a/src/app/personside/infotabs/ytelser/pleiepenger/PleiepengerEkspanderbartPanel.tsx
+++ b/src/app/personside/infotabs/ytelser/pleiepenger/PleiepengerEkspanderbartPanel.tsx
@@ -15,8 +15,11 @@ function PleiepengerEkspanderbartpanel({pleiepenger}: Props) {
         return null;
     }
 
+    const sistePeriodeForPleiepengerettighet = getSistePeriodeForPleiepengerettighet(pleiepenger);
     const tittelTillegsInfo = [
-        'ID-dato: ' + formaterDato(getSistePeriodeForPleiepengerettighet(pleiepenger).fom),
+        'ID-dato: ' + (sistePeriodeForPleiepengerettighet
+            ? formaterDato(sistePeriodeForPleiepengerettighet.fom)
+            : 'N/A'),
         'Barnets f.nr: ' + pleiepenger.barnet
     ];
 

--- a/src/app/personside/infotabs/ytelser/pleiepenger/Pleiepengerperiode.tsx
+++ b/src/app/personside/infotabs/ytelser/pleiepenger/Pleiepengerperiode.tsx
@@ -2,7 +2,6 @@ import * as React from 'react';
 import { Pleiepengeperiode, Vedtak } from '../../../../../models/ytelse/pleiepenger';
 import theme from '../../../../../styles/personOversiktTheme';
 import styled from 'styled-components';
-import { GråttPanel } from '../../../../../components/common-styled-components';
 import YtelserPeriode from '../felles-styling/YtelserPeriode';
 import DescriptionList from '../felles-styling/DescriptionList';
 import { Undertittel } from 'nav-frontend-typografi';
@@ -14,28 +13,20 @@ interface Props {
     periodeNummer: number;
 }
 
-const Padding = styled.div`
-  margin: ${theme.margin.px10} ${theme.margin.px20} ${theme.margin.px40};
-`;
-
 const PaddingBottom = styled.div`
   padding-bottom: 1rem;
 `;
 
 const VedtaksListe = styled.ul`
   list-style: none;
-  margin-right: 1rem;
+  padding: 2rem;
   li {
-    margin-bottom: ${theme.margin.px20};
+    margin-top: ${theme.margin.px10};
+    &:not(:last-child) {
+      padding-bottom: ${theme.margin.px20};
+      border-bottom: ${theme.border.skilleDashed};
+    }
   }
-`;
-
-const Flex = styled.div`
-  display: flex;
-`;
-
-const TittelStyling = styled.div`
-  padding: 1rem 0.3rem .5rem;
 `;
 
 function Vedtak({vedtak}: { vedtak: Vedtak }) {
@@ -50,37 +41,22 @@ function Vedtak({vedtak}: { vedtak: Vedtak }) {
 
     return (
         <li>
-            <GråttPanel>
-                <DescriptionList entries={anvisteUtbetalingerEntries}/>
-                <PaddingBottom/>
-            </GråttPanel>
+            <DescriptionList entries={anvisteUtbetalingerEntries}/>
+            <PaddingBottom/>
         </li>
     );
 }
 
 function Pleiepengerperiode({periode, ...props}: Props) {
 
-    const entries = {
-        Pleiedager: periode.antallPleiepengedager
-    };
-
     const vedtak = periode.vedtak.map((v, index) => <Vedtak key={index} vedtak={v}/>);
 
     return (
         <YtelserPeriode tittel={`Periode ${props.periodeNummer} - ${formaterDato(periode.fom)}`}>
-            <Flex>
-                <Padding>
-                    <DescriptionList entries={entries}/>
-                </Padding>
-                <div>
-                    <TittelStyling>
-                        <Undertittel>Anviste utbetalinger</Undertittel>
-                    </TittelStyling>
-                    <VedtaksListe>
-                        {vedtak}
-                    </VedtaksListe>
-                </div>
-            </Flex>
+            <VedtaksListe>
+                <Undertittel>Anviste utbetalinger</Undertittel>
+                {vedtak}
+            </VedtaksListe>
         </YtelserPeriode>
     );
 }

--- a/src/app/personside/infotabs/ytelser/pleiepenger/__snapshots__/pleiepenger.test.tsx.snap
+++ b/src/app/personside/infotabs/ytelser/pleiepenger/__snapshots__/pleiepenger.test.tsx.snap
@@ -350,7 +350,7 @@ exports[`Om Oversikten i pleiepengeretten matcher snapshot 1`] = `
 `;
 
 exports[`Om Pleiepengeperiode i pleiepengeretten matcher snapshot 1`] = `
-.c5 {
+.c4 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -360,16 +360,16 @@ exports[`Om Pleiepengeperiode i pleiepengeretten matcher snapshot 1`] = `
   flex-wrap: wrap;
 }
 
-.c5 dt {
+.c4 dt {
   color: #78706a;
 }
 
-.c5 dd {
+.c4 dd {
   font-weight: bold;
   margin-top: .3rem;
 }
 
-.c5 > div {
+.c4 > div {
   margin-top: 1.875rem;
   padding-right: 1rem;
   min-width: 13rem;
@@ -381,13 +381,6 @@ exports[`Om Pleiepengeperiode i pleiepengeretten matcher snapshot 1`] = `
 
 .c1 {
   font-weight: bold;
-}
-
-.c8 {
-  border-radius: 0.5rem;
-  background-color: #e9e7e7;
-  box-shadow: inset 0 0 0 .3rem white;
-  padding: 1.25rem;
 }
 
 .c0 > *:first-child {
@@ -404,32 +397,22 @@ exports[`Om Pleiepengeperiode i pleiepengeretten matcher snapshot 1`] = `
   border-top: solid 0.0625rem #b7b1a9;
 }
 
-.c4 {
-  margin: 0.625rem 1.25rem 2.5rem;
-}
-
-.c9 {
+.c5 {
   padding-bottom: 1rem;
 }
 
-.c7 {
-  list-style: none;
-  margin-right: 1rem;
-}
-
-.c7 li {
-  margin-bottom: 1.25rem;
-}
-
 .c3 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
+  list-style: none;
+  padding: 2rem;
 }
 
-.c6 {
-  padding: 1rem 0.3rem .5rem;
+.c3 li {
+  margin-top: 0.625rem;
+}
+
+.c3 li:not(:last-child) {
+  padding-bottom: 1.25rem;
+  border-bottom: dotted 0.09375rem #b7b1a9;
 }
 
 <li
@@ -448,129 +431,95 @@ exports[`Om Pleiepengeperiode i pleiepengeretten matcher snapshot 1`] = `
       </span>
     </span>
   </h3>
-  <div
+  <ul
     className="c3"
   >
-    <div
-      className="c4"
+    <h2
+      className="typo-undertittel"
     >
+      Anviste utbetalinger
+    </h2>
+    <li>
       <dl
-        className="c5"
+        className="c4"
       >
         <div>
           <dt
             className="typo-etikett-liten"
           >
-            Pleiedager
+            Fra og med dato
           </dt>
           <dd
             className="typo-normal"
           >
-            3
+            01.01.1970
+          </dd>
+        </div>
+        <div>
+          <dt
+            className="typo-etikett-liten"
+          >
+            Til og med dato
+          </dt>
+          <dd
+            className="typo-normal"
+          >
+            01.01.1970
+          </dd>
+        </div>
+        <div>
+          <dt
+            className="typo-etikett-liten"
+          >
+            Bruttobeløp
+          </dt>
+          <dd
+            className="typo-normal"
+          >
+            NOK 812.00
+          </dd>
+        </div>
+        <div>
+          <dt
+            className="typo-etikett-liten"
+          >
+            Anvist Utbetaling
+          </dt>
+          <dd
+            className="typo-normal"
+          >
+            01.01.1970
+          </dd>
+        </div>
+        <div>
+          <dt
+            className="typo-etikett-liten"
+          >
+            Dagsats
+          </dt>
+          <dd
+            className="typo-normal"
+          >
+            NOK 51.00
+          </dd>
+        </div>
+        <div>
+          <dt
+            className="typo-etikett-liten"
+          >
+            Pleiepengegrad
+          </dt>
+          <dd
+            className="typo-normal"
+          >
+            30%
           </dd>
         </div>
       </dl>
-    </div>
-    <div>
       <div
-        className="c6"
-      >
-        <h2
-          className="typo-undertittel"
-        >
-          Anviste utbetalinger
-        </h2>
-      </div>
-      <ul
-        className="c7"
-      >
-        <li>
-          <div
-            className="c8"
-          >
-            <dl
-              className="c5"
-            >
-              <div>
-                <dt
-                  className="typo-etikett-liten"
-                >
-                  Fra og med dato
-                </dt>
-                <dd
-                  className="typo-normal"
-                >
-                  01.01.1970
-                </dd>
-              </div>
-              <div>
-                <dt
-                  className="typo-etikett-liten"
-                >
-                  Til og med dato
-                </dt>
-                <dd
-                  className="typo-normal"
-                >
-                  01.01.1970
-                </dd>
-              </div>
-              <div>
-                <dt
-                  className="typo-etikett-liten"
-                >
-                  Bruttobeløp
-                </dt>
-                <dd
-                  className="typo-normal"
-                >
-                  NOK 812.00
-                </dd>
-              </div>
-              <div>
-                <dt
-                  className="typo-etikett-liten"
-                >
-                  Anvist Utbetaling
-                </dt>
-                <dd
-                  className="typo-normal"
-                >
-                  01.01.1970
-                </dd>
-              </div>
-              <div>
-                <dt
-                  className="typo-etikett-liten"
-                >
-                  Dagsats
-                </dt>
-                <dd
-                  className="typo-normal"
-                >
-                  NOK 51.00
-                </dd>
-              </div>
-              <div>
-                <dt
-                  className="typo-etikett-liten"
-                >
-                  Pleiepengegrad
-                </dt>
-                <dd
-                  className="typo-normal"
-                >
-                  30%
-                </dd>
-              </div>
-            </dl>
-            <div
-              className="c9"
-            />
-          </div>
-        </li>
-      </ul>
-    </div>
-  </div>
+        className="c5"
+      />
+    </li>
+  </ul>
 </li>
 `;

--- a/src/app/personside/infotabs/ytelser/pleiepenger/pleiepengerUtils.test.tsx
+++ b/src/app/personside/infotabs/ytelser/pleiepenger/pleiepengerUtils.test.tsx
@@ -9,7 +9,6 @@ import Pleiepenger from './Pleiepenger';
 import { mount } from 'enzyme';
 import * as React from 'react';
 import TestProvider from '../../../../../test/Testprovider';
-import { AlertStripeInfo } from 'nav-frontend-alertstriper';
 
 const mockpleiepengeRettighet = getMockPleiepengerettighet('10108000398');
 const mockPeriode = mockpleiepengeRettighet.perioder[0];

--- a/src/app/personside/infotabs/ytelser/pleiepenger/pleiepengerUtils.test.tsx
+++ b/src/app/personside/infotabs/ytelser/pleiepenger/pleiepengerUtils.test.tsx
@@ -5,6 +5,11 @@ import {
     getSistePeriodeForPleiepengerettighet,
     getSisteVedtakForPleiepengerettighet, sorterArbeidsforholdEtterRefusjonTom
 } from './pleiepengerUtils';
+import Pleiepenger from './Pleiepenger';
+import { mount } from 'enzyme';
+import * as React from 'react';
+import TestProvider from '../../../../../test/Testprovider';
+import { AlertStripeInfo } from 'nav-frontend-alertstriper';
 
 const mockpleiepengeRettighet = getMockPleiepengerettighet('10108000398');
 const mockPeriode = mockpleiepengeRettighet.perioder[0];
@@ -47,16 +52,31 @@ const testRettighet: Pleiepengerettighet = {
     }],
 };
 
-test('get siste periode fra pleiepengerettighet', () => {
+test('get siste periode fra pleiepengerettighet returner', () => {
     const pleiepengePeriode = getSistePeriodeForPleiepengerettighet(testRettighet);
 
+    // @ts-ignore
     expect(pleiepengePeriode.fom).toEqual('2010-01-01');
 });
 
 test('get siste vedtak fra pleiepengerettighet', () => {
     const vedtak = getSisteVedtakForPleiepengerettighet(testRettighet);
 
+    // @ts-ignore
     expect(vedtak.periode).toEqual({fom: '2010-01-01', tom: '2011-01-01'});
+});
+
+test('get siste vedtak fra pleiepengerettighet returnerer undefined dersom ingen vedtak finnes', () => {
+    const testRettighetUtenVedtak: Pleiepengerettighet = {
+        ...testRettighet,
+        perioder: [{
+            ...testRettighet.perioder[0],
+            vedtak: []
+        }]
+    };
+    const vedtak = getSisteVedtakForPleiepengerettighet(testRettighetUtenVedtak);
+
+    expect(vedtak).toBe(undefined);
 });
 
 describe('arbeidsforhold i pleiepengerettighet', () => {
@@ -103,4 +123,18 @@ describe('arbeidsforhold i pleiepengerettighet', () => {
 
         expect(sortert[0].refusjonTom).toEqual('2012-01-01');
     });
+});
+
+test('rendrer fint selv om bruker ikke har noen arbeidsforhold', () => {
+    const testRettighetUtenArbeidsforhold: Pleiepengerettighet = {
+        ...testRettighet,
+        perioder: [{
+            ...testRettighet.perioder[0],
+            arbeidsforhold: []
+        }]
+    };
+
+    const result = mount(<TestProvider><Pleiepenger pleiepenger={testRettighetUtenArbeidsforhold}/></TestProvider>);
+
+    expect(result.html()).toContain('Kunne ikke finne arbeidsforhold');
 });

--- a/src/app/personside/infotabs/ytelser/pleiepenger/pleiepengerUtils.ts
+++ b/src/app/personside/infotabs/ytelser/pleiepenger/pleiepengerUtils.ts
@@ -6,14 +6,18 @@ import {
 } from '../../../../../models/ytelse/pleiepenger';
 import { genericAscendingDateComparator } from '../../../../../utils/dateUtils';
 
-export function getSistePeriodeForPleiepengerettighet(pleiepenger: Pleiepengerettighet): Pleiepengeperiode {
+export function getSistePeriodeForPleiepengerettighet(pleiepenger: Pleiepengerettighet): Pleiepengeperiode | undefined {
     return pleiepenger.perioder
         .sort(genericAscendingDateComparator(p => p.fom))
         .reverse()[0];
 }
 
-export function getSisteVedtakForPleiepengerettighet(pleiepenger: Pleiepengerettighet): Vedtak {
-    return getSistePeriodeForPleiepengerettighet(pleiepenger).vedtak
+export function getSisteVedtakForPleiepengerettighet(pleiepenger: Pleiepengerettighet): Vedtak | undefined {
+    const sistePeriodeForPleiepengerettighet = getSistePeriodeForPleiepengerettighet(pleiepenger);
+    if (!sistePeriodeForPleiepengerettighet) {
+        return undefined;
+    }
+    return sistePeriodeForPleiepengerettighet.vedtak
         .sort(genericAscendingDateComparator(vedtak => vedtak.periode.fom))
         .reverse()[0];
 }

--- a/src/components/common-styled-components.tsx
+++ b/src/components/common-styled-components.tsx
@@ -19,6 +19,11 @@ export const FlexEnd = styled.div`
   justify-content: flex-end;
 `;
 
+export const FlexCenter = styled.div`
+  display: flex;
+  justify-content: center;
+`;
+
 export const Uppercase = styled.span`
   text-transform: uppercase;
 `;

--- a/src/components/standalone/Pleiepenger/PleiepengerLaster.tsx
+++ b/src/components/standalone/Pleiepenger/PleiepengerLaster.tsx
@@ -12,6 +12,8 @@ import { hentPleiepenger } from '../../../redux/restReducers/ytelser/pleiepenger
 import { AsyncDispatch } from '../../../redux/ThunkTypes';
 import PlukkRestData from '../../../app/personside/infotabs/ytelser/pleiepenger/PlukkRestData';
 import Pleiepenger from '../../../app/personside/infotabs/ytelser/pleiepenger/Pleiepenger';
+import { FlexCenter } from '../../common-styled-components';
+import theme, { pxToRem } from '../../../styles/personOversiktTheme';
 
 interface OwnProps {
     fødselsnummer: string;
@@ -30,6 +32,11 @@ type Props = OwnProps & StateProps & DispatchProps;
 
 const Margin = styled.div`
   margin: .5em;
+`;
+
+const Style = styled.div`
+  ${theme.hvittPanel};
+  max-width: ${pxToRem(900)};
 `;
 
 const onPending = (
@@ -72,7 +79,7 @@ class PleiepengerLaster extends React.PureComponent<Props> {
             return <AlertStripeInfo>Kunne ikke finne pleiepengerettighet for barnet</AlertStripeInfo>;
         }
 
-        return <Pleiepenger pleiepenger={aktuellRettighet}/>;
+        return <FlexCenter><Style><Pleiepenger pleiepenger={aktuellRettighet}/></Style></FlexCenter>;
     }
 
     render() {


### PR DESCRIPTION
* Begrenser bredden på pleiepengersiden slik at den ikke blir for bred og uleselig
* fjerner pleiepengedager som ikke er relevant lenger
* lenken "vis alle arbeidsforhold" skjules dersom det ikke er mer enn ett arbeidsforhold
* fikser teknisk feil som skjedde dersom det ikke finnes vedtak for rettigheten