### PR TITLE
Erstatter toggle funksjonalitet med kun lukking

### DIFF
--- a/src/app/personside/kontrollsporsmal/HandleKontrollSporsmalHotkeys.tsx
+++ b/src/app/personside/kontrollsporsmal/HandleKontrollSporsmalHotkeys.tsx
@@ -2,11 +2,11 @@ import * as React from 'react';
 import { loggEvent } from '../../../utils/frontendLogger';
 import { getSaksbehandlerIdent } from '../../../utils/loggInfo/getSaksbehandlerIdent';
 import { Action, Dispatch } from 'redux';
-import { toggleKontrollSpørsmål } from '../../../redux/kontrollSporsmal/actions';
+import { lukkKontrollSpørsmål } from '../../../redux/kontrollSporsmal/actions';
 import { connect } from 'react-redux';
 
 interface DispatchProps {
-    toggleKontrollSpørsmål: () => void;
+    lukkKontrollSpørsmål: () => void;
 }
 
 class HandleKontrollSporsmalHotkeys extends React.Component<DispatchProps> {
@@ -33,14 +33,14 @@ class HandleKontrollSporsmalHotkeys extends React.Component<DispatchProps> {
 
         if (key === 'l' && event.altKey) {
             loggEvent('Hurtigtast', 'Kontrollsporsmal', {type: 'Alt + L'}, {ident: getSaksbehandlerIdent()});
-            this.props.toggleKontrollSpørsmål();
+            this.props.lukkKontrollSpørsmål();
         }
     }
 }
 
 function mapDispatchToProps(dispatch: Dispatch<Action>): DispatchProps {
     return {
-        toggleKontrollSpørsmål: () => dispatch(toggleKontrollSpørsmål())
+        lukkKontrollSpørsmål: () => dispatch(lukkKontrollSpørsmål())
     };
 }
 

--- a/src/app/personside/kontrollsporsmal/Header.tsx
+++ b/src/app/personside/kontrollsporsmal/Header.tsx
@@ -4,12 +4,12 @@ import Undertittel from 'nav-frontend-typografi/lib/undertittel';
 import { connect } from 'react-redux';
 import { AsyncDispatch } from '../../../redux/ThunkTypes';
 import theme from '../../../styles/personOversiktTheme';
-import { roterKontrollSpørsmål, toggleKontrollSpørsmål } from '../../../redux/kontrollSporsmal/actions';
+import { roterKontrollSpørsmål, lukkKontrollSpørsmål } from '../../../redux/kontrollSporsmal/actions';
 import { loggEvent } from '../../../utils/frontendLogger';
 import KnappBase from 'nav-frontend-knapper';
 
 interface DispatchProps {
-    toggleKontrollSpørsmål: () => void;
+    lukkKontrollSpørsmål: () => void;
     nyttSpørsmål: () => void;
 }
 
@@ -64,13 +64,13 @@ class Header extends React.PureComponent<DispatchProps> {
 
     private handleLukkClick() {
         loggEvent('Knapp', 'Kontrollsporsmal', {type: 'Lukk'});
-        this.props.toggleKontrollSpørsmål();
+        this.props.lukkKontrollSpørsmål();
     }
 }
 
 function mapDispatchToProps(dispatch: AsyncDispatch): DispatchProps {
     return {
-        toggleKontrollSpørsmål: () => dispatch(toggleKontrollSpørsmål()),
+        lukkKontrollSpørsmål: () => dispatch(lukkKontrollSpørsmål()),
         nyttSpørsmål: () => dispatch(roterKontrollSpørsmål())
     };
 }

--- a/src/redux/kontrollSporsmal/actions.ts
+++ b/src/redux/kontrollSporsmal/actions.ts
@@ -1,4 +1,4 @@
-import { ActionTypes, Roter, SetSpørsmål, Spørsmål, ToggleSynlig } from './types';
+import { ActionTypes, Roter, SetSpørsmål, Spørsmål, Lukk } from './types';
 
 export function setKontrollSpørsmål(spørsmål: Spørsmål[]): SetSpørsmål {
     return {
@@ -13,8 +13,8 @@ export function roterKontrollSpørsmål(): Roter {
     };
 }
 
-export function toggleKontrollSpørsmål(): ToggleSynlig {
+export function lukkKontrollSpørsmål(): Lukk {
     return {
-        type: ActionTypes.ToggleSynlig
+        type: ActionTypes.Lukk
     };
 }

--- a/src/redux/kontrollSporsmal/kontrollSporsmalReducer.test.ts
+++ b/src/redux/kontrollSporsmal/kontrollSporsmalReducer.test.ts
@@ -1,6 +1,6 @@
 import { Action, createStore } from 'redux';
 import kontrollspørsmålReducer from './reducer';
-import { roterKontrollSpørsmål, setKontrollSpørsmål, toggleKontrollSpørsmål } from './actions';
+import { roterKontrollSpørsmål, setKontrollSpørsmål, lukkKontrollSpørsmål } from './actions';
 import { Spørsmål } from './types';
 
 const spm1: Spørsmål = {
@@ -69,13 +69,13 @@ describe('Kontrollspørsmål reducer', () => {
 
         expect(store.getState().synlig).toBe(true);
 
-        store.dispatch(toggleKontrollSpørsmål());
+        store.dispatch(lukkKontrollSpørsmål());
 
         expect(store.getState().synlig).toBe(false);
 
-        store.dispatch(toggleKontrollSpørsmål());
+        store.dispatch(lukkKontrollSpørsmål());
 
-        expect(store.getState().synlig).toBe(true);
+        expect(store.getState().synlig).toBe(false);
     });
 });
 

--- a/src/redux/kontrollSporsmal/reducer.ts
+++ b/src/redux/kontrollSporsmal/reducer.ts
@@ -19,10 +19,10 @@ function reducer(state: KontrollSpørsmålState = initState, action: Actions): K
                     ...state
                 };
             }
-        case ActionTypes.ToggleSynlig:
+        case ActionTypes.Lukk:
             return {
                 ...state,
-                synlig: !state.synlig
+                synlig: false
             };
         default:
             return state;

--- a/src/redux/kontrollSporsmal/types.ts
+++ b/src/redux/kontrollSporsmal/types.ts
@@ -23,13 +23,13 @@ export const initState: KontrollSpørsmålState = {
 export enum ActionTypes {
     Roter = 'KONTROLLSPØRSMAL / ROTER',
     SetSpørsmål = 'KONTROLLSPØRSMÅL / SETSPØRSMÅL',
-    ToggleSynlig = 'KONTROLLSPØRSMÅL / TOGGLESYNLIG'
+    Lukk = 'KONTROLLSPØRSMÅL / LUKK'
 }
 
 export type Actions =
     Roter |
     SetSpørsmål |
-    ToggleSynlig;
+    Lukk;
 
 export interface Roter extends Action {
     type: ActionTypes.Roter;
@@ -40,6 +40,6 @@ export interface SetSpørsmål extends Action {
     spørsmål: Spørsmål[];
 }
 
-export interface ToggleSynlig extends Action {
-    type: ActionTypes.ToggleSynlig;
+export interface Lukk extends Action {
+    type: ActionTypes.Lukk;
 }


### PR DESCRIPTION


Dette var aldri en del av funksjonsbeskrivelsen, og ga egentlig forvirrende resultat da man ikke kunne toggle på igjen hvis funksjonalitet fungerte som det skulle, men plutselig kunne det pga EventListener buggen