### PR TITLE
refetcher tildelte oppgaver etter at henvendelse er opprettet

### DIFF
--- a/src/app/personside/dialogpanel/fortsettDialog/useOpprettHenvendelse.tsx
+++ b/src/app/personside/dialogpanel/fortsettDialog/useOpprettHenvendelse.tsx
@@ -21,10 +21,13 @@ type OpprettHenvendelseStatus = NotFinishedOpprettHenvendelseStatus | FinishedOp
 
 function useOpprettHenvendelse(traad: Traad): OpprettHenvendelseStatus {
     const opprettHenvendelseResource = useRestResource(resources => resources.opprettHenvendelse);
+    const reloadTildelteOppgaver = useRestResource(resources => resources.tildelteOppgaver.actions.reload);
     const dispatch = useDispatch();
 
     useOnMount(function getBehandlingsId() {
-        dispatch(opprettHenvendelseResource.actions.post({ traadId: traad.traadId }));
+        dispatch(
+            opprettHenvendelseResource.actions.post({ traadId: traad.traadId }, () => dispatch(reloadTildelteOppgaver))
+        );
         return () => {
             dispatch(opprettHenvendelseResource.actions.reset);
         };


### PR DESCRIPTION
når man oppretter en ny henvendelse på en tråd vil backenden sjekke om
det finnes en oppgave på tråden. Hvis det finnes vil saksbehandler bli
tildelt oppgaven når man trykker "Ny melding" (eller egnetlig når ny
henvendelse blir opprettet). For at oppgaven skal bli
ferdigstilt når man til slutt svarer på meldingen må frontenden sende med
oppgaveId, og for å få tilgang på den må tildelte oppgaver refetches da
det er der oppgaveId ligger.