### PR TITLE
Bughunt/justeringmeldinger

### DIFF
--- a/src/app/personside/infotabs/meldinger/traadvisning/Enkeltmelding.tsx
+++ b/src/app/personside/infotabs/meldinger/traadvisning/Enkeltmelding.tsx
@@ -6,10 +6,15 @@ import { erMeldingFraNav } from '../utils/meldingerUtils';
 import { meldingstypeTekst, temagruppeTekst } from '../utils/meldingstekster';
 import { formatterDatoTid } from '../../../../../utils/dateUtils';
 import Tekstomrade from 'nav-frontend-tekstomrade';
+import styled from 'styled-components';
 
 interface Props {
     melding: Melding;
 }
+
+const SnakkebobleWrapper = styled.div`
+    text-align: left;
+`;
 
 function meldingstittel(melding: Melding) {
     const lestTekst = melding.status === LestStatus.Lest ? 'Lest,' : 'Ulest,';
@@ -30,11 +35,13 @@ function EnkeltMelding(props: Props) {
     return (
         <div className="snakkeboble_ikoner">
             <Snakkeboble pilHoyre={fraNav} ikonClass={fraNav ? 'nav-ikon' : 'bruker-ikon'}>
-                <Element>{topptekst}</Element>
-                <Normaltekst>{datoTekst}</Normaltekst>
-                <Normaltekst>Skrevet av: {skrevetAv}</Normaltekst>
-                <hr />
-                <Tekstomrade>{props.melding.fritekst}</Tekstomrade>
+                <SnakkebobleWrapper>
+                    <Element>{topptekst}</Element>
+                    <Normaltekst>{datoTekst}</Normaltekst>
+                    <Normaltekst>Skrevet av: {skrevetAv}</Normaltekst>
+                    <hr />
+                    <Tekstomrade>{props.melding.fritekst}</Tekstomrade>
+                </SnakkebobleWrapper>
             </Snakkeboble>
         </div>
     );

--- a/src/app/personside/infotabs/oversikt/__snapshots__/Oversikt.test.tsx.snap
+++ b/src/app/personside/infotabs/oversikt/__snapshots__/Oversikt.test.tsx.snap
@@ -345,7 +345,7 @@ exports[`Viser oversikt med alt innhold 1`] = `
                 <p
                   className="typo-normal"
                 >
-                  5. Juli 2018
+                  6. Juli 2018
                    / 
                   Ligger hos banken
                 </p>
@@ -361,9 +361,9 @@ exports[`Viser oversikt med alt innhold 1`] = `
                 <p
                   className="typo-normal"
                 >
-                  17.06.2015
+                  18.06.2015
                    - 
-                  16.12.2016
+                  17.12.2016
                 </p>
                 <p
                   className="typo-normal"
@@ -394,7 +394,7 @@ exports[`Viser oversikt med alt innhold 1`] = `
                 <p
                   className="typo-normal"
                 >
-                  25. Juli 2017
+                  26. Juli 2017
                    / 
                   Ligger hos banken
                 </p>
@@ -410,9 +410,9 @@ exports[`Viser oversikt med alt innhold 1`] = `
                 <p
                   className="typo-normal"
                 >
-                  24.01.2016
+                  25.01.2016
                    - 
-                  05.05.2018
+                  06.05.2018
                 </p>
                 <p
                   className="typo-normal"
@@ -443,7 +443,7 @@ exports[`Viser oversikt med alt innhold 1`] = `
                 <p
                   className="typo-normal"
                 >
-                  4. Desember 2016
+                  5. Desember 2016
                    / 
                   Returnert til NAV for saksbehandling
                 </p>
@@ -459,9 +459,9 @@ exports[`Viser oversikt med alt innhold 1`] = `
                 <p
                   className="typo-normal"
                 >
-                  20.05.2015
+                  21.05.2015
                    - 
-                  21.11.2014
+                  22.11.2014
                 </p>
                 <p
                   className="typo-normal"


### PR DESCRIPTION
Fra bughunt: All skrift skal venstrestilles i traad. kommende endringer kan være større margin for å tydliggjøre at det er for forskjellige snakkebobler