### PR TITLE
[OPP-954] Infomelding dersom alle meldinger er journalfort

### DIFF
--- a/src/app/personside/infotabs/meldinger/MeldingerContainer.tsx
+++ b/src/app/personside/infotabs/meldinger/MeldingerContainer.tsx
@@ -14,7 +14,7 @@ import { MeldingerDyplenkeRouteComponentProps, useInfotabsDyplenker, useValgtTra
 import { withRouter } from 'react-router';
 import TraadVisning from './traadvisning/TraadVisning';
 import Verktoylinje from './traadvisning/verktoylinje/Verktoylinje';
-import { AlertStripeAdvarsel, AlertStripeInfo } from 'nav-frontend-alertstriper';
+import { AlertStripeInfo } from 'nav-frontend-alertstriper';
 import { ScrollBar, scrollBarContainerStyle } from '../utils/InfoTabsScrollBar';
 import { useSokEtterMeldinger } from './utils/meldingerUtils';
 
@@ -43,7 +43,7 @@ const MeldingerArticleStyle = styled.article`
 
 function TraadVisningWrapper(props: TraadVisningWrapperProps) {
     if (props.traaderEtterSok.length === 0) {
-        return <AlertStripeAdvarsel>Søket ga ingen treff på meldinger</AlertStripeAdvarsel>;
+        return <AlertStripeInfo>Søket ga ingen treff på meldinger</AlertStripeInfo>;
     }
     return (
         <>

--- a/src/app/personside/infotabs/meldinger/traadvisning/verktoylinje/journalforing/JournalforingPanel.tsx
+++ b/src/app/personside/infotabs/meldinger/traadvisning/verktoylinje/journalforing/JournalforingPanel.tsx
@@ -3,6 +3,9 @@ import styled from 'styled-components';
 import VelgSak from './VelgSak';
 import { JournalforSak } from './JournalforSak';
 import { Traad } from '../../../../../../../models/meldinger/meldinger';
+import { erEldsteMeldingJournalfort } from '../../../utils/meldingerUtils';
+import { AlertStripeInfo } from 'nav-frontend-alertstriper';
+import { Hovedknapp } from 'nav-frontend-knapper';
 
 export enum SakKategori {
     FAG = 'Fagsaker',
@@ -44,9 +47,16 @@ const Container = styled.section`
     margin-top: 1rem;
 `;
 
+const Margin = styled.div`
+    > * {
+        margin-top: 1rem;
+    }
+`;
+
 function JournalforingPanel(props: Props) {
     const [aktivtVindu, setAktivtVindu] = useState<AktivtVindu>(AktivtVindu.SAKLISTE);
     const [valgtSak, setValgtSak] = useState<JournalforingsSak>();
+    const erJournalfort = erEldsteMeldingJournalfort(props.traad);
 
     function velgSak(sak: JournalforingsSak) {
         setAktivtVindu(AktivtVindu.SAKVISNING);
@@ -56,6 +66,15 @@ function JournalforingPanel(props: Props) {
     const tilbake = () => {
         setAktivtVindu(AktivtVindu.SAKLISTE);
     };
+
+    if (erJournalfort) {
+        return (
+            <Margin>
+                <AlertStripeInfo>Tråden er allerede journalført</AlertStripeInfo>
+                <Hovedknapp onClick={props.lukkPanel}>Lukk</Hovedknapp>
+            </Margin>
+        );
+    }
 
     if (aktivtVindu === AktivtVindu.SAKVISNING && valgtSak !== undefined) {
         return <JournalforSak traad={props.traad} sak={valgtSak} tilbake={tilbake} lukkPanel={props.lukkPanel} />;

--- a/src/mock/meldinger/meldinger-mock.ts
+++ b/src/mock/meldinger/meldinger-mock.ts
@@ -44,7 +44,9 @@ function getMelding(temagruppe: Temagruppe): Melding {
         temagruppe: temagruppe,
         skrevetAv: getSaksbehandler(),
         journalfortAv: getSaksbehandler(),
-        journalfortDato: moment(faker.date.recent(50)).format(backendDatoformat),
+        journalfortDato: navfaker.random.vektetSjanse(0.5)
+            ? moment(faker.date.recent(50)).format(backendDatoformat)
+            : undefined,
         journalfortSaksid: faker.random.alphaNumeric(5),
         journalfortTemanavn: navfaker.random.arrayElement(['Dagpenger', 'Arbeid', 'Pensjon', 'Bidrag']),
         fritekst: faker.lorem.sentences(4),


### PR DESCRIPTION
<img width="721" alt="Screen Shot 2019-10-04 at 12 34 55 PM" src="https://user-images.githubusercontent.com/11627538/66201342-6e886100-e6a3-11e9-953f-aea02e7872d8.png">

Velger å legge inn en melding til brukeren om at tråden er journalfort fordi jeg synes det gir en bedre tilbakemelding og forståelse. Å kun disable knappen kan skape forvirring ettersom de ikke får vite hvorfor den er disablet.