### PR TITLE
bruker nav-frontend-alertstripe istedenfor hjemmelaget løsning i kont…

### DIFF
--- a/src/app/personside/kontrollsporsmal/Kontrollsporsmal.tsx
+++ b/src/app/personside/kontrollsporsmal/Kontrollsporsmal.tsx
@@ -26,7 +26,8 @@ interface DispatchProps {
 type Props = DispatchProps & StateProps;
 
 const KontrollSporsmalStyling = styled.section`
-    ${theme.hvittPanel};
+    background-color: white;
+    box-shadow: 0 0 0.5rem rgba(0, 0, 0, 0.1), 0 0 0 1px rgba(0, 0, 0, 0.1);
     padding: ${theme.margin.px20};
     margin-bottom: 0.5rem;
     display: -ms-grid;

--- a/src/app/personside/kontrollsporsmal/SporsmalOgSvar.tsx
+++ b/src/app/personside/kontrollsporsmal/SporsmalOgSvar.tsx
@@ -4,7 +4,7 @@ import { Normaltekst, Undertittel } from 'nav-frontend-typografi';
 import { Bold } from '../../../components/common-styled-components';
 import { Spørsmål } from '../../../redux/kontrollSporsmal/types';
 import theme, { pxToRem } from '../../../styles/personOversiktTheme';
-import UtropstegnPlain from '../../../svg/UtropstegnPlain';
+import { AlertStripeAdvarsel } from 'nav-frontend-alertstriper';
 
 interface Props {
     spørsmål: Spørsmål;
@@ -41,15 +41,8 @@ const Luft = styled.div`
     margin-bottom: 1rem;
 `;
 
-const Feilmelding = styled.div`
-    align-items: center;
-    justify-content: center;
-    display: flex;
-    svg {
-        height: ${theme.margin.px30};
-        width: auto;
-        margin-right: ${theme.margin.px10};
-    }
+const IngenKontrollspørsmålStyling = styled(AlertStripeAdvarsel)`
+    margin-right: 1rem;
 `;
 
 class SpørsmålOgSvar extends React.PureComponent<Props> {
@@ -84,10 +77,9 @@ function lagSvar(spørsmål: Spørsmål) {
 
 export function FeilTekst() {
     return (
-        <Feilmelding>
-            <UtropstegnPlain />
-            <Normaltekst>Det finnes ingen opplysninger som kan brukes til å stille kontrollspørsmål</Normaltekst>
-        </Feilmelding>
+        <IngenKontrollspørsmålStyling>
+            Vi fant ingen opplysninger som kan brukes til å stille kontrollspørsmål
+        </IngenKontrollspørsmålStyling>
     );
 }
 


### PR DESCRIPTION
…rollspørsmål, pluss småstyling

Var ikke helt i henhold til nav-frontend:
Før:
![image](https://user-images.githubusercontent.com/29202094/67394388-5f127e80-f5a4-11e9-8704-dcd40d46be30.png)

Etter:
![image](https://user-images.githubusercontent.com/29202094/67394395-63d73280-f5a4-11e9-827f-5b223de4e979.png)
