### PR TITLE
Bugfix/opp 756

### DIFF
--- a/src/app/personside/infotabs/oppfolging/OppfolgingDetaljerKomponent.tsx
+++ b/src/app/personside/infotabs/oppfolging/OppfolgingDetaljerKomponent.tsx
@@ -29,7 +29,7 @@ function VisOppfolgingDetaljer(props: Props) {
     const detaljer = props.detaljertOppfølging;
     const arbeidsrettetOppfølging = detaljer.oppfølging.erUnderOppfølging ? 'Ja' : 'Nei';
     const oppfølgingsenhet = `${detaljer.oppfølging.enhet.id} ${detaljer.oppfølging.enhet.navn}`;
-    const meldeplikt = detaljer.meldeplikt ? 'Ja' : 'Nei';
+    const meldeplikt = detaljer.meldeplikt ? 'Ja' : detaljer.meldeplikt === false ? 'Nei' : 'Meldeplikt Ukjent';
     const descriptionListProps = {
         'Er under oppfølging': arbeidsrettetOppfølging,
         Oppfølgingsenhet: oppfølgingsenhet,

--- a/src/app/personside/infotabs/oppfolging/OppfolgingVedtakKomponent.tsx
+++ b/src/app/personside/infotabs/oppfolging/OppfolgingVedtakKomponent.tsx
@@ -37,8 +37,7 @@ function VedtakElement(props: { vedtak: OppfolgingsVedtak }) {
     const descriptionListItems = {
         [datoInterval]: props.vedtak.vedtakstype,
         Status: props.vedtak.vedtakstatus,
-        Aktivitetsfase: props.vedtak.aktivitetsfase,
-        Vedtaksdato: props.vedtak.vedtaksdato
+        Aktivitetsfase: props.vedtak.aktivitetsfase
     };
 
     return (

--- a/src/app/personside/infotabs/oppfolging/OppfolgingYtelserEkspanderbartPanel.tsx
+++ b/src/app/personside/infotabs/oppfolging/OppfolgingYtelserEkspanderbartPanel.tsx
@@ -35,26 +35,26 @@ const ElementStyle = styled.div`
 function OppfolgingYtelserListe(props: { ytelser: OppfolgingsYtelse[] }) {
     const sortertPåDato = props.ytelser.sort(genericDescendingDateComparator(ytelse => ytelse.datoKravMottatt));
 
-    const listekomponenter = sortertPåDato.map(ytelse => <YtelseElement ytselse={ytelse} />);
+    const listekomponenter = sortertPåDato.map(ytelse => <YtelseElement ytelse={ytelse} />);
 
     return <ListeStyle>{listekomponenter}</ListeStyle>;
 }
 
-function YtelseElement(props: { ytselse: OppfolgingsYtelse }) {
+function YtelseElement(props: { ytelse: OppfolgingsYtelse }) {
     const descriptionListProps = {
-        status: props.ytselse.status,
-        'Dato søknad mottatt': props.ytselse.datoKravMottatt,
-        'Dato fra': props.ytselse.fom,
-        'Dato til': props.ytselse.tom,
-        'Dager igjen': props.ytselse.dagerIgjenMedBortfall,
-        'Uker igjen': props.ytselse.ukerIgjenMedBortfall
+        Status: props.ytelse.status,
+        'Dato søknad mottatt': props.ytelse.datoKravMottatt,
+        'Dato fra': props.ytelse.fom,
+        'Dato til': props.ytelse.tom,
+        'Dager igjen': props.ytelse.dagerIgjenMedBortfall,
+        'Uker igjen': props.ytelse.ukerIgjenMedBortfall
     };
     return (
         <ElementStyle>
-            <Undertittel>{props.ytselse.type}</Undertittel>
+            <Undertittel>{props.ytelse.type}</Undertittel>
             <YtelsePanelStyle>
                 <DescriptionList entries={descriptionListProps} />
-                <OppfolgingsVedtakListe ytelseVedtak={props.ytselse.vedtak} />
+                <OppfolgingsVedtakListe ytelseVedtak={props.ytelse.vedtak} />
             </YtelsePanelStyle>
         </ElementStyle>
     );

--- a/src/mock/oppfolging-mock.ts
+++ b/src/mock/oppfolging-mock.ts
@@ -42,7 +42,7 @@ export function getMockYtelserOgKontrakter(fødselsnummer: string): DetaljertOpp
 
     return {
         oppfølging: getMockOppfølging(fødselsnummer),
-        meldeplikt: faker.random.boolean(),
+        meldeplikt: false,
         formidlingsgruppe: 'FMGRP' + faker.random.number(5),
         innsatsgruppe: 'INGRP' + faker.random.number(10),
         sykemeldtFra: moment(faker.date.recent(10)).format(backendDatoformat),
@@ -85,7 +85,6 @@ function getVedtak(): OppfolgingsVedtak {
     return {
         aktivFra: moment(faker.date.recent(40)).format(backendDatoformat),
         aktivTil: moment(faker.date.recent(20)).format(backendDatoformat),
-        vedtaksdato: moment(faker.date.recent(20)).format(backendDatoformat),
         aktivitetsfase: 'Ikke spesif. aktivitetsfase',
         vedtakstatus: navfaker.random.arrayElement(['Iverksatt', 'Avsluttet']),
         vedtakstype: 'Vedtak: Ordinære dagpenger'

--- a/src/mock/oppfolging-mock.ts
+++ b/src/mock/oppfolging-mock.ts
@@ -42,7 +42,7 @@ export function getMockYtelserOgKontrakter(fødselsnummer: string): DetaljertOpp
 
     return {
         oppfølging: getMockOppfølging(fødselsnummer),
-        meldeplikt: false,
+        meldeplikt: faker.random.boolean(),
         formidlingsgruppe: 'FMGRP' + faker.random.number(5),
         innsatsgruppe: 'INGRP' + faker.random.number(10),
         sykemeldtFra: moment(faker.date.recent(10)).format(backendDatoformat),

--- a/src/models/oppfolging.ts
+++ b/src/models/oppfolging.ts
@@ -47,7 +47,6 @@ export interface OppfolgingsYtelse {
 export interface OppfolgingsVedtak {
     aktivFra: string;
     aktivTil: string;
-    vedtaksdato: string;
     aktivitetsfase?: string;
     vedtakstatus: string;
     vedtakstype: string;


### PR DESCRIPTION
- Meldeplikt == null skal behandles ulikt fra meldeplikt ==false 
- Vedtaksdato skal ikke benyttes (var ikke i bruk i gamle oppfølging)
- Rettet skrivefeil i datoKravMotatt (Dato Søknad Motatt) - her kommer en tilsvarende endring i modiabrukerdialog straks.