### PR TITLE
trekker inn svg-er fra less for å unngå problem i modiabrukerdialog

### DIFF
--- a/src/app/personside/dialogpanel/fortsettDialog/__snapshots__/FortsettDialog.test.tsx.snap
+++ b/src/app/personside/dialogpanel/fortsettDialog/__snapshots__/FortsettDialog.test.tsx.snap
@@ -1,50 +1,12 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`viser fortsett dialog 1`] = `
-.c3 .snakkeboble-panel {
-  -webkit-flex-basis: 70%;
-  -ms-flex-preferred-size: 70%;
-  flex-basis: 70%;
-}
-
-.c3 .nav-ikon,
-.c3 .bruker-ikon {
-  background-size: contain;
-  background-repeat: no-repeat;
-  background-position-y: 0.5rem;
-}
-
-.c3 .nav-ikon {
-  background-image: url(navlogo.svg);
-  width: 3.5rem;
-}
-
-.c3 .bruker-ikon {
-  background-image: url(bruker.svg);
-  width: 2.5rem;
-}
-
 .c2 {
   margin-bottom: 1rem;
 }
 
 .c2 .ekspanderbartPanel__hode {
   padding: 0.6rem;
-}
-
-.c5 label {
-  position: absolute !important;
-  height: 1px;
-  width: 1px;
-  overflow: hidden;
-  -webkit-clip: rect(1px 1px 1px 1px);
-  clip: rect(1px 1px 1px 1px);
-  -webkit-clip: rect(1px,1px,1px,1px);
-  clip: rect(1px,1px,1px,1px);
-}
-
-.c4 textarea {
-  min-height: 9rem;
 }
 
 .c4 label {
@@ -58,7 +20,11 @@ exports[`viser fortsett dialog 1`] = `
   clip: rect(1px,1px,1px,1px);
 }
 
