### PR TITLE
OPP-642 Historiske utbetalinger Ytelser

### DIFF
--- a/src/app/personside/infotabs/utbetalinger/Utbetalinger.tsx
+++ b/src/app/personside/infotabs/utbetalinger/Utbetalinger.tsx
@@ -7,6 +7,7 @@ import { FilterState } from './filter/Filter';
 import TotaltUtbetalt from './totalt utbetalt/TotaltUtbetalt';
 import { ArrayGroup, groupArray, GroupedArray } from '../../../../utils/groupArray';
 import {
+    fjernTommeUtbetalinger,
     getTypeFromYtelse,
     månedOgÅrForUtbetaling,
     reduceUtbetlingerTilYtelser,
@@ -18,23 +19,23 @@ import Månedsgruppe from './MånedsGruppe';
 import HandleUtbetalingerArrowKeys from './HandleUtbetalingerHotKeys';
 
 const UtbetalingerArticle = styled.article`
-  ${theme.hvittPanel};
-  margin-top: ${theme.margin.layout};
-  margin-bottom: ${theme.margin.layout};
-  > *:first-child {
-    padding: ${theme.margin.px20};
-  }
+    ${theme.hvittPanel};
+    margin-top: ${theme.margin.layout};
+    margin-bottom: ${theme.margin.layout};
+    > *:first-child {
+        padding: ${theme.margin.px20};
+    }
 `;
 
 const UtbetalingerListe = styled.ol`
-  padding: 0;
-  margin: 0;
+    padding: 0;
+    margin: 0;
 `;
 
 const Wrapper = styled.div`
-  ol {
-    list-style: none;
-  }
+    ol {
+        list-style: none;
+    }
 `;
 
 export function getFiltrerteUtbetalinger(utbetalinger: Utbetaling[], filter: FilterState) {
@@ -49,16 +50,13 @@ function filtrerPaUtbetaltTilValg(utbetaling: Utbetaling, filter: FilterState) {
 }
 
 function filtrerBortYtelserSomIkkeErValgt(utbetaling: Utbetaling, filter: FilterState): Utbetaling {
-    const ytelser = reduceUtbetlingerTilYtelser([utbetaling])
-        .filter(ytelse => filter.ytelser.includes(getTypeFromYtelse(ytelse)));
+    const ytelser = reduceUtbetlingerTilYtelser([utbetaling]).filter(ytelse =>
+        filter.ytelser.includes(getTypeFromYtelse(ytelse))
+    );
     return {
         ...utbetaling,
         ytelser: ytelser
     };
-}
-
-function fjernTommeUtbetalinger(utbetaling: Utbetaling) {
-    return utbetaling.ytelser && utbetaling.ytelser.length > 0;
 }
 
 interface UtbetalingerProps {
@@ -66,7 +64,7 @@ interface UtbetalingerProps {
     filter: FilterState;
 }
 
-function Utbetalinger({filter, ...props}: UtbetalingerProps) {
+function Utbetalinger({ filter, ...props }: UtbetalingerProps) {
     const filtrerteUtbetalinger = getFiltrerteUtbetalinger(props.utbetalingerData.utbetalinger, filter);
     if (filtrerteUtbetalinger.length === 0) {
         return (
@@ -82,22 +80,16 @@ function Utbetalinger({filter, ...props}: UtbetalingerProps) {
     );
 
     const månedsGrupper = utbetalingerGruppert.map((gruppe: ArrayGroup<Utbetaling>) => (
-        <Månedsgruppe
-            key={gruppe.category}
-            gruppe={gruppe}
-            {...props}
-        />
+        <Månedsgruppe key={gruppe.category} gruppe={gruppe} {...props} />
     ));
 
     return (
         <Wrapper>
-            <TotaltUtbetalt utbetalinger={filtrerteUtbetalinger} periode={props.utbetalingerData.periode}/>
+            <TotaltUtbetalt utbetalinger={filtrerteUtbetalinger} periode={props.utbetalingerData.periode} />
             <HandleUtbetalingerArrowKeys utbetalinger={filtrerteUtbetalinger}>
                 <UtbetalingerArticle aria-label="Utbetalinger">
                     <Undertittel>Utbetalinger</Undertittel>
-                    <UtbetalingerListe aria-label="Måneder">
-                        {månedsGrupper}
-                    </UtbetalingerListe>
+                    <UtbetalingerListe aria-label="Måneder">{månedsGrupper}</UtbetalingerListe>
                 </UtbetalingerArticle>
             </HandleUtbetalingerArrowKeys>
         </Wrapper>

--- a/src/app/personside/infotabs/utbetalinger/utils/utbetalingerUtils.tsx
+++ b/src/app/personside/infotabs/utbetalinger/utils/utbetalingerUtils.tsx
@@ -250,3 +250,7 @@ export function reduceUtbetlingerTilYtelser(utbetalinger: Utbetaling[]): Ytelse[
 }
 
 export const getTypeFromYtelse = (ytelse: Ytelse) => ytelse.type || 'Mangler beskrivelse';
+
+export function fjernTommeUtbetalinger(utbetaling: Utbetaling) {
+    return utbetaling.ytelser && utbetaling.ytelser.length > 0;
+}

--- a/src/app/personside/infotabs/ytelser/felles-styling/YtelserPeriode.tsx
+++ b/src/app/personside/infotabs/ytelser/felles-styling/YtelserPeriode.tsx
@@ -11,23 +11,24 @@ interface Props {
 }
 
 const PeriodeStyling = styled.li`
-  > *:first-child {
-    background-color: ${theme.color.kategori};
-    padding: .2rem ${theme.margin.px20};
-  }
-  ol {
-    padding: 0;
-    margin: 0;
-  }
-  ol > *:not(:first-child) {
-    border-top: ${theme.border.skille};
-  }
+    > *:first-child {
+        background-color: ${theme.color.kategori};
+        padding: 0.2rem ${theme.margin.px20};
+    }
+    ol {
+        padding: 0;
+        margin: 0;
+    }
 `;
 
 function YtelserPeriode(props: Props) {
     return (
         <PeriodeStyling>
-            <Normaltekst tag="h3"><Bold><Uppercase>{props.tittel}</Uppercase></Bold></Normaltekst>
+            <Normaltekst tag="h3">
+                <Bold>
+                    <Uppercase>{props.tittel}</Uppercase>
+                </Bold>
+            </Normaltekst>
             {props.children}
         </PeriodeStyling>
     );

--- a/src/app/personside/infotabs/ytelser/foreldrepenger/Arbeidsforhold.tsx
+++ b/src/app/personside/infotabs/ytelser/foreldrepenger/Arbeidsforhold.tsx
@@ -22,7 +22,7 @@ function ArbeidsForhold({ arbeidsforhold }: Props) {
         ),
         Inntekstsperiode: arbeidsforhold.inntektsperiode,
         'Inntekt for perioden':
-            arbeidsforhold.inntektForPerioden && 'NOK ' + formaterNOK(arbeidsforhold.inntektForPerioden),
+            arbeidsforhold.inntektForPerioden && formaterNOK(arbeidsforhold.inntektForPerioden) + ' NOK',
         Refusjonstype: arbeidsforhold.refusjonstype,
         'Refusjon til dato': arbeidsforhold.refusjonTom && formaterDato(arbeidsforhold.refusjonTom)
     };

--- a/src/app/personside/infotabs/ytelser/foreldrepenger/ForeldrePenger.test.tsx
+++ b/src/app/personside/infotabs/ytelser/foreldrepenger/ForeldrePenger.test.tsx
@@ -2,10 +2,15 @@ import * as React from 'react';
 import * as renderer from 'react-test-renderer';
 import Foreldrepenger from './ForeldrePenger';
 import { statiskForeldrepengeMock } from '../../../../../mock/ytelse/statiskForeldrepengeMock';
+import TestProvider from '../../../../../test/Testprovider';
 
 test('Foreldrepengeperiode matcher snapshot', () => {
     const testRettighet = statiskForeldrepengeMock;
-    const result = renderer.create(<Foreldrepenger foreldrepenger={testRettighet} />);
+    const result = renderer.create(
+        <TestProvider>
+            <Foreldrepenger foreldrepenger={testRettighet} />
+        </TestProvider>
+    );
 
     expect(result).toMatchSnapshot();
 });

--- a/src/app/personside/infotabs/ytelser/foreldrepenger/ForeldrepengePeriode.tsx
+++ b/src/app/personside/infotabs/ytelser/foreldrepenger/ForeldrepengePeriode.tsx
@@ -6,6 +6,7 @@ import theme from '../../../../../styles/personOversiktTheme';
 import DescriptionList from '../../../../../components/DescriptionList';
 import YtelserPeriode from '../felles-styling/YtelserPeriode';
 import { formaterDato } from '../../../../../utils/dateUtils';
+import { YtelserKeys } from '../ytelserKeys';
 
 interface Props {
     periode: Foreldrepengerperiode;
@@ -62,6 +63,7 @@ function ForeldrepengePeriode({ periode, periodenr }: Props) {
                     <Utbetalinger
                         kommendeUtbetalinger={periode.kommendeUtbetalinger}
                         historiskeUtbetalinger={periode.historiskeUtbetalinger}
+                        ytelsesType={YtelserKeys.Foreldrepenger}
                     />
                 </Stor>
             </Flex>

--- a/src/app/personside/infotabs/ytelser/foreldrepenger/Oversikt.tsx
+++ b/src/app/personside/infotabs/ytelser/foreldrepenger/Oversikt.tsx
@@ -52,10 +52,11 @@ function AlleArbeidsforhold(props: { foreldrePenger: Foreldrepengerettighet }) {
         </DetaljerCollapse>
     );
 
+    const flereArbeidsforhold = tidligereArbeidsforhold.length > 0;
     return (
         <>
             <ArbeidsForhold arbeidsforhold={gjeldendeArbeidsforhold} />
-            {tidligereArbeidsforhold.length > 0 && tidligereArbeidsforholdCollapse}
+            {flereArbeidsforhold && tidligereArbeidsforholdCollapse}
         </>
     );
 }

--- a/src/app/personside/infotabs/ytelser/foreldrepenger/__snapshots__/ForeldrePenger.test.tsx.snap
+++ b/src/app/personside/infotabs/ytelser/foreldrepenger/__snapshots__/ForeldrePenger.test.tsx.snap
@@ -1,31 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`Foreldrepengeperiode matcher snapshot 1`] = `
-.c1 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-flex-wrap: wrap;
-  -ms-flex-wrap: wrap;
-  flex-wrap: wrap;
-}
-
-.c1 dt {
-  color: #78706a;
-}
-
-.c1 dd {
-  font-weight: bold;
-  margin-top: 0.3rem;
-}
-
-.c1 > div {
-  margin: 0.9375rem 0;
-  padding-right: 1rem;
-  min-width: 13rem;
-}
-
 .c20 {
   text-align: center;
 }
@@ -39,6 +14,17 @@ exports[`Foreldrepengeperiode matcher snapshot 1`] = `
   -webkit-justify-content: flex-end;
   -ms-flex-pack: end;
   justify-content: flex-end;
+}
+
+.c24 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
 }
 
 .c13 {
@@ -89,6 +75,31 @@ exports[`Foreldrepengeperiode matcher snapshot 1`] = `
   border-color: #0067C5;
 }
 
+.c1 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-wrap: wrap;
+  -ms-flex-wrap: wrap;
+  flex-wrap: wrap;
+}
+
+.c1 dt {
+  color: #78706a;
+}
+
+.c1 dd {
+  font-weight: bold;
+  margin-top: 0.3rem;
+}
+
+.c1 > div {
+  margin: 0.9375rem 0;
+  padding-right: 1rem;
+  min-width: 13rem;
+}
+
 .c8 {
   margin-right: .5rem;
 }
@@ -99,7 +110,7 @@ exports[`Foreldrepengeperiode matcher snapshot 1`] = `
   padding: 0 1.25rem 1.25rem;
 }
 
-.c22 {
+.c21 {
   -webkit-transition: 0.5s;
   transition: 0.5s;
   padding: 1.25rem;
@@ -119,8 +130,16 @@ exports[`Foreldrepengeperiode matcher snapshot 1`] = `
   margin-right: 1.25rem;
 }
 
-.c23 {
+.c22 {
   margin-bottom: 1.25rem;
+}
+
+.c19 {
+  padding: 0.5rem;
+}
+
+.c23 {
+  padding: 0.5rem;
 }
 
 .c18 {
@@ -131,26 +150,14 @@ exports[`Foreldrepengeperiode matcher snapshot 1`] = `
   margin: 0.625rem 0;
 }
 
-.c21 {
-  list-style: none;
-}
-
-.c19 {
-  padding: 0.5rem;
-}
-
 .c11 > *:first-child {
   background-color: #cce1f3;
-  padding: .2rem 1.25rem;
+  padding: 0.2rem 1.25rem;
 }
 
 .c11 ol {
   padding: 0;
   margin: 0;
-}
-
-.c11 ol > *:not(:first-child) {
-  border-top: solid 0.0625rem #b7b1a9;
 }
 
 .c16 {
@@ -444,7 +451,7 @@ exports[`Foreldrepengeperiode matcher snapshot 1`] = `
           <dd
             className="typo-normal"
           >
-            NOK 40,062.00
+            40,062.00 NOK
           </dd>
         </div>
         <div>
@@ -646,258 +653,263 @@ exports[`Foreldrepengeperiode matcher snapshot 1`] = `
         <div
           className="c17"
         >
-          <div
+          <section
+            aria-label="Utbetalinger Foreldrepenger"
             className="c18"
           >
-            <div
-              className="c19"
-            >
+            <section>
               <div
-                className="c20"
+                className="c19"
               >
-                <h4
-                  className="typo-undertittel"
-                >
-                  Kommende utbetalinger
-                </h4>
-              </div>
-            </div>
-            <ul
-              className="c21"
-            >
-              <li>
                 <div
-                  className="c22"
-                  open={false}
+                  className="c20"
                 >
-                  <dl
-                    className="c1"
+                  <h4
+                    className="typo-undertittel"
                   >
-                    <div>
-                      <dt
-                        className="typo-etikett-liten"
-                      >
-                        Registeringsdato
-                      </dt>
-                      <dd
-                        className="typo-normal"
-                      >
-                        25.06.2018
-                      </dd>
-                    </div>
-                    <div>
-                      <dt
-                        className="typo-etikett-liten"
-                      >
-                        Type
-                      </dt>
-                      <dd
-                        className="typo-normal"
-                      >
-                        KONTOØVERFØRING
-                      </dd>
-                    </div>
-                    <div>
-                      <dt
-                        className="typo-etikett-liten"
-                      >
-                        Periode
-                      </dt>
-                      <dd
-                        className="typo-normal"
-                      >
-                        14.01.2018 - 15.07.2017
-                      </dd>
-                    </div>
-                    <div>
-                      <dt
-                        className="typo-etikett-liten"
-                      >
-                        Utbetalingsgrad
-                      </dt>
-                      <dd
-                        className="typo-normal"
-                      >
-                        79%
-                      </dd>
-                    </div>
-                  </dl>
+                    Kommende utbetalinger
+                  </h4>
+                </div>
+              </div>
+              <ol>
+                <li
+                  aria-label="Kommende utbetaling 25.06.2018"
+                >
                   <div
-                    className="c23"
+                    className="c21"
+                    open={false}
                   >
+                    <dl
+                      className="c1"
+                    >
+                      <div>
+                        <dt
+                          className="typo-etikett-liten"
+                        >
+                          Registeringsdato
+                        </dt>
+                        <dd
+                          className="typo-normal"
+                        >
+                          25.06.2018
+                        </dd>
+                      </div>
+                      <div>
+                        <dt
+                          className="typo-etikett-liten"
+                        >
+                          Type
+                        </dt>
+                        <dd
+                          className="typo-normal"
+                        >
+                          KONTOØVERFØRING
+                        </dd>
+                      </div>
+                      <div>
+                        <dt
+                          className="typo-etikett-liten"
+                        >
+                          Periode
+                        </dt>
+                        <dd
+                          className="typo-normal"
+                        >
+                          14.01.2018 - 15.07.2017
+                        </dd>
+                      </div>
+                      <div>
+                        <dt
+                          className="typo-etikett-liten"
+                        >
+                          Utbetalingsgrad
+                        </dt>
+                        <dd
+                          className="typo-normal"
+                        >
+                          79%
+                        </dd>
+                      </div>
+                    </dl>
                     <div
-                      className="c5"
+                      className="c22"
                     >
                       <div
-                        className="c6"
+                        className="c5"
                       >
-                        <button
-                          aria-expanded={false}
-                          className="c7"
-                          onClick={[Function]}
+                        <div
+                          className="c6"
                         >
-                          <span
-                            className="c8"
+                          <button
+                            aria-expanded={false}
+                            className="c7"
+                            onClick={[Function]}
                           >
                             <span
-                              className="typo-normal"
+                              className="c8"
                             >
-                              Vis
-                               
-                              detaljer
+                              <span
+                                className="typo-normal"
+                              >
+                                Vis
+                                 
+                                detaljer
+                              </span>
                             </span>
-                          </span>
-                          <i
-                            className="nav-frontend-chevron chevronboks chevron--ned"
-                          />
-                        </button>
+                            <i
+                              className="nav-frontend-chevron chevronboks chevron--ned"
+                            />
+                          </button>
+                        </div>
                       </div>
                     </div>
-                  </div>
-                  <div
-                    className="c10"
-                    open={false}
-                  />
-                </div>
-              </li>
-            </ul>
-            <div
-              className="c19"
-            >
-              <div
-                className="c20"
-              >
-                <h4
-                  className="typo-undertittel"
-                >
-                  Utførte utbetalinger
-                </h4>
-              </div>
-            </div>
-            <ul
-              className="c21"
-            >
-              <li>
-                <div
-                  className="c22"
-                  open={false}
-                >
-                  <dl
-                    className="c1"
-                  >
-                    <div>
-                      <dt
-                        className="typo-etikett-liten"
-                      >
-                        Dato
-                      </dt>
-                      <dd
-                        className="typo-normal"
-                      >
-                        26.01.2019
-                      </dd>
-                    </div>
-                    <div>
-                      <dt
-                        className="typo-etikett-liten"
-                      >
-                        Type
-                      </dt>
-                      <dd
-                        className="typo-normal"
-                      >
-                        KONTOØVERFØRING
-                      </dd>
-                    </div>
-                    <div>
-                      <dt
-                        className="typo-etikett-liten"
-                      >
-                        Periode
-                      </dt>
-                      <dd
-                        className="typo-normal"
-                      >
-                        09.02.2018 - 25.03.2018
-                      </dd>
-                    </div>
-                    <div>
-                      <dt
-                        className="typo-etikett-liten"
-                      >
-                        Utbetalingsgrad
-                      </dt>
-                      <dd
-                        className="typo-normal"
-                      >
-                        1%
-                      </dd>
-                    </div>
-                    <div>
-                      <dt
-                        className="typo-etikett-liten"
-                      >
-                        Netto
-                      </dt>
-                      <dd
-                        className="typo-normal"
-                      >
-                        773.00 NOK
-                      </dd>
-                    </div>
-                    <div>
-                      <dt
-                        className="typo-etikett-liten"
-                      >
-                        Registeringsdato
-                      </dt>
-                      <dd
-                        className="typo-normal"
-                      >
-                        26.01.2019
-                      </dd>
-                    </div>
-                  </dl>
-                  <div
-                    className="c23"
-                  >
                     <div
-                      className="c5"
+                      className="c10"
+                      open={false}
+                    />
+                  </div>
+                </li>
+              </ol>
+            </section>
+            <section>
+              <div
+                className="c23"
+              >
+                <div
+                  className="c20"
+                >
+                  <h4
+                    className="typo-undertittel"
+                  >
+                    Utførte utbetalinger
+                  </h4>
+                </div>
+              </div>
+              <ol>
+                <li
+                  aria-label="Utført utbetaling 26.01.2019"
+                >
+                  <div
+                    className="c21"
+                    open={false}
+                  >
+                    <dl
+                      className="c1"
+                    >
+                      <div>
+                        <dt
+                          className="typo-etikett-liten"
+                        >
+                          Type
+                        </dt>
+                        <dd
+                          className="typo-normal"
+                        >
+                          KONTOØVERFØRING
+                        </dd>
+                      </div>
+                      <div>
+                        <dt
+                          className="typo-etikett-liten"
+                        >
+                          Netto
+                        </dt>
+                        <dd
+                          className="typo-normal"
+                        >
+                          773.00 NOK
+                        </dd>
+                      </div>
+                      <div>
+                        <dt
+                          className="typo-etikett-liten"
+                        >
+                          Dato
+                        </dt>
+                        <dd
+                          className="typo-normal"
+                        >
+                          26.01.2019
+                        </dd>
+                      </div>
+                      <div>
+                        <dt
+                          className="typo-etikett-liten"
+                        >
+                          Periode
+                        </dt>
+                        <dd
+                          className="typo-normal"
+                        >
+                          09.02.2018 - 25.03.2018
+                        </dd>
+                      </div>
+                      <div>
+                        <dt
+                          className="typo-etikett-liten"
+                        >
+                          Utbetalingsgrad
+                        </dt>
+                        <dd
+                          className="typo-normal"
+                        >
+                          1%
+                        </dd>
+                      </div>
+                    </dl>
+                    <div
+                      className="c22"
                     >
                       <div
-                        className="c6"
+                        className="c5"
                       >
-                        <button
-                          aria-expanded={false}
-                          className="c7"
-                          onClick={[Function]}
+                        <div
+                          className="c6"
                         >
-                          <span
-                            className="c8"
+                          <button
+                            aria-expanded={false}
+                            className="c7"
+                            onClick={[Function]}
                           >
                             <span
-                              className="typo-normal"
+                              className="c8"
                             >
-                              Vis
-                               
-                              detaljer
+                              <span
+                                className="typo-normal"
+                              >
+                                Vis
+                                 
+                                detaljer
+                              </span>
                             </span>
-                          </span>
-                          <i
-                            className="nav-frontend-chevron chevronboks chevron--ned"
-                          />
-                        </button>
+                            <i
+                              className="nav-frontend-chevron chevronboks chevron--ned"
+                            />
+                          </button>
+                        </div>
                       </div>
                     </div>
+                    <div
+                      className="c10"
+                      open={false}
+                    />
                   </div>
-                  <div
-                    className="c10"
-                    open={false}
-                  />
-                </div>
-              </li>
-            </ul>
-          </div>
+                </li>
+              </ol>
+              <div
+                className="c24"
+              >
+                <button
+                  className="knapp knapp--standard"
+                  disabled={false}
+                  onClick={[Function]}
+                  type="submit"
+                >
+                  Hent alle historiske utbetalinger
+                </button>
+              </div>
+            </section>
+          </section>
         </div>
       </div>
     </li>

--- a/src/app/personside/infotabs/ytelser/pleiepenger/__snapshots__/pleiepenger.test.tsx.snap
+++ b/src/app/personside/infotabs/ytelser/pleiepenger/__snapshots__/pleiepenger.test.tsx.snap
@@ -393,16 +393,12 @@ exports[`Om Pleiepengeperiode i pleiepengeretten matcher snapshot 1`] = `
 
 .c0 > *:first-child {
   background-color: #cce1f3;
-  padding: .2rem 1.25rem;
+  padding: 0.2rem 1.25rem;
 }
 
 .c0 ol {
   padding: 0;
   margin: 0;
-}
-
-.c0 ol > *:not(:first-child) {
-  border-top: solid 0.0625rem #b7b1a9;
 }
 
 .c5 {

--- a/src/app/personside/infotabs/ytelser/utbetalinger/HistoriskUtbetalingKomponent.test.tsx
+++ b/src/app/personside/infotabs/ytelser/utbetalinger/HistoriskUtbetalingKomponent.test.tsx
@@ -1,0 +1,10 @@
+import * as React from 'react';
+import * as renderer from 'react-test-renderer';
+import HistoriskUtbetalingKomponent from './HistoriskUtbetalingKomponent';
+import { statiskHistoriskUtbetaling } from '../../../../../mock/ytelse/statiskForeldrepengeMock';
+
+test('Historisk enkelutbetaling matcher snapshot', () => {
+    const result = renderer.create(<HistoriskUtbetalingKomponent historiskUtbetaling={statiskHistoriskUtbetaling} />);
+
+    expect(result).toMatchSnapshot();
+});

--- a/src/app/personside/infotabs/ytelser/utbetalinger/HistoriskUtbetalingKomponent.tsx
+++ b/src/app/personside/infotabs/ytelser/utbetalinger/HistoriskUtbetalingKomponent.tsx
@@ -1,0 +1,47 @@
+import { HistoriskUtbetaling } from '../../../../../models/ytelse/ytelse-utbetalinger';
+import { formaterDato } from '../../../../../utils/dateUtils';
+import { formaterNOK } from '../../utbetalinger/utils/utbetalingerUtils';
+import { getFormatertKreditortrekkFraHistoriskUtbetaling } from './utbetalingerUtils';
+import * as React from 'react';
+import { useState } from 'react';
+import DetaljerCollapse from '../../../../../components/DetaljerCollapse';
+import DescriptionList from '../../../../../components/DescriptionList';
+
+interface Props {
+    historiskUtbetaling: HistoriskUtbetaling;
+}
+
+function HistoriskUtbetalingKomponent({ historiskUtbetaling }: Props) {
+    const utbetaltEntries = {
+        Type: historiskUtbetaling.type,
+        Netto: historiskUtbetaling.nettobeløp && formaterNOK(historiskUtbetaling.nettobeløp) + ' NOK',
+        Dato: historiskUtbetaling.utbetalingsdato && formaterDato(historiskUtbetaling.utbetalingsdato),
+        Periode:
+            historiskUtbetaling.vedtak &&
+            `${formaterDato(historiskUtbetaling.vedtak.fra)} - ${formaterDato(historiskUtbetaling.vedtak.til)}`,
+        Utbetalingsgrad: historiskUtbetaling.utbetalingsgrad && historiskUtbetaling.utbetalingsgrad + '%'
+    };
+    const utbetaltDetaljerEntries = {
+        Dagsats: historiskUtbetaling.dagsats && formaterNOK(historiskUtbetaling.dagsats),
+        Bruttobeløp: historiskUtbetaling.bruttobeløp && formaterNOK(historiskUtbetaling.bruttobeløp) + ' NOK',
+        Arbeidsgiver: historiskUtbetaling.arbeidsgiverNavn,
+        Organisasjonsnummer: historiskUtbetaling.arbeidsgiverOrgNr,
+        Skattetrekk: historiskUtbetaling.skattetrekk,
+        Kreditortrekk: getFormatertKreditortrekkFraHistoriskUtbetaling(historiskUtbetaling)
+    };
+    const [visDetaljer, setVisDetaljer] = useState(false);
+    return (
+        <li aria-label={'Utført utbetaling ' + utbetaltEntries.Dato}>
+            <DetaljerCollapse
+                header={<DescriptionList entries={utbetaltEntries} />}
+                alwaysGrayBackground={true}
+                open={visDetaljer}
+                toggle={() => setVisDetaljer(!visDetaljer)}
+            >
+                <DescriptionList entries={utbetaltDetaljerEntries} />
+            </DetaljerCollapse>
+        </li>
+    );
+}
+
+export default HistoriskUtbetalingKomponent;

--- a/src/app/personside/infotabs/ytelser/utbetalinger/HistoriskeUtbetalinger.test.tsx
+++ b/src/app/personside/infotabs/ytelser/utbetalinger/HistoriskeUtbetalinger.test.tsx
@@ -1,0 +1,58 @@
+import * as React from 'react';
+import HistoriskeUtbetalinger from './HistoriskeUtbetalinger';
+import { statiskHistoriskUtbetaling } from '../../../../../mock/ytelse/statiskForeldrepengeMock';
+import { YtelserKeys } from '../ytelserKeys';
+import { statiskMockUtbetaling, statiskMockYtelse } from '../../../../../mock/statiskMockUtbetaling';
+import { Utbetaling } from '../../../../../models/utbetalinger';
+import { STATUS } from '../../../../../redux/restReducers/utils';
+import { mount } from 'enzyme';
+
+const type = YtelserKeys.Foreldrepenger;
+
+test('Viser to historiske utbetalinger dersom den forsynes med en historisk utbetaling og en utbetaling med matchende type', () => {
+    const utbetaling: Utbetaling = {
+        ...statiskMockUtbetaling,
+        ytelser: [
+            {
+                ...statiskMockYtelse,
+                type: type
+            }
+        ]
+    };
+
+    const result = mount(
+        <HistoriskeUtbetalinger
+            historiskeUtbetalinger={[statiskHistoriskUtbetaling]}
+            hentHistoriskeUtbetalinger={() => undefined}
+            ytelseType={type}
+            toÅrGamleUtbetalingerFraUtbetalingerRestkonto={[utbetaling]}
+            reducerStatus={STATUS.SUCCESS}
+        />
+    );
+
+    expect(
+        result
+            .find('ol')
+            .first()
+            .find('li')
+    ).toHaveLength(2);
+});
+
+test('Viser knapp for å hente fler utbetalinger hvis utbetalingereducer ikke har startet', () => {
+    const result = mount(
+        <HistoriskeUtbetalinger
+            historiskeUtbetalinger={[statiskHistoriskUtbetaling]}
+            hentHistoriskeUtbetalinger={() => undefined}
+            ytelseType={type}
+            toÅrGamleUtbetalingerFraUtbetalingerRestkonto={null}
+            reducerStatus={STATUS.NOT_STARTED}
+        />
+    );
+
+    expect(
+        result
+            .find('button')
+            .last()
+            .html()
+    ).toContain('Hent alle');
+});

--- a/src/app/personside/infotabs/ytelser/utbetalinger/HistoriskeUtbetalinger.tsx
+++ b/src/app/personside/infotabs/ytelser/utbetalinger/HistoriskeUtbetalinger.tsx
@@ -1,0 +1,93 @@
+import { HistoriskUtbetaling } from '../../../../../models/ytelse/ytelse-utbetalinger';
+import * as React from 'react';
+import HistoriskUtbetalingKomponent from './HistoriskUtbetalingKomponent';
+import { Knapp } from 'nav-frontend-knapper';
+import NavFrontendSpinner from 'nav-frontend-spinner';
+import {
+    filtrerBortUtbetalingerSomIkkeErUtbetalt,
+    fjernTommeUtbetalinger
+} from '../../utbetalinger/utils/utbetalingerUtils';
+import { genericAscendingDateComparator } from '../../../../../utils/dateUtils';
+import { AlertStripeInfo } from 'nav-frontend-alertstriper';
+import { YtelserKeys } from '../ytelserKeys';
+import { AlignTextCenter, FlexCenter } from '../../../../../components/common-styled-components';
+import { fjernUrelevanteUtbetalinger, mapUtbetlaingerTilHistoriskeUtbetalinger } from './utbetalingerUtils';
+import { STATUS } from '../../../../../redux/restReducers/utils';
+import ErrorBoundary from '../../../../../components/ErrorBoundary';
+import { Utbetaling } from '../../../../../models/utbetalinger';
+import { Undertittel } from 'nav-frontend-typografi';
+import styled from 'styled-components';
+
+interface Props {
+    historiskeUtbetalinger: HistoriskUtbetaling[];
+    ytelseType: YtelserKeys;
+    toÅrGamleUtbetalingerFraUtbetalingerRestkonto: Utbetaling[] | null;
+    reducerStatus: STATUS;
+    hentHistoriskeUtbetalinger: () => void;
+}
+
+const Padding = styled.div`
+    padding: 0.5rem;
+`;
+
+class HistoriskeUtbetalinger extends React.PureComponent<Props> {
+    constructor(props: Props) {
+        super(props);
+    }
+
+    getSammenflettedeUtbetalinger(): HistoriskUtbetaling[] {
+        if (!this.props.toÅrGamleUtbetalingerFraUtbetalingerRestkonto) {
+            return this.props.historiskeUtbetalinger;
+        } else {
+            const relevanteUtbetlaingerFraUtbetalingRestkonto = this.props.toÅrGamleUtbetalingerFraUtbetalingerRestkonto
+                .map(fjernUrelevanteUtbetalinger(this.props.ytelseType))
+                .filter(filtrerBortUtbetalingerSomIkkeErUtbetalt)
+                .filter(fjernTommeUtbetalinger);
+
+            const mappetTilHistoriskUtbetaling = mapUtbetlaingerTilHistoriskeUtbetalinger(
+                relevanteUtbetlaingerFraUtbetalingRestkonto
+            );
+
+            return [...this.props.historiskeUtbetalinger, ...mappetTilHistoriskUtbetaling];
+        }
+    }
+
+    render() {
+        const sorterteSammenflettedeUtbetalinger = this.getSammenflettedeUtbetalinger()
+            .sort(genericAscendingDateComparator(utbetaling => utbetaling.utbetalingsdato || new Date()))
+            .reverse();
+
+        if (this.props.reducerStatus === STATUS.SUCCESS && sorterteSammenflettedeUtbetalinger.length === 0) {
+            return <AlertStripeInfo>Kunne ikke finne noen historiske utbetalinger</AlertStripeInfo>;
+        }
+
+        const historiskeUtbetalinger = sorterteSammenflettedeUtbetalinger.map((utbetaling, index) => (
+            <HistoriskUtbetalingKomponent key={index} historiskUtbetaling={utbetaling} />
+        ));
+
+        const hentAlleUtbetalingerKnapp = this.props.reducerStatus === STATUS.NOT_STARTED && (
+            <FlexCenter>
+                <Knapp onClick={this.props.hentHistoriskeUtbetalinger}>Hent alle historiske utbetalinger</Knapp>
+            </FlexCenter>
+        );
+
+        const spinner = this.props.reducerStatus === STATUS.LOADING && <NavFrontendSpinner type={'S'} />;
+
+        return (
+            <ErrorBoundary boundaryName="Historiske utbetalinger">
+                <section>
+                    <Padding>
+                        <AlignTextCenter>
+                            <Undertittel tag="h4">Utførte utbetalinger</Undertittel>
+                        </AlignTextCenter>
+                    </Padding>
+                    <ol>{historiskeUtbetalinger}</ol>
+                    {hentAlleUtbetalingerKnapp}
+                    {spinner}
+                </section>
+            </ErrorBoundary>
+        );
+    }
+}
+
+export default HistoriskeUtbetalinger;

--- a/src/app/personside/infotabs/ytelser/utbetalinger/HistoriskeUtbetalinger.tsx
+++ b/src/app/personside/infotabs/ytelser/utbetalinger/HistoriskeUtbetalinger.tsx
@@ -7,11 +7,11 @@ import {
     filtrerBortUtbetalingerSomIkkeErUtbetalt,
     fjernTommeUtbetalinger
 } from '../../utbetalinger/utils/utbetalingerUtils';
-import { genericAscendingDateComparator } from '../../../../../utils/dateUtils';
+import { genericDescendingDateComparator } from '../../../../../utils/dateUtils';
 import { AlertStripeInfo } from 'nav-frontend-alertstriper';
 import { YtelserKeys } from '../ytelserKeys';
 import { AlignTextCenter, FlexCenter } from '../../../../../components/common-styled-components';
-import { fjernUrelevanteUtbetalinger, mapUtbetlaingerTilHistoriskeUtbetalinger } from './utbetalingerUtils';
+import { fjernUrelevanteUtbetalinger, mapUtbetalingerTilHistoriskeUtbetalinger } from './utbetalingerUtils';
 import { STATUS } from '../../../../../redux/restReducers/utils';
 import ErrorBoundary from '../../../../../components/ErrorBoundary';
 import { Utbetaling } from '../../../../../models/utbetalinger';
@@ -44,7 +44,7 @@ class HistoriskeUtbetalinger extends React.PureComponent<Props> {
                 .filter(filtrerBortUtbetalingerSomIkkeErUtbetalt)
                 .filter(fjernTommeUtbetalinger);
 
-            const mappetTilHistoriskUtbetaling = mapUtbetlaingerTilHistoriskeUtbetalinger(
+            const mappetTilHistoriskUtbetaling = mapUtbetalingerTilHistoriskeUtbetalinger(
                 relevanteUtbetlaingerFraUtbetalingRestkonto
             );
 
@@ -53,9 +53,9 @@ class HistoriskeUtbetalinger extends React.PureComponent<Props> {
     }
 
     render() {
-        const sorterteSammenflettedeUtbetalinger = this.getSammenflettedeUtbetalinger()
-            .sort(genericAscendingDateComparator(utbetaling => utbetaling.utbetalingsdato || new Date()))
-            .reverse();
+        const sorterteSammenflettedeUtbetalinger = this.getSammenflettedeUtbetalinger().sort(
+            genericDescendingDateComparator(utbetaling => utbetaling.utbetalingsdato || new Date())
+        );
 
         if (this.props.reducerStatus === STATUS.SUCCESS && sorterteSammenflettedeUtbetalinger.length === 0) {
             return <AlertStripeInfo>Kunne ikke finne noen historiske utbetalinger</AlertStripeInfo>;

--- a/src/app/personside/infotabs/ytelser/utbetalinger/HistoriskeUtbetalingerContainer.tsx
+++ b/src/app/personside/infotabs/ytelser/utbetalinger/HistoriskeUtbetalingerContainer.tsx
@@ -1,0 +1,79 @@
+import * as React from 'react';
+import { AppState } from '../../../../../redux/reducers';
+import { AsyncDispatch } from '../../../../../redux/ThunkTypes';
+import { hentHistoriskeUtbetalinger } from '../../../../../redux/restReducers/ytelser/historiskeUtbetalinger';
+import { connect } from 'react-redux';
+import { isLoaded, isNotStarted, Loaded, RestReducer } from '../../../../../redux/restReducers/restReducer';
+import { UtbetalingerResponse } from '../../../../../models/utbetalinger';
+import { Person, PersonRespons } from '../../../../../models/person/person';
+import { YtelserKeys } from '../ytelserKeys';
+import HistoriskeUtbetalinger from './HistoriskeUtbetalinger';
+import { HistoriskUtbetaling } from '../../../../../models/ytelse/ytelse-utbetalinger';
+
+interface OwnProps {
+    ytelseType: YtelserKeys;
+    historiskeUtbetalinger: HistoriskUtbetaling[];
+}
+
+interface StateProps {
+    toÅrGamleUtbetalingerFraUtbetalingerRestkonto: RestReducer<UtbetalingerResponse>;
+    personInformasjon: RestReducer<PersonRespons>;
+}
+
+interface DispatchProps {
+    hentHistoriskeUtbetalinger: (fnr: string) => void;
+}
+
+type Props = DispatchProps & StateProps & OwnProps;
+
+class HistoriskeUtbetalingerContainer extends React.PureComponent<Props> {
+    constructor(props: Props) {
+        super(props);
+        this.hentAlleHistoriskeUtbetalinger = this.hentAlleHistoriskeUtbetalinger.bind(this);
+    }
+
+    hentAlleHistoriskeUtbetalinger() {
+        if (
+            isNotStarted(this.props.toÅrGamleUtbetalingerFraUtbetalingerRestkonto) &&
+            isLoaded(this.props.personInformasjon)
+        ) {
+            const fnr = (this.props.personInformasjon as Loaded<Person>).data.fødselsnummer;
+            this.props.hentHistoriskeUtbetalinger(fnr);
+        }
+    }
+
+    render() {
+        const toÅrGamleUtbetalingerFraUtbetalingerRestkonto = isLoaded(
+            this.props.toÅrGamleUtbetalingerFraUtbetalingerRestkonto
+        )
+            ? this.props.toÅrGamleUtbetalingerFraUtbetalingerRestkonto.data.utbetalinger
+            : null;
+        return (
+            <HistoriskeUtbetalinger
+                historiskeUtbetalinger={this.props.historiskeUtbetalinger}
+                ytelseType={this.props.ytelseType}
+                hentHistoriskeUtbetalinger={this.hentAlleHistoriskeUtbetalinger}
+                reducerStatus={this.props.toÅrGamleUtbetalingerFraUtbetalingerRestkonto.status}
+                toÅrGamleUtbetalingerFraUtbetalingerRestkonto={toÅrGamleUtbetalingerFraUtbetalingerRestkonto}
+            />
+        );
+    }
+}
+
+function mapStateToProops(state: AppState): StateProps {
+    return {
+        toÅrGamleUtbetalingerFraUtbetalingerRestkonto: state.restEndepunkter.historiskeUtbetalingerYtelser,
+        personInformasjon: state.restEndepunkter.personinformasjon
+    };
+}
+
+function mapDispatchToProps(dispatch: AsyncDispatch): DispatchProps {
+    return {
+        hentHistoriskeUtbetalinger: (fnr: string) => dispatch(hentHistoriskeUtbetalinger(fnr))
+    };
+}
+
+export default connect(
+    mapStateToProops,
+    mapDispatchToProps
+)(HistoriskeUtbetalingerContainer);

--- a/src/app/personside/infotabs/ytelser/utbetalinger/KommendeUtbetalingKomponent.test.tsx
+++ b/src/app/personside/infotabs/ytelser/utbetalinger/KommendeUtbetalingKomponent.test.tsx
@@ -1,0 +1,10 @@
+import * as React from 'react';
+import * as renderer from 'react-test-renderer';
+import { statiskKommendeUtbetaling } from '../../../../../mock/ytelse/statiskForeldrepengeMock';
+import KommendeUtbetalingKomponent from './KommendeUtbetalingKomponent';
+
+test('Kommende enkelutbetaling matcher snapshot', () => {
+    const result = renderer.create(<KommendeUtbetalingKomponent kommendeUtbetaling={statiskKommendeUtbetaling} />);
+
+    expect(result).toMatchSnapshot();
+});

--- a/src/app/personside/infotabs/ytelser/utbetalinger/KommendeUtbetalingKomponent.tsx
+++ b/src/app/personside/infotabs/ytelser/utbetalinger/KommendeUtbetalingKomponent.tsx
@@ -1,0 +1,45 @@
+import { KommendeUtbetaling } from '../../../../../models/ytelse/ytelse-utbetalinger';
+import { formaterDato } from '../../../../../utils/dateUtils';
+import { formaterNOK } from '../../utbetalinger/utils/utbetalingerUtils';
+import * as React from 'react';
+import { useState } from 'react';
+import DescriptionList from '../../../../../components/DescriptionList';
+import DetaljerCollapse from '../../../../../components/DetaljerCollapse';
+
+interface Props {
+    kommendeUtbetaling: KommendeUtbetaling;
+}
+
+function KommendeUtbetalingKomponent({ kommendeUtbetaling }: Props) {
+    const kommendeEntries = {
+        Registeringsdato: kommendeUtbetaling.utbetalingsdato && formaterDato(kommendeUtbetaling.utbetalingsdato),
+        Type: kommendeUtbetaling.type,
+        Periode:
+            kommendeUtbetaling.vedtak &&
+            `${formaterDato(kommendeUtbetaling.vedtak.fra)} - ${formaterDato(kommendeUtbetaling.vedtak.til)}`,
+        Utbetalingsgrad: kommendeUtbetaling.utbetalingsgrad && kommendeUtbetaling.utbetalingsgrad + '%'
+    };
+
+    const kommendeDetaljerEntries = {
+        Dagsats: kommendeUtbetaling.dagsats && formaterNOK(kommendeUtbetaling.dagsats) + ' NOK',
+        Bruttobeløp: kommendeUtbetaling.bruttobeløp && formaterNOK(kommendeUtbetaling.bruttobeløp) + ' NOK',
+        Arbeidsgiver: kommendeUtbetaling.arbeidsgiverNavn,
+        Organisasjonsnummer: kommendeUtbetaling.arbeidsgiverOrgNr,
+        'Saksbehandlerident (Tryde-ident)': kommendeUtbetaling.saksbehandler
+    };
+    const [visDetaljer, setVisDetaljer] = useState(false);
+    return (
+        <li aria-label={'Kommende utbetaling ' + kommendeEntries.Registeringsdato}>
+            <DetaljerCollapse
+                header={<DescriptionList entries={kommendeEntries} />}
+                alwaysGrayBackground={true}
+                open={visDetaljer}
+                toggle={() => setVisDetaljer(!visDetaljer)}
+            >
+                <DescriptionList entries={kommendeDetaljerEntries} />
+            </DetaljerCollapse>
+        </li>
+    );
+}
+
+export default KommendeUtbetalingKomponent;

--- a/src/app/personside/infotabs/ytelser/utbetalinger/KommendeUtbetalinger.tsx
+++ b/src/app/personside/infotabs/ytelser/utbetalinger/KommendeUtbetalinger.tsx
@@ -1,0 +1,38 @@
+import { KommendeUtbetaling } from '../../../../../models/ytelse/ytelse-utbetalinger';
+import * as React from 'react';
+import { AlertStripeInfo } from 'nav-frontend-alertstriper';
+import styled from 'styled-components';
+import { AlignTextCenter } from '../../../../../components/common-styled-components';
+import { Undertittel } from 'nav-frontend-typografi';
+import KommendeUtbetalingKomponent from './KommendeUtbetalingKomponent';
+
+interface Props {
+    kommendeUtbetalinger: KommendeUtbetaling[];
+}
+
+const Padding = styled.div`
+    padding: 0.5rem;
+`;
+
+function KommendeUtbetalinger(props: Props) {
+    const kommendeUtbetalinger = props.kommendeUtbetalinger.map((utbetaling, index) => (
+        <KommendeUtbetalingKomponent key={index} kommendeUtbetaling={utbetaling} />
+    ));
+
+    if (kommendeUtbetalinger.length === 0) {
+        return <AlertStripeInfo>Ingen kommende utbetalinger funnet</AlertStripeInfo>;
+    }
+
+    return (
+        <section>
+            <Padding>
+                <AlignTextCenter>
+                    <Undertittel tag="h4">Kommende utbetalinger</Undertittel>
+                </AlignTextCenter>
+            </Padding>
+            <ol>{kommendeUtbetalinger}</ol>
+        </section>
+    );
+}
+
+export default KommendeUtbetalinger;

--- a/src/app/personside/infotabs/ytelser/utbetalinger/Utbetalinger.test.tsx
+++ b/src/app/personside/infotabs/ytelser/utbetalinger/Utbetalinger.test.tsx
@@ -1,0 +1,19 @@
+import * as React from 'react';
+import * as renderer from 'react-test-renderer';
+import TestProvider from '../../../../../test/Testprovider';
+import Utbetalinger from './Utbetalinger';
+import { YtelserKeys } from '../ytelserKeys';
+
+test('Utbetalinger matcher snapshot', () => {
+    const result = renderer.create(
+        <TestProvider>
+            <Utbetalinger
+                kommendeUtbetalinger={[]}
+                historiskeUtbetalinger={[]}
+                ytelsesType={YtelserKeys.Foreldrepenger}
+            />
+        </TestProvider>
+    );
+
+    expect(result).toMatchSnapshot();
+});

--- a/src/app/personside/infotabs/ytelser/utbetalinger/Utbetalinger.tsx
+++ b/src/app/personside/infotabs/ytelser/utbetalinger/Utbetalinger.tsx
@@ -2,138 +2,35 @@ import * as React from 'react';
 import { HistoriskUtbetaling, KommendeUtbetaling } from '../../../../../models/ytelse/ytelse-utbetalinger';
 import styled from 'styled-components';
 import theme from '../../../../../styles/personOversiktTheme';
-import { Undertittel } from 'nav-frontend-typografi';
-import DescriptionList from '../../../../../components/DescriptionList';
-import { formaterDato } from '../../../../../utils/dateUtils';
-import { formaterNOK } from '../../utbetalinger/utils/utbetalingerUtils';
-import DetaljerCollapse from '../../../../../components/DetaljerCollapse';
-import { useState } from 'react';
-import { AlignTextCenter } from '../../../../../components/common-styled-components';
-import { AlertStripeInfo } from 'nav-frontend-alertstriper';
-import { getFormatertKreditortrekkFraHistoriskUtbetaling } from './utbetalingerUtils';
+import KommendeUtbetalinger from './KommendeUtbetalinger';
+import { YtelserKeys } from '../ytelserKeys';
+import HistoriskeUtbetalingerContainer from './HistoriskeUtbetalingerContainer';
+import ErrorBoundary from '../../../../../components/ErrorBoundary';
 
 interface Props {
     kommendeUtbetalinger: KommendeUtbetaling[];
     historiskeUtbetalinger: HistoriskUtbetaling[];
+    ytelsesType: YtelserKeys;
 }
 
-const Wrapper = styled.div`
+const StyledSection = styled.section`
     > * {
         margin: ${theme.margin.px10} 0;
     }
     margin-right: 1rem;
 `;
 
-const VedtaksListe = styled.ul`
-    list-style: none;
-`;
-
-const Padding = styled.div`
-    padding: 0.5rem;
-`;
-
-function HistoriskUtbetalingKomponent({ historiskUtbetaling }: { historiskUtbetaling: HistoriskUtbetaling }) {
-    const utbetaltEntries = {
-        Dato: historiskUtbetaling.utbetalingsdato && formaterDato(historiskUtbetaling.utbetalingsdato),
-        Type: historiskUtbetaling.type,
-        Periode:
-            historiskUtbetaling.vedtak &&
-            `${formaterDato(historiskUtbetaling.vedtak.fra)} - ${formaterDato(historiskUtbetaling.vedtak.til)}`,
-        Utbetalingsgrad: historiskUtbetaling.utbetalingsgrad && historiskUtbetaling.utbetalingsgrad + '%',
-        Netto: historiskUtbetaling.nettobeløp && formaterNOK(historiskUtbetaling.nettobeløp) + ' NOK',
-        Registeringsdato: historiskUtbetaling.utbetalingsdato && formaterDato(historiskUtbetaling.utbetalingsdato)
-    };
-    const utbetaltDetaljerEntries = {
-        Dagsats: historiskUtbetaling.dagsats && formaterNOK(historiskUtbetaling.dagsats),
-        Bruttobeløp: historiskUtbetaling.bruttobeløp && formaterNOK(historiskUtbetaling.bruttobeløp) + ' NOK',
-        Nettobeløp: historiskUtbetaling.nettobeløp && formaterNOK(historiskUtbetaling.nettobeløp) + ' NOK',
-        Arbeidsgiver: historiskUtbetaling.arbeidsgiverNavn,
-        Organisasjonsnummer: historiskUtbetaling.arbeidsgiverOrgNr,
-        Skattetrekk: historiskUtbetaling.skattetrekk,
-        Kreditortrekk: getFormatertKreditortrekkFraHistoriskUtbetaling(historiskUtbetaling)
-    };
-    const [visDetaljer, setVisDetaljer] = useState(false);
-    return (
-        <li>
-            <DetaljerCollapse
-                header={<DescriptionList entries={utbetaltEntries} />}
-                alwaysGrayBackground={true}
-                open={visDetaljer}
-                toggle={() => setVisDetaljer(!visDetaljer)}
-            >
-                <DescriptionList entries={utbetaltDetaljerEntries} />
-            </DetaljerCollapse>
-        </li>
-    );
-}
-
-function KommendeUtbetalingKomponent({ kommendeUtbetaling }: { kommendeUtbetaling: KommendeUtbetaling }) {
-    const kommendeEntries = {
-        Registeringsdato: kommendeUtbetaling.utbetalingsdato && formaterDato(kommendeUtbetaling.utbetalingsdato),
-        Type: kommendeUtbetaling.type,
-        Periode:
-            kommendeUtbetaling.vedtak &&
-            `${formaterDato(kommendeUtbetaling.vedtak.fra)} - ${formaterDato(kommendeUtbetaling.vedtak.til)}`,
-        Utbetalingsgrad: kommendeUtbetaling.utbetalingsgrad && kommendeUtbetaling.utbetalingsgrad + '%'
-    };
-
-    const kommendeDetaljerEntries = {
-        Dagsats: kommendeUtbetaling.dagsats && formaterNOK(kommendeUtbetaling.dagsats) + ' NOK',
-        Bruttobeløp: kommendeUtbetaling.bruttobeløp && formaterNOK(kommendeUtbetaling.bruttobeløp) + ' NOK',
-        Arbeidsgiver: kommendeUtbetaling.arbeidsgiverNavn,
-        Organisasjonsnummer: kommendeUtbetaling.arbeidsgiverOrgNr,
-        'Saksbehandlerident (Tryde-ident)': kommendeUtbetaling.saksbehandler
-    };
-    const [visDetaljer, setVisDetaljer] = useState(false);
-    return (
-        <li>
-            <DetaljerCollapse
-                header={<DescriptionList entries={kommendeEntries} />}
-                alwaysGrayBackground={true}
-                open={visDetaljer}
-                toggle={() => setVisDetaljer(!visDetaljer)}
-            >
-                <DescriptionList entries={kommendeDetaljerEntries} />
-            </DetaljerCollapse>
-        </li>
-    );
-}
-
 function Utbetalinger(props: Props) {
-    const kommendeUtbetalinger = props.kommendeUtbetalinger.map((utbetaling, index) => (
-        <KommendeUtbetalingKomponent key={index} kommendeUtbetaling={utbetaling} />
-    ));
-    const utførteUtbetalinger = props.historiskeUtbetalinger.map((utbetaling, index) => (
-        <HistoriskUtbetalingKomponent key={index} historiskUtbetaling={utbetaling} />
-    ));
-
     return (
-        <Wrapper>
-            <Padding>
-                <AlignTextCenter>
-                    <Undertittel tag="h4">Kommende utbetalinger</Undertittel>
-                </AlignTextCenter>
-            </Padding>
-            <VedtaksListe>
-                {kommendeUtbetalinger.length > 0 ? (
-                    kommendeUtbetalinger
-                ) : (
-                    <AlertStripeInfo>Ingen kommende utbetalinger funnet</AlertStripeInfo>
-                )}
-            </VedtaksListe>
-            <Padding>
-                <AlignTextCenter>
-                    <Undertittel tag="h4">Utførte utbetalinger</Undertittel>
-                </AlignTextCenter>
-            </Padding>
-            <VedtaksListe>
-                {utførteUtbetalinger.length > 0 ? (
-                    utførteUtbetalinger
-                ) : (
-                    <AlertStripeInfo>Ingen utførte utbetalinger funnet</AlertStripeInfo>
-                )}
-            </VedtaksListe>
-        </Wrapper>
+        <ErrorBoundary boundaryName="Utbetalinger Ytelser">
+            <StyledSection aria-label={'Utbetalinger ' + props.ytelsesType}>
+                <KommendeUtbetalinger kommendeUtbetalinger={props.kommendeUtbetalinger} />
+                <HistoriskeUtbetalingerContainer
+                    historiskeUtbetalinger={props.historiskeUtbetalinger}
+                    ytelseType={props.ytelsesType}
+                />
+            </StyledSection>
+        </ErrorBoundary>
     );
 }
 

--- a/src/app/personside/infotabs/ytelser/utbetalinger/__snapshots__/HistoriskUtbetalingKomponent.test.tsx.snap
+++ b/src/app/personside/infotabs/ytelser/utbetalinger/__snapshots__/HistoriskUtbetalingKomponent.test.tsx.snap
@@ -1,0 +1,219 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Historisk enkelutbetaling matcher snapshot 1`] = `
+.c4 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-box-pack: end;
+  -webkit-justify-content: flex-end;
+  -ms-flex-pack: end;
+  justify-content: flex-end;
+}
+
+.c5 {
+  position: relative;
+  border: none;
+  padding: 0;
+  border-radius: .35rem;
+  cursor: pointer;
+  background-color: transparent;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  color: #0067c5;
+}
+
+.c5:after {
+  border-bottom: 1px #B7B1A9 solid;
+  position: absolute;
+  bottom: 0;
+  left: 0;
+  width: 100%;
+}
+
+.c5:focus {
+  outline: none;
+  box-shadow: 0 0 0 0.1875rem #FFBD66;
+}
+
+.c5:hover {
+  opacity: 0.8;
+}
+
+.c5:hover:after {
+  content: '';
+  border-color: #0067C5;
+}
+
+.c6 {
+  margin-right: .5rem;
+}
+
+.c0 {
+  -webkit-transition: 0.5s;
+  transition: 0.5s;
+  padding: 1.25rem;
+  border-radius: 0.5rem;
+  background-color: #e9e7e7;
+  box-shadow: inset 0 0 0 .3rem white;
+  padding: 1.25rem;
+}
+
+.c7 {
+  -webkit-transition: 0.5s;
+  transition: 0.5s;
+  padding: 0 1.25rem;
+}
+
+.c2 {
+  margin-bottom: 1.25rem;
+}
+
+.c1 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-wrap: wrap;
+  -ms-flex-wrap: wrap;
+  flex-wrap: wrap;
+}
+
+.c1 dt {
+  color: #78706a;
+}
+
+.c1 dd {
+  font-weight: bold;
+  margin-top: 0.3rem;
+}
+
+.c1 > div {
+  margin: 0.9375rem 0;
+  padding-right: 1rem;
+  min-width: 13rem;
+}
+
+@media print {
+  .c3 {
+    display: none;
+  }
+}
+
+<li
+  aria-label="Utført utbetaling 26.01.2019"
+>
+  <div
+    className="c0"
+    open={false}
+  >
+    <dl
+      className="c1"
+    >
+      <div>
+        <dt
+          className="typo-etikett-liten"
+        >
+          Type
+        </dt>
+        <dd
+          className="typo-normal"
+        >
+          KONTOØVERFØRING
+        </dd>
+      </div>
+      <div>
+        <dt
+          className="typo-etikett-liten"
+        >
+          Netto
+        </dt>
+        <dd
+          className="typo-normal"
+        >
+          773.00 NOK
+        </dd>
+      </div>
+      <div>
+        <dt
+          className="typo-etikett-liten"
+        >
+          Dato
+        </dt>
+        <dd
+          className="typo-normal"
+        >
+          26.01.2019
+        </dd>
+      </div>
+      <div>
+        <dt
+          className="typo-etikett-liten"
+        >
+          Periode
+        </dt>
+        <dd
+          className="typo-normal"
+        >
+          09.02.2018 - 25.03.2018
+        </dd>
+      </div>
+      <div>
+        <dt
+          className="typo-etikett-liten"
+        >
+          Utbetalingsgrad
+        </dt>
+        <dd
+          className="typo-normal"
+        >
+          1%
+        </dd>
+      </div>
+    </dl>
+    <div
+      className="c2"
+    >
+      <div
+        className="c3"
+      >
+        <div
+          className="c4"
+        >
+          <button
+            aria-expanded={false}
+            className="c5"
+            onClick={[Function]}
+          >
+            <span
+              className="c6"
+            >
+              <span
+                className="typo-normal"
+              >
+                Vis
+                 
+                detaljer
+              </span>
+            </span>
+            <i
+              className="nav-frontend-chevron chevronboks chevron--ned"
+            />
+          </button>
+        </div>
+      </div>
+    </div>
+    <div
+      className="c7"
+      open={false}
+    />
+  </div>
+</li>
+`;

--- a/src/app/personside/infotabs/ytelser/utbetalinger/__snapshots__/KommendeUtbetalingKomponent.test.tsx.snap
+++ b/src/app/personside/infotabs/ytelser/utbetalinger/__snapshots__/KommendeUtbetalingKomponent.test.tsx.snap
@@ -1,0 +1,207 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Kommende enkelutbetaling matcher snapshot 1`] = `
+.c1 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-wrap: wrap;
+  -ms-flex-wrap: wrap;
+  flex-wrap: wrap;
+}
+
+.c1 dt {
+  color: #78706a;
+}
+
+.c1 dd {
+  font-weight: bold;
+  margin-top: 0.3rem;
+}
+
+.c1 > div {
+  margin: 0.9375rem 0;
+  padding-right: 1rem;
+  min-width: 13rem;
+}
+
+.c4 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-box-pack: end;
+  -webkit-justify-content: flex-end;
+  -ms-flex-pack: end;
+  justify-content: flex-end;
+}
+
+.c5 {
+  position: relative;
+  border: none;
+  padding: 0;
+  border-radius: .35rem;
+  cursor: pointer;
+  background-color: transparent;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  color: #0067c5;
+}
+
+.c5:after {
+  border-bottom: 1px #B7B1A9 solid;
+  position: absolute;
+  bottom: 0;
+  left: 0;
+  width: 100%;
+}
+
+.c5:focus {
+  outline: none;
+  box-shadow: 0 0 0 0.1875rem #FFBD66;
+}
+
+.c5:hover {
+  opacity: 0.8;
+}
+
+.c5:hover:after {
+  content: '';
+  border-color: #0067C5;
+}
+
+.c6 {
+  margin-right: .5rem;
+}
+
+.c0 {
+  -webkit-transition: 0.5s;
+  transition: 0.5s;
+  padding: 1.25rem;
+  border-radius: 0.5rem;
+  background-color: #e9e7e7;
+  box-shadow: inset 0 0 0 .3rem white;
+  padding: 1.25rem;
+}
+
+.c7 {
+  -webkit-transition: 0.5s;
+  transition: 0.5s;
+  padding: 0 1.25rem;
+}
+
+.c2 {
+  margin-bottom: 1.25rem;
+}
+
+@media print {
+  .c3 {
+    display: none;
+  }
+}
+
+<li
+  aria-label="Kommende utbetaling 25.06.2018"
+>
+  <div
+    className="c0"
+    open={false}
+  >
+    <dl
+      className="c1"
+    >
+      <div>
+        <dt
+          className="typo-etikett-liten"
+        >
+          Registeringsdato
+        </dt>
+        <dd
+          className="typo-normal"
+        >
+          25.06.2018
+        </dd>
+      </div>
+      <div>
+        <dt
+          className="typo-etikett-liten"
+        >
+          Type
+        </dt>
+        <dd
+          className="typo-normal"
+        >
+          KONTOØVERFØRING
+        </dd>
+      </div>
+      <div>
+        <dt
+          className="typo-etikett-liten"
+        >
+          Periode
+        </dt>
+        <dd
+          className="typo-normal"
+        >
+          14.01.2018 - 15.07.2017
+        </dd>
+      </div>
+      <div>
+        <dt
+          className="typo-etikett-liten"
+        >
+          Utbetalingsgrad
+        </dt>
+        <dd
+          className="typo-normal"
+        >
+          79%
+        </dd>
+      </div>
+    </dl>
+    <div
+      className="c2"
+    >
+      <div
+        className="c3"
+      >
+        <div
+          className="c4"
+        >
+          <button
+            aria-expanded={false}
+            className="c5"
+            onClick={[Function]}
+          >
+            <span
+              className="c6"
+            >
+              <span
+                className="typo-normal"
+              >
+                Vis
+                 
+                detaljer
+              </span>
+            </span>
+            <i
+              className="nav-frontend-chevron chevronboks chevron--ned"
+            />
+          </button>
+        </div>
+      </div>
+    </div>
+    <div
+      className="c7"
+      open={false}
+    />
+  </div>
+</li>
+`;

--- a/src/app/personside/infotabs/ytelser/utbetalinger/__snapshots__/Utbetalinger.test.tsx.snap
+++ b/src/app/personside/infotabs/ytelser/utbetalinger/__snapshots__/Utbetalinger.test.tsx.snap
@@ -1,0 +1,105 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Utbetalinger matcher snapshot 1`] = `
+.c2 {
+  text-align: center;
+}
+
+.c3 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+}
+
+.c1 {
+  padding: 0.5rem;
+}
+
+.c0 {
+  margin-right: 1rem;
+}
+
+.c0 > * {
+  margin: 0.625rem 0;
+}
+
+<section
+  aria-label="Utbetalinger Foreldrepenger"
+  className="c0"
+>
+  <div
+    className="alertstripe alertstripe--info"
+  >
+    <span
+      aria-label="info"
+      className="alertstripe__ikon"
+    >
+      <svg
+        focusable="false"
+        height="1.5em"
+        kind="info-sirkel-fyll"
+        viewBox="0 0 24 24"
+        width="1.5em"
+      >
+        <g
+          fill="none"
+          fillRule="evenodd"
+        >
+          <path
+            d="M12.205-.004l-.214.002a12.225 12.225 0 0 0-8.517 3.659C1.179 5.977-.053 9.013.002 12.208c.115 6.613 5.296 11.793 11.795 11.793l.212-.002c6.726-.116 12.105-5.595 11.99-12.21C23.883 5.178 18.702-.003 12.204-.003z"
+            fill="#FFA733"
+            fillRule="nonzero"
+          />
+          <path
+            d="M12.027 19H12A1.499 1.499 0 0 1 11.973 16L12 16a1.501 1.501 0 0 1 .027 3z"
+            fill="#3E3832"
+          />
+          <path
+            d="M12 5a1 1 0 0 1 1 1v7a1 1 0 0 1-2 0V6a1 1 0 0 1 1-1z"
+            fill="#3E3832"
+            fillRule="nonzero"
+          />
+        </g>
+      </svg>
+    </span>
+    <span
+      className="typo-normal alertstripe__tekst"
+    >
+      Ingen kommende utbetalinger funnet
+    </span>
+  </div>
+  <section>
+    <div
+      className="c1"
+    >
+      <div
+        className="c2"
+      >
+        <h4
+          className="typo-undertittel"
+        >
+          Utførte utbetalinger
+        </h4>
+      </div>
+    </div>
+    <ol />
+    <div
+      className="c3"
+    >
+      <button
+        className="knapp knapp--standard"
+        disabled={false}
+        onClick={[Function]}
+        type="submit"
+      >
+        Hent alle historiske utbetalinger
+      </button>
+    </div>
+  </section>
+</section>
+`;

--- a/src/app/personside/infotabs/ytelser/utbetalinger/utbetalingerUtils.test.ts
+++ b/src/app/personside/infotabs/ytelser/utbetalinger/utbetalingerUtils.test.ts
@@ -1,7 +1,11 @@
 import { HistoriskUtbetaling } from '../../../../../models/ytelse/ytelse-utbetalinger';
 import { getHistoriskUtbetaling } from '../../../../../mock/ytelse/ytelse-utbetalinger-mock';
 import faker from 'faker/locale/nb_NO';
-import { getFormatertKreditortrekkFraHistoriskUtbetaling } from './utbetalingerUtils';
+import {
+    getFormatertKreditortrekkFraHistoriskUtbetaling,
+    mapUtbetlaingerTilHistoriskeUtbetalinger
+} from './utbetalingerUtils';
+import { statiskMockUtbetaling, statiskMockYtelse } from '../../../../../mock/statiskMockUtbetaling';
 
 test('Beregner riktig kreditortrekk fra historisk utbetaling', () => {
     faker.seed(1234);
@@ -10,16 +14,52 @@ test('Beregner riktig kreditortrekk fra historisk utbetaling', () => {
         trekk: [
             {
                 kreditorsNavn: 'KnusOgKneskålAS',
-                beløp: 50,
+                beløp: 50
             },
             {
                 kreditorsNavn: 'iKreditt.no',
-                beløp: 100,
-            },
-        ],
+                beløp: 100
+            }
+        ]
     };
 
     const result = getFormatertKreditortrekkFraHistoriskUtbetaling(historiskUtbetaling);
 
-    expect(result).toContain('150.00 NOK');
+    expect(result).toBe('150.00 NOK');
+});
+
+describe('Tomt kreditortrekk gir tom streng', () => {
+    test('ved tomt array', () => {
+        faker.seed(1234);
+        const historiskUtbetaling: HistoriskUtbetaling = {
+            ...getHistoriskUtbetaling(faker),
+            trekk: []
+        };
+
+        const result = getFormatertKreditortrekkFraHistoriskUtbetaling(historiskUtbetaling);
+
+        expect(result).toBe('');
+    });
+    test('ved null', () => {
+        faker.seed(1234);
+        const historiskUtbetaling: HistoriskUtbetaling = {
+            ...getHistoriskUtbetaling(faker),
+            trekk: null
+        };
+
+        const result = getFormatertKreditortrekkFraHistoriskUtbetaling(historiskUtbetaling);
+
+        expect(result).toBe('');
+    });
+});
+
+test('Mapper utbetaling til historiske utbetalinger', () => {
+    const result = mapUtbetlaingerTilHistoriskeUtbetalinger([
+        {
+            ...statiskMockUtbetaling,
+            ytelser: [statiskMockYtelse, statiskMockYtelse]
+        }
+    ]);
+
+    expect(result).toHaveLength(2);
 });

--- a/src/app/personside/infotabs/ytelser/utbetalinger/utbetalingerUtils.test.ts
+++ b/src/app/personside/infotabs/ytelser/utbetalinger/utbetalingerUtils.test.ts
@@ -3,7 +3,7 @@ import { getHistoriskUtbetaling } from '../../../../../mock/ytelse/ytelse-utbeta
 import faker from 'faker/locale/nb_NO';
 import {
     getFormatertKreditortrekkFraHistoriskUtbetaling,
-    mapUtbetlaingerTilHistoriskeUtbetalinger
+    mapUtbetalingerTilHistoriskeUtbetalinger
 } from './utbetalingerUtils';
 import { statiskMockUtbetaling, statiskMockYtelse } from '../../../../../mock/statiskMockUtbetaling';
 
@@ -54,7 +54,7 @@ describe('Tomt kreditortrekk gir tom streng', () => {
 });
 
 test('Mapper utbetaling til historiske utbetalinger', () => {
-    const result = mapUtbetlaingerTilHistoriskeUtbetalinger([
+    const result = mapUtbetalingerTilHistoriskeUtbetalinger([
         {
             ...statiskMockUtbetaling,
             ytelser: [statiskMockYtelse, statiskMockYtelse]

--- a/src/app/personside/infotabs/ytelser/utbetalinger/utbetalingerUtils.ts
+++ b/src/app/personside/infotabs/ytelser/utbetalinger/utbetalingerUtils.ts
@@ -1,10 +1,79 @@
 import { HistoriskUtbetaling, KreditorTrekk } from '../../../../../models/ytelse/ytelse-utbetalinger';
-import { formaterNOK } from '../../utbetalinger/utils/utbetalingerUtils';
+import {
+    flatMapYtelser,
+    formaterNOK,
+    getBruttoSumYtelser,
+    getNettoSumYtelser,
+    getTypeFromYtelse,
+    reduceUtbetlingerTilYtelser
+} from '../../utbetalinger/utils/utbetalingerUtils';
+import { Utbetaling, Ytelse } from '../../../../../models/utbetalinger';
+import { YtelserKeys } from '../ytelserKeys';
 
 export function getFormatertKreditortrekkFraHistoriskUtbetaling(historiskUtbetaling: HistoriskUtbetaling): string {
-    if (!historiskUtbetaling.trekk) {
+    if (!historiskUtbetaling.trekk || historiskUtbetaling.trekk.length === 0) {
         return '';
     }
     const trekkSummert = historiskUtbetaling.trekk.reduce((acc: number, trekk: KreditorTrekk) => acc + trekk.beløp, 0);
     return formaterNOK(trekkSummert) + ' NOK';
+}
+
+export function mapUtbetlaingerTilHistoriskeUtbetalinger(utbetalinger: Utbetaling[]): HistoriskUtbetaling[] {
+    return utbetalinger.reduce(
+        (acc: HistoriskUtbetaling[], utbetaling: Utbetaling) => [
+            ...acc,
+            ...mapUtbetalingTilHistoriskeUtbetalinger(utbetaling)
+        ],
+        []
+    );
+}
+
+function mapUtbetalingTilHistoriskeUtbetalinger(utbetaling: Utbetaling): HistoriskUtbetaling[] {
+    const alleTilhørendeYtelser = flatMapYtelser([utbetaling]);
+    return alleTilhørendeYtelser.map(ytelse => mapYtelseTilHistoriskUtbetaling(ytelse, utbetaling));
+}
+
+function mapYtelseTilHistoriskUtbetaling(ytelse: Ytelse, utbetaling: Utbetaling): HistoriskUtbetaling {
+    const nettoSum = getNettoSumYtelser([ytelse]);
+    const bruttoSum = getBruttoSumYtelser([ytelse]);
+    return {
+        vedtak: {
+            fra: ytelse.periode.start,
+            til: ytelse.periode.slutt
+        },
+        utbetalingsgrad: null,
+        utbetalingsdato: utbetaling.utbetalingsdato,
+        nettobeløp: nettoSum,
+        bruttobeløp: bruttoSum,
+        skattetrekk: ytelse.skattsum,
+        arbeidsgiverNavn: null,
+        arbeidsgiverOrgNr: null,
+        dagsats: null,
+        type: ytelse.type,
+        trekk: mapTrekkTilKreditortrekk(ytelse)
+    };
+}
+
+function mapTrekkTilKreditortrekk(ytelse: Ytelse): null | KreditorTrekk[] {
+    if (!ytelse.trekkListe) {
+        return null;
+    }
+    return ytelse.trekkListe.map(trekk => {
+        return {
+            kreditorsNavn: trekk.kreditor || '',
+            beløp: trekk.trekkbeløp
+        };
+    });
+}
+
+export function fjernUrelevanteUtbetalinger(relevantYtelse: YtelserKeys) {
+    return (utbetaling: Utbetaling) => {
+        const ytelser = reduceUtbetlingerTilYtelser([utbetaling]).filter(
+            ytelse => relevantYtelse === getTypeFromYtelse(ytelse)
+        );
+        return {
+            ...utbetaling,
+            ytelser: ytelser
+        };
+    };
 }

--- a/src/app/personside/infotabs/ytelser/utbetalinger/utbetalingerUtils.ts
+++ b/src/app/personside/infotabs/ytelser/utbetalinger/utbetalingerUtils.ts
@@ -18,7 +18,7 @@ export function getFormatertKreditortrekkFraHistoriskUtbetaling(historiskUtbetal
     return formaterNOK(trekkSummert) + ' NOK';
 }
 
-export function mapUtbetlaingerTilHistoriskeUtbetalinger(utbetalinger: Utbetaling[]): HistoriskUtbetaling[] {
+export function mapUtbetalingerTilHistoriskeUtbetalinger(utbetalinger: Utbetaling[]): HistoriskUtbetaling[] {
     return utbetalinger.reduce(
         (acc: HistoriskUtbetaling[], utbetaling: Utbetaling) => [
             ...acc,

--- a/src/app/personside/infotabs/ytelser/ytelserKeys.ts
+++ b/src/app/personside/infotabs/ytelser/ytelserKeys.ts
@@ -1,0 +1,5 @@
+// Brukes til å finne ut hvilke utbetalinger fra UtbetalingerRestkonto som tilhører disse ytelsene, må matche kodeverk
+export enum YtelserKeys {
+    Foreldrepenger = 'Foreldrepenger',
+    Sykepenger = 'Sykepenger'
+}

--- a/src/mock/ytelse/statiskForeldrepengeMock.ts
+++ b/src/mock/ytelse/statiskForeldrepengeMock.ts
@@ -1,5 +1,38 @@
 import { Fødsel } from '../../models/ytelse/foreldrepenger';
 
+export const statiskHistoriskUtbetaling = {
+    vedtak: { fra: '2018-02-09', til: '2018-03-25' },
+    utbetalingsgrad: 1,
+    utbetalingsdato: '2019-01-26',
+    nettobeløp: 773,
+    bruttobeløp: 291,
+    skattetrekk: 45,
+    arbeidsgiverNavn: 'Kristoffersen RFH',
+    arbeidsgiverOrgNr: '1234567890',
+    dagsats: 616,
+    type: 'KONTOØVERFØRING',
+    trekk: [
+        {
+            kreditorsNavn: 'Andresen, Finstad and Kristoffersen',
+            beløp: 117
+        },
+        { kreditorsNavn: 'Aas, Berntsen and Jacobsen', beløp: 397 }
+    ]
+};
+
+export const statiskKommendeUtbetaling = {
+    vedtak: { fra: '2018-01-14', til: '2017-07-15' },
+    utbetalingsgrad: 79,
+    utbetalingsdato: '2018-06-25',
+    bruttobeløp: 466,
+    arbeidsgiverNavn: 'Vedvik - Lunde',
+    arbeidsgiverOrgNr: '1234567890',
+    arbeidsgiverKontonr: '549801574',
+    dagsats: 705,
+    saksbehandler: 'Mari Johannessen',
+    type: 'KONTOØVERFØRING'
+};
+
 export const statiskForeldrepengeMock: Fødsel = {
     forelder: '10108000398',
     andreForeldersFnr: '03063850003',
@@ -35,41 +68,8 @@ export const statiskForeldrepengeMock: Fødsel = {
             rettTilFedrekvote: 'Rett til fedrekvote',
             rettTilMødrekvote: 'Ingen rett til mødrekvote',
             stansårsak: 'Avsluttet',
-            historiskeUtbetalinger: [
-                {
-                    vedtak: { fra: '2018-02-09', til: '2018-03-25' },
-                    utbetalingsgrad: 1,
-                    utbetalingsdato: '2019-01-26',
-                    nettobeløp: 773,
-                    bruttobeløp: 291,
-                    skattetrekk: 45,
-                    arbeidsgiverNavn: 'Kristoffersen RFH',
-                    arbeidsgiverOrgNr: '1234567890',
-                    dagsats: 616,
-                    type: 'KONTOØVERFØRING',
-                    trekk: [
-                        {
-                            kreditorsNavn: 'Andresen, Finstad and Kristoffersen',
-                            beløp: 117
-                        },
-                        { kreditorsNavn: 'Aas, Berntsen and Jacobsen', beløp: 397 }
-                    ]
-                }
-            ],
-            kommendeUtbetalinger: [
-                {
-                    vedtak: { fra: '2018-01-14', til: '2017-07-15' },
-                    utbetalingsgrad: 79,
-                    utbetalingsdato: '2018-06-25',
-                    bruttobeløp: 466,
-                    arbeidsgiverNavn: 'Vedvik - Lunde',
-                    arbeidsgiverOrgNr: '1234567890',
-                    arbeidsgiverKontonr: '549801574',
-                    dagsats: 705,
-                    saksbehandler: 'Mari Johannessen',
-                    type: 'KONTOØVERFØRING'
-                }
-            ]
+            historiskeUtbetalinger: [statiskHistoriskUtbetaling],
+            kommendeUtbetalinger: [statiskKommendeUtbetaling]
         }
     ],
     slutt: null,

--- a/src/models/ytelse/ytelse-utbetalinger.ts
+++ b/src/models/ytelse/ytelse-utbetalinger.ts
@@ -1,42 +1,42 @@
 import { Periode } from '../periode';
 
 export interface HistoriskUtbetaling {
-    vedtak?: Periode;
-    utbetalingsgrad?: number;
-    utbetalingsdato?: string;
-    nettobeløp?: number;
-    bruttobeløp?: number;
-    skattetrekk?: number;
-    arbeidsgiverNavn?: string;
-    arbeidsgiverOrgNr?: string;
-    dagsats?: number;
-    type?: string;
-    trekk?: KreditorTrekk[];
+    vedtak: null | Periode;
+    utbetalingsgrad: null | number;
+    utbetalingsdato: null | string;
+    nettobeløp: null | number;
+    bruttobeløp: null | number;
+    skattetrekk: null | number;
+    arbeidsgiverNavn: null | string;
+    arbeidsgiverOrgNr: null | string;
+    dagsats: null | number;
+    type: null | string;
+    trekk: null | KreditorTrekk[];
 }
 
 export interface KommendeUtbetaling {
-    vedtak?: Periode;
-    utbetalingsgrad?: number;
-    utbetalingsdato?: string;
-    bruttobeløp?: number;
-    arbeidsgiverNavn?: string;
-    arbeidsgiverKontonr?: string;
-    arbeidsgiverOrgNr?: string;
-    dagsats?: number;
-    saksbehandler?: string;
-    type?: string;
+    vedtak: null | Periode;
+    utbetalingsgrad: null | number;
+    utbetalingsdato: null | string;
+    bruttobeløp: null | number;
+    arbeidsgiverNavn: null | string;
+    arbeidsgiverKontonr: null | string;
+    arbeidsgiverOrgNr: null | string;
+    dagsats: null | number;
+    saksbehandler: null | string;
+    type: null | string;
 }
 
 export interface UtbetalingPåVent {
-    vedtak?: Periode;
-    utbetalingsgrad?: number;
-    oppgjørstype?: string;
-    arbeidskategori?: string;
-    stansårsak?: string;
-    ferie1?: Periode;
-    ferie2?: Periode;
-    sanksjon?: Periode;
-    sykmeldt?: Periode;
+    vedtak: null | Periode;
+    utbetalingsgrad: null | number;
+    oppgjørstype: null | string;
+    arbeidskategori: null | string;
+    stansårsak: null | string;
+    ferie1: null | Periode;
+    ferie2: null | Periode;
+    sanksjon: null | Periode;
+    sykmeldt: null | Periode;
 }
 
 export interface KreditorTrekk {

--- a/src/redux/restReducers/personinformasjon.ts
+++ b/src/redux/restReducers/personinformasjon.ts
@@ -10,8 +10,9 @@ import { resetPleiepengerReducer } from './ytelser/pleiepenger';
 import { resetForeldrepengerReducer } from './ytelser/foreldrepenger';
 import { erGyldigFødselsnummer } from 'nav-faker/dist/personidentifikator/helpers/fodselsnummer-utils';
 import { AsyncDispatch } from '../ThunkTypes';
+import { resetHistoriskeUtbetalingerReducer } from './ytelser/historiskeUtbetalinger';
 
-const {reducer, action, actionNames, reload} = createActionsAndReducer('personinformasjon');
+const { reducer, action, actionNames, reload } = createActionsAndReducer('personinformasjon');
 
 function hentPerson(fødselsnummer: string) {
     return action(() => getPerson(fødselsnummer));
@@ -34,6 +35,7 @@ export function hentAllPersonData(dispatch: AsyncDispatch, fødselsnummer: strin
     dispatch(resetSykepengerReducer());
     dispatch(resetPleiepengerReducer());
     dispatch(resetForeldrepengerReducer());
+    dispatch(resetHistoriskeUtbetalingerReducer());
 }
 
 export const personinformasjonActionNames = actionNames;

--- a/src/redux/restReducers/restReducers.ts
+++ b/src/redux/restReducers/restReducers.ts
@@ -22,6 +22,7 @@ import utbetalingerReducer from './utbetalinger';
 import sykepengerReducer from './ytelser/sykepenger';
 import pleiepengerReducer from './ytelser/pleiepenger';
 import foreldrepengerReducer from './ytelser/foreldrepenger';
+import historiskeUtbetalingerReducer from './ytelser/historiskeUtbetalinger';
 import oppfolgingReducer from './oppfolging';
 import saksoversiktReducer from './saksoversikt';
 import { PersonRespons } from '../../models/person/person';
@@ -63,6 +64,7 @@ export interface RestEndepunkter {
     utbetalingerReducer: RestReducer<UtbetalingerResponse>;
     sykepengerReducer: RestReducer<SykepengerResponse>;
     pleiepengerReducer: RestReducer<PleiepengerResponse>;
+    historiskeUtbetalingerYtelser: RestReducer<UtbetalingerResponse>;
     foreldrepengerReducer: RestReducer<ForeldrepengerResponse>;
     oppfolgingReducer: RestReducer<Oppfolging>;
     saksoversiktReducer: RestReducer<SakstemaResponse>;
@@ -90,6 +92,7 @@ export default combineReducers<RestEndepunkter>({
     utbetalingerReducer: utbetalingerReducer,
     sykepengerReducer: sykepengerReducer,
     pleiepengerReducer: pleiepengerReducer,
+    historiskeUtbetalingerYtelser: historiskeUtbetalingerReducer,
     foreldrepengerReducer: foreldrepengerReducer,
     oppfolgingReducer: oppfolgingReducer,
     saksoversiktReducer: saksoversiktReducer

--- a/src/redux/restReducers/ytelser/historiskeUtbetalinger.ts
+++ b/src/redux/restReducers/ytelser/historiskeUtbetalinger.ts
@@ -1,0 +1,23 @@
+import { createActionsAndReducer } from '../restReducer';
+import { getUtbetalinger } from '../../../api/utbetaling-api';
+import moment from 'moment';
+
+const { reducer, action, tilbakestillReducer } = createActionsAndReducer('historiskeUtbetalingerYtelser');
+
+export function hentHistoriskeUtbetalinger(fødselsnummer: string) {
+    return action(() =>
+        getUtbetalinger(
+            fødselsnummer,
+            moment()
+                .add(-2, 'year')
+                .toDate(),
+            new Date()
+        )
+    );
+}
+
+export function resetHistoriskeUtbetalingerReducer() {
+    return tilbakestillReducer;
+}
+
+export default reducer;

--- a/src/utils/dateUtils.test.ts
+++ b/src/utils/dateUtils.test.ts
@@ -3,7 +3,8 @@ import {
     erImorgenEllerSenere,
     erMaksEttÅrFramITid,
     formaterDato,
-    genericAscendingDateComparator
+    genericAscendingDateComparator,
+    genericDescendingDateComparator
 } from './dateUtils';
 
 Date.now = jest.fn(() => new Date()); // for å motvirke Date.now() mock i setupTests.ts
@@ -16,7 +17,6 @@ it('Formaterer dato på backend-format til ønsket visningsformat', () => {
 });
 
 describe('dato erImorgenEllerSenere', () => {
-
     it('Dagens dato', () => {
         expect(erImorgenEllerSenere(new Date())).toEqual(false);
     });
@@ -26,11 +26,9 @@ describe('dato erImorgenEllerSenere', () => {
         date.setFullYear(3000);
         expect(erImorgenEllerSenere(date)).toEqual(true);
     });
-
 });
 
 describe('dato erMaksEttÅrFramITid', () => {
-
     it('Dagens dato', () => {
         expect(erMaksEttÅrFramITid(new Date())).toEqual(true);
     });
@@ -40,7 +38,6 @@ describe('dato erMaksEttÅrFramITid', () => {
         date.setFullYear(3000);
         expect(erMaksEttÅrFramITid(date)).toEqual(false);
     });
-
 });
 
 describe('Sorterer etter dato', () => {
@@ -56,10 +53,21 @@ describe('Sorterer etter dato', () => {
         interface MockObject {
             date: string | Date;
         }
-        const datoA: MockObject = {date: '2012-01-01'};
-        const datoB: MockObject = {date: new Date('2000-01-01')};
+        const datoA: MockObject = { date: '2012-01-01' };
+        const datoB: MockObject = { date: new Date('2000-01-01') };
         const sortedDates = [datoA, datoB].sort(genericAscendingDateComparator(object => object.date));
 
-        expect(sortedDates[sortedDates.length - 1]).toEqual(datoA);
+        expect(sortedDates[0]).toEqual(datoB);
+    });
+
+    it('Generic descending comparator', () => {
+        interface MockObject {
+            date: string | Date;
+        }
+        const datoA: MockObject = { date: '2012-01-01' };
+        const datoB: MockObject = { date: new Date('2000-01-01') };
+        const sortedDates = [datoA, datoB].sort(genericDescendingDateComparator(object => object.date));
+
+        expect(sortedDates[0]).toEqual(datoA);
     });
 });

--- a/src/utils/dateUtils.ts
+++ b/src/utils/dateUtils.ts
@@ -27,10 +27,14 @@ export function getAlderFromFødselsnummer(fødselsnummer: string) {
     return moment().diff(navfaker.personIdentifikator.getFødselsdato(fødselsnummer), 'years');
 }
 
-export function ascendingDateComparator (a: Date, b: Date) {
+export function ascendingDateComparator(a: Date, b: Date) {
     return a > b ? 1 : -1;
 }
 
 export function genericAscendingDateComparator<T>(getDate: (element: T) => Date | string) {
     return (a: T, b: T): number => ascendingDateComparator(new Date(getDate(a)), new Date(getDate(b)));
+}
+
+export function genericDescendingDateComparator<T>(getDate: (element: T) => Date | string) {
+    return (a: T, b: T): number => -ascendingDateComparator(new Date(getDate(a)), new Date(getDate(b)));
 }


### PR DESCRIPTION
Bruker data fra UtbetalingerRestkonto for å lage historiske utbetalinger for Foreldrepenger og Sykepenger som går 2 år tilbake i tid.

Dette kallet er ganske treigt, og det gjøres derfor ikke før bruker trykker på knapp for å hente alle historiske utbetalinger.
Utbetalinger filtreres dermed for å finne utbetalinger som matcher den aktuelle ytelsen og mappes deretter om til HistoriskUtbetaling