### PR TITLE
OPP-723 Visning av dato i totalt utbetalt og begrensninger på datovelger

### DIFF
--- a/src/api/utbetaling-api.ts
+++ b/src/api/utbetaling-api.ts
@@ -2,20 +2,24 @@ import { UtbetalingerResponse } from '../models/utbetalinger';
 import { apiBaseUri } from './config';
 import moment from 'moment';
 
+export const tidligsteTilgjengeligeDatoUtbetalingerRestkonto = moment()
+    .subtract(5, 'year')
+    .startOf('year')
+    .toDate();
+
 export function getUtbetalinger(
     fodselsnummer: string,
     startDato: Date,
-    sluttDato: Date)
-: Promise<UtbetalingerResponse> {
+    sluttDato: Date
+): Promise<UtbetalingerResponse> {
     const fra = moment(startDato).format('YYYY-MM-DD');
     const til = moment(sluttDato).format('YYYY-MM-DD');
     const uri = `${apiBaseUri}/utbetaling/${fodselsnummer}?startDato=${fra}&sluttDato=${til}`;
-    return fetch(uri, {credentials: 'include'})
-        .then((response) => {
-            if (response.ok) {
-                return response.json();
-            } else {
-                throw response.statusText;
-            }
-        });
+    return fetch(uri, { credentials: 'include' }).then(response => {
+        if (response.ok) {
+            return response.json();
+        } else {
+            throw response.statusText;
+        }
+    });
 }

--- a/src/app/personside/infotabs/utbetalinger/__snapshots__/UtbetalingerContainer.test.tsx.snap
+++ b/src/app/personside/infotabs/utbetalinger/__snapshots__/UtbetalingerContainer.test.tsx.snap
@@ -51,11 +51,11 @@ exports[`Viser utbetalingercontainer med alt innhold 1`] = `
 }
 
 .c5 > *:first-child {
-  margin-bottom: .5rem;
+  margin-bottom: 0.5rem;
 }
 
 .c5 > * {
-  margin-top: .5rem;
+  margin-top: 0.5rem;
 }
 
 .c7 {
@@ -69,7 +69,7 @@ exports[`Viser utbetalingercontainer med alt innhold 1`] = `
 }
 
 .c6 > *:first-child {
-  margin-bottom: .8rem;
+  margin-bottom: 0.8rem;
 }
 
 .c6 > *:last-child {

--- a/src/app/personside/infotabs/utbetalinger/totalt utbetalt/TotaltUtbetalt.tsx
+++ b/src/app/personside/infotabs/utbetalinger/totalt utbetalt/TotaltUtbetalt.tsx
@@ -30,25 +30,25 @@ interface State {
 }
 
 const Wrapper = styled.article`
-  ${theme.hvittPanel};
-  cursor: pointer;
+    ${theme.hvittPanel};
+    cursor: pointer;
 `;
 
 const Header = styled.div`
-  padding: ${theme.margin.px20} ${theme.margin.px20} 0;
+    padding: ${theme.margin.px20} ${theme.margin.px20} 0;
 `;
 
 const TotaltUtbetaltOversikt = styled.section`
-  margin: 1rem 0;
-  th {
-    font-weight: normal;
-  }
-  th {
-    text-transform: uppercase;
-  }
-  td {
-    font-weight: bold;
-  }
+    margin: 1rem 0;
+    th {
+        font-weight: normal;
+    }
+    th {
+        text-transform: uppercase;
+    }
+    td {
+        font-weight: bold;
+    }
 `;
 
 class TotaltUtbetalt extends React.PureComponent<TotaltUtbetaltProps, State> {
@@ -57,7 +57,7 @@ class TotaltUtbetalt extends React.PureComponent<TotaltUtbetaltProps, State> {
 
     constructor(props: TotaltUtbetaltProps) {
         super(props);
-        this.state = {visDetaljer: false};
+        this.state = { visDetaljer: false };
         this.toggleVisDetaljer = this.toggleVisDetaljer.bind(this);
         this.handlePrint = this.handlePrint.bind(this);
     }
@@ -86,38 +86,34 @@ class TotaltUtbetalt extends React.PureComponent<TotaltUtbetaltProps, State> {
     }
 
     render() {
-        const periode: string =
-            formaterDato(this.props.periode.startDato)
-            + ' - '
-            + formaterDato(this.props.periode.sluttDato);
+        const sluttDato =
+            new Date(this.props.periode.sluttDato) > new Date() ? new Date() : this.props.periode.sluttDato;
+        const periode: string = formaterDato(this.props.periode.startDato) + ' - ' + formaterDato(sluttDato);
         const brutto: string = summertBeløpStringFraUtbetalinger(this.props.utbetalinger, getBruttoSumYtelser);
         const trekk: string = summertBeløpStringFraUtbetalinger(this.props.utbetalinger, getTrekkSumYtelser);
         const utbetalt: string = summertBeløpStringFraUtbetalinger(this.props.utbetalinger, getNettoSumYtelser);
         const totaltUtbetaltTabell = createTable(
             ['Totalt Utbetalt', 'Brutto', 'Trekk', 'Utbetalt'],
-            [[periode, brutto, trekk, utbetalt]]);
+            [[periode, brutto, trekk, utbetalt]]
+        );
 
         return (
-            <Printer getPrintTrigger={trigger => this.print = trigger}>
+            <Printer getPrintTrigger={trigger => (this.print = trigger)}>
                 <Wrapper
                     aria-label="Totalt utbetalt"
                     onClick={(event: React.MouseEvent<HTMLElement>) =>
-                        cancelIfHighlighting(
-                            () => this.handleClickOnUtbetaling(event)
-                        )
+                        cancelIfHighlighting(() => this.handleClickOnUtbetaling(event))
                     }
                 >
                     <UtbetalingTabellStyling>
                         <Header>
                             <Undertittel>Totalt utbetalt for perioden</Undertittel>
                             <TotaltUtbetaltOversikt>
-                                <Normaltekst tag="span">
-                                    {totaltUtbetaltTabell}
-                                </Normaltekst>
+                                <Normaltekst tag="span">{totaltUtbetaltTabell}</Normaltekst>
                             </TotaltUtbetaltOversikt>
                             <FlexEnd>
                                 <span ref={this.printerButtonRef}>
-                                    <PrintKnapp onClick={this.handlePrint}/>
+                                    <PrintKnapp onClick={this.handlePrint} />
                                 </span>
                             </FlexEnd>
                         </Header>


### PR DESCRIPTION
For å fange opp utbetalinger frem i tid vil det ved valg av "SISTE 30 DAGER" og "INNEVÆRENDE ÅR" bli søkt også 100 dager fremover i tid.
I frontenden ønsker vi ikke å vise dette i periode-visningen da det kan være forvirrende å se en dato 100 dager frem i tid.
Legger derfor til logikk som vil vise dagens dato dersom sluttdato er frem i tid.

Legger også til begrensninger og feilmeldinger på datovalg slik at man ikke kan velge datoer frem i tid eller mer enn fem år tilbake i tid fom 1 januar da betalinger lenger tilbake i tid ikke er tilgjengelig fra tjenesten.