-.c7 label {
+.c3 textarea {
+  min-height: 9rem;
+}
+
+.c3 label {
   position: absolute !important;
   height: 1px;
   width: 1px;
@@ -69,15 +35,26 @@ exports[`viser fortsett dialog 1`] = `
   clip: rect(1px,1px,1px,1px);
 }
 
-.c9 .ekspanderbartPanel__hode {
+.c6 label {
+  position: absolute !important;
+  height: 1px;
+  width: 1px;
+  overflow: hidden;
+  -webkit-clip: rect(1px 1px 1px 1px);
+  clip: rect(1px 1px 1px 1px);
+  -webkit-clip: rect(1px,1px,1px,1px);
+  clip: rect(1px,1px,1px,1px);
+}
+
+.c8 .ekspanderbartPanel__hode {
   padding: 0.6rem;
 }
 
-.c11 > *:not(:first-child) {
+.c10 > *:not(:first-child) {
   margin-top: 0.3rem;
 }
 
-.c10 {
+.c9 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -87,7 +64,7 @@ exports[`viser fortsett dialog 1`] = `
   flex-direction: column;
 }
 
-.c10 > * {
+.c9 > * {
   margin-top: 0.5rem;
 }
 
@@ -114,7 +91,7 @@ exports[`viser fortsett dialog 1`] = `
   margin-bottom: 1rem;
 }
 
-.c6 > *:not(:first-child) {
+.c5 > *:not(:first-child) {
   margin-top: 1rem;
 }
 
@@ -122,7 +99,7 @@ exports[`viser fortsett dialog 1`] = `
   padding: 1rem .8rem;
 }
 
-.c8 {
+.c7 {
   margin-top: 1rem;
 }
 
@@ -166,7 +143,7 @@ exports[`viser fortsett dialog 1`] = `
         className="ekspanderbartPanel__innhold"
       >
         <div
-          className="c3"
+          className="snakkeboble_ikoner"
         >
           <div
             className="snakkeboble snakkeboble--hoyre"
@@ -214,7 +191,7 @@ exports[`viser fortsett dialog 1`] = `
           </div>
         </div>
         <div
-          className="c3"
+          className="snakkeboble_ikoner"
         >
           <div
             className="snakkeboble snakkeboble--venstre"
@@ -262,7 +239,7 @@ exports[`viser fortsett dialog 1`] = `
           </div>
         </div>
         <div
-          className="c3"
+          className="snakkeboble_ikoner"
         >
           <div
             className="snakkeboble snakkeboble--venstre"
@@ -310,7 +287,7 @@ exports[`viser fortsett dialog 1`] = `
           </div>
         </div>
         <div
-          className="c3"
+          className="snakkeboble_ikoner"
         >
           <div
             className="snakkeboble snakkeboble--hoyre"
@@ -360,7 +337,7 @@ exports[`viser fortsett dialog 1`] = `
       </article>
     </div>
     <div
-      className="c4"
+      className="c3"
     >
       <div
         className="skjemaelement textarea__container"
@@ -413,7 +390,7 @@ exports[`viser fortsett dialog 1`] = `
     </div>
     <div>
       <div
-        className="skjemaelement c5"
+        className="skjemaelement c4"
       >
         <label
           className="skjemaelement__label"
@@ -501,7 +478,7 @@ exports[`viser fortsett dialog 1`] = `
         </div>
       </div>
       <fieldset
-        className="c6"
+        className="c5"
       >
         <div
           className="skjemaelement skjemaelement--horisontal"
@@ -529,7 +506,7 @@ exports[`viser fortsett dialog 1`] = `
         className=""
       >
         <div
-          className="skjemaelement c7"
+          className="skjemaelement c6"
         >
           <label
             className="skjemaelement__label"
@@ -592,14 +569,14 @@ exports[`viser fortsett dialog 1`] = `
       </div>
     </div>
     <button
-      className="knapp c8 knapp--hoved"
+      className="knapp c7 knapp--hoved"
       disabled={false}
       type="submit"
     >
       Del med Aremark
     </button>
     <div
-      className="ekspanderbartPanel c9 ekspanderbartPanel--lukket ekspanderbartPanel--border"
+      className="ekspanderbartPanel c8 ekspanderbartPanel--lukket ekspanderbartPanel--border"
     >
       <button
         aria-expanded={false}
@@ -626,10 +603,10 @@ exports[`viser fortsett dialog 1`] = `
         className="ekspanderbartPanel__innhold"
       >
         <div
-          className="c10"
+          className="c9"
         >
           <fieldset
-            className="c11"
+            className="c10"
           >
             <legend
               className="sr-only"
@@ -676,7 +653,7 @@ exports[`viser fortsett dialog 1`] = `
               className=""
             >
               <div
-                className="skjemaelement c7"
+                className="skjemaelement c6"
               >
                 <label
                   className="skjemaelement__label"

--- a/src/app/personside/infotabs/meldinger/traadvisning/Enkeltmelding.tsx
+++ b/src/app/personside/infotabs/meldinger/traadvisning/Enkeltmelding.tsx
@@ -5,33 +5,11 @@ import { Element, Normaltekst } from 'nav-frontend-typografi';
 import { erMeldingFraNav } from '../utils/meldingerUtils';
 import { meldingstypeTekst, temagruppeTekst } from '../utils/meldingstekster';
 import { formatterDatoTid } from '../../../../../utils/dateUtils';
-import styled from 'styled-components';
-import navlogo from '../../../../../svg/navlogo.svg';
-import brukerikon from '../../../../../svg/bruker.svg';
+import './enkeltmelding.less';
 
 interface Props {
     melding: Melding;
 }
-
-const Style = styled.div`
-    .snakkeboble-panel {
-        flex-basis: 70%;
-    }
-    .nav-ikon,
-    .bruker-ikon {
-        background-size: contain;
-        background-repeat: no-repeat;
-        background-position-y: 0.5rem;
-    }
-    .nav-ikon {
-        background-image: url(${navlogo});
-        width: 3.5rem;
-    }
-    .bruker-ikon {
-        background-image: url(${brukerikon});
-        width: 2.5rem;
-    }
-`;
 
 function meldingstittel(melding: Melding) {
     const ulestTekst = melding.status === LestStatus.IkkeLest ? 'Ulest, ' : '';
@@ -50,7 +28,7 @@ function EnkeltMelding(props: Props) {
     const skrevetAv = saksbehandlerTekst(props.melding.skrevetAv);
 
     return (
-        <Style>
+        <div className="snakkeboble_ikoner">
             <Snakkeboble pilHoyre={fraNav} ikonClass={fraNav ? 'nav-ikon' : 'bruker-ikon'}>
                 <Element>{topptekst}</Element>
                 <Normaltekst>{datoTekst}</Normaltekst>
@@ -58,7 +36,7 @@ function EnkeltMelding(props: Props) {
                 <hr />
                 <Normaltekst>{props.melding.fritekst}</Normaltekst>
             </Snakkeboble>
-        </Style>
+        </div>
     );
 }
 

--- a/src/app/personside/infotabs/meldinger/traadvisning/enkeltmelding.less
+++ b/src/app/personside/infotabs/meldinger/traadvisning/enkeltmelding.less
@@ -1,0 +1,19 @@
+.snakkeboble_ikoner {
+    .snakkeboble-panel {
+        flex-basis: 70%;
+    }
+    .nav-ikon,
+    .bruker-ikon {
+        background-size: contain;
+        background-repeat: no-repeat;
+        background-position-y: 0.5rem;
+    }
+    .nav-ikon {
+        background-image: url('../../../../../svg/navlogo.svg');
+        width: 3.5rem;
+    }
+    .bruker-ikon {
+        background-image: url('../../../../../svg/bruker.svg');
+        width: 2.5rem;
+    }
+}


### PR DESCRIPTION
svg'ene blir pr nå ikke med i biblioteket, dette førte til at bygget til modiabrukerdialog krasjet pga at den prøvde å trekke inn svg fra en js-fil
nå trekker vi svg inn via less istedenfor, less blir ikke pakket med i biblioteket heller og derfor prøver aldri modiabrukerdialog å trekke inn svg'en
komponenten som benytter svg brukes ikke i modiabrukerdialog, løser det derfor på denne måten, litt hacky, men hele problemstillingen forsvinner snart når vi lanserer nye personoversikten