### PR TITLE
Forslag til hvordan vi raskere kan gi saksbehandlere info om bruker

### DIFF
--- a/src/app/personside/Personside.tsx
+++ b/src/app/personside/Personside.tsx
@@ -1,36 +1,17 @@
 import * as React from 'react';
-import AlertStripe from 'nav-frontend-alertstriper';
-import { erPersonResponsAvTypeBegrensetTilgang, PersonRespons } from '../../models/person/person';
+import { erPersonResponsAvTypeBegrensetTilgang } from '../../models/person/person';
 import MainLayout from './MainLayout';
-import FillCenterAndFadeIn from '../../components/FillCenterAndFadeIn';
 import BegrensetTilgangSide from './BegrensetTilgangSide';
-import RestResourceConsumer from '../../rest/consumer/RestResourceConsumer';
-import { CenteredLazySpinner } from '../../components/LazySpinner';
-
-const onError = (
-    <FillCenterAndFadeIn>
-        <AlertStripe type="advarsel">Beklager. Det skjedde en feil ved lasting av persondata.</AlertStripe>
-    </FillCenterAndFadeIn>
-);
+import { useRestResource } from '../../utils/customHooks';
+import { hasData } from '../../rest/utils/restResource';
 
 function Personside() {
-    function getSideinnhold(personResource: PersonRespons) {
-        if (erPersonResponsAvTypeBegrensetTilgang(personResource)) {
-            return <BegrensetTilgangSide person={personResource} />;
-        } else {
-            return <MainLayout />;
-        }
+    const personResource = useRestResource(resources => resources.personinformasjon);
+    if (hasData(personResource) && erPersonResponsAvTypeBegrensetTilgang(personResource.data)) {
+        return <BegrensetTilgangSide person={personResource.data} />;
+    } else {
+        return <MainLayout />;
     }
-
-    return (
-        <RestResourceConsumer<PersonRespons>
-            getResource={restResources => restResources.personinformasjon}
-            returnOnError={onError}
-            returnOnPending={<CenteredLazySpinner type="XXL" />}
-        >
-            {data => getSideinnhold(data)}
-        </RestResourceConsumer>
-    );
 }
 
 export default Personside;

--- a/src/app/personside/kontrollsporsmal/Kontrollsporsmal.tsx
+++ b/src/app/personside/kontrollsporsmal/Kontrollsporsmal.tsx
@@ -4,8 +4,6 @@ import theme from '../../../styles/personOversiktTheme';
 import KontrollSpørsmålKnapper from './KontrollSpørsmålKnapper';
 import SpørsmålOgSvar from './SporsmalOgSvarContainer';
 import HandleKontrollSporsmalHotkeys from './HandleKontrollSporsmalHotkeys';
-import IfFeatureToggleOn from '../../../components/featureToggle/IfFeatureToggleOn';
-import { FeatureToggles } from '../../../components/featureToggle/toggleIDs';
 import { jobberMedSpørsmålOgSvar, kontrollspørsmålHarBlittLukketForBruker } from './cookieUtils';
 import { erKontaktsenter } from '../../../utils/loggInfo/saksbehandlersEnhetInfo';
 import { useAppState, useFødselsnummer, useRestResource } from '../../../utils/customHooks';
@@ -34,6 +32,12 @@ const KontrollSporsmalStyling = styled.section`
     }
 `;
 
+const SpinnerWrapper = styled(FillCenterAndFadeIn)`
+    background-color: white;
+    height: 7rem;
+    margin-bottom: 0.5rem;
+`;
+
 function Kontrollsporsmal() {
     const visKontrollSpørsmål = useAppState(state => state.kontrollSpørsmål.open);
     const fnr = useFødselsnummer();
@@ -50,14 +54,14 @@ function Kontrollsporsmal() {
 
     if (isLoading(personResource)) {
         return (
-            <FillCenterAndFadeIn>
+            <SpinnerWrapper>
                 <LazySpinner />
-            </FillCenterAndFadeIn>
+            </SpinnerWrapper>
         );
     }
 
     return (
-        <IfFeatureToggleOn toggleID={FeatureToggles.Kontrollspørsmål}>
+        <>
             <KontrollSporsmalStyling role="region" aria-label="Visittkort-hode">
                 <h2 className={'visually-hidden'}>Kontrollspørsmål</h2>
                 <div className="innhold">
@@ -68,7 +72,7 @@ function Kontrollsporsmal() {
                 </div>
             </KontrollSporsmalStyling>
             <HandleKontrollSporsmalHotkeys />
-        </IfFeatureToggleOn>
+        </>
     );
 }
 

--- a/src/app/personside/visittkort/VisittkortContainer.tsx
+++ b/src/app/personside/visittkort/VisittkortContainer.tsx
@@ -1,12 +1,9 @@
 import * as React from 'react';
-import { connect } from 'react-redux';
-import { Person, PersonRespons } from '../../../models/person/person';
+import { Person } from '../../../models/person/person';
 import VisittkortHeader from './header/VisittkortHeader';
 import VisittkortBody from './body/VisittkortBody';
 import ErrorBoundary from '../../../components/ErrorBoundary';
 import HandleVisittkortHotkeys from './HandleVisittkortHotkeys';
-import { AppState } from '../../../redux/reducers';
-import { toggleVisittkort } from '../../../redux/uiReducers/UIReducer';
 import { UnmountClosed } from 'react-collapse';
 import AriaNotification from '../../../components/AriaNotification';
 import styled from 'styled-components';
@@ -14,70 +11,75 @@ import theme from '../../../styles/personOversiktTheme';
 import { erNyePersonoversikten } from '../../../utils/erNyPersonoversikt';
 import HandleVisittkortHotkeysGamlemodia from './HandleVisittkortHotkeysGamlemodia';
 import { loggSkjermInfoDaglig } from '../../../utils/loggInfo/loggSkjermInfoDaglig';
-import { AsyncDispatch } from '../../../redux/ThunkTypes';
-import { HasData } from '../../../rest/utils/restResource';
-
-interface StateProps {
-    visittkortErApent: boolean;
-    person: Person;
-}
-
-interface DispatchProps {
-    toggleVisittkort: (erApen?: boolean) => void;
-}
-
-type Props = StateProps & DispatchProps;
+import { hasData, isFailed } from '../../../rest/utils/restResource';
+import { useAppState, useOnMount, useRestResource } from '../../../utils/customHooks';
+import { useDispatch } from 'react-redux';
+import { AlertStripeFeil } from 'nav-frontend-alertstriper';
+import { useCallback } from 'react';
+import { toggleVisittkort } from '../../../redux/uiReducers/UIReducer';
+import NavFrontendSpinner from 'nav-frontend-spinner';
+import FillCenterAndFadeIn from '../../../components/FillCenterAndFadeIn';
 
 const VisittkortBodyWrapper = styled.div`
     border-radius: ${theme.borderRadius.layout};
 `;
 
-class VisittkortContainer extends React.PureComponent<Props> {
-    componentDidMount() {
+const SpinnerWrapper = styled(FillCenterAndFadeIn)`
+    background-color: white;
+    padding: 1rem;
+`;
+
+function VisittkortContainer() {
+    const erApnet = useAppState(state => state.ui.visittkort.apent);
+    const personResource = useRestResource(resources => resources.personinformasjon);
+    const dispatch = useDispatch();
+    const toggle = useCallback(
+        (apent?: boolean) => {
+            dispatch(toggleVisittkort(apent));
+        },
+        [dispatch]
+    );
+
+    useOnMount(() => {
         loggSkjermInfoDaglig();
+    });
+
+    if (isFailed(personResource)) {
+        return <AlertStripeFeil>Kunne ikke hente personinfo</AlertStripeFeil>;
     }
 
-    render() {
-        const { person, visittkortErApent: erApnet, toggleVisittkort: toggle } = this.props;
-        const visittkortHotkeys = erNyePersonoversikten() ? (
-            <HandleVisittkortHotkeys />
-        ) : (
-            <HandleVisittkortHotkeysGamlemodia />
-        );
+    if (!hasData(personResource)) {
         return (
-            <ErrorBoundary>
-                <AriaNotification
-                    beskjed={`Visittkortet ble ${erApnet ? 'åpnet' : 'lukket'}`}
-                    dontShowOnFirstRender={true}
-                />
-                {visittkortHotkeys}
-                <article role="region" aria-label="Visittkort" aria-expanded={erApnet}>
-                    <VisittkortHeader person={person} toggleVisittkort={toggle} visittkortApent={erApnet} />
-                    <VisittkortBodyWrapper className="hook-for-spesialstyling-i-gamlemodia-visittkortbodywrapper">
-                        <UnmountClosed isOpened={erApnet}>
-                            <VisittkortBody person={person} />
-                        </UnmountClosed>
-                    </VisittkortBodyWrapper>
-                </article>
-            </ErrorBoundary>
+            <SpinnerWrapper>
+                <NavFrontendSpinner type="XL" />
+            </SpinnerWrapper>
         );
     }
+
+    const person = personResource.data as Person;
+
+    const visittkortHotkeys = erNyePersonoversikten() ? (
+        <HandleVisittkortHotkeys />
+    ) : (
+        <HandleVisittkortHotkeysGamlemodia />
+    );
+    return (
+        <ErrorBoundary>
+            <AriaNotification
+                beskjed={`Visittkortet ble ${erApnet ? 'åpnet' : 'lukket'}`}
+                dontShowOnFirstRender={true}
+            />
+            {visittkortHotkeys}
+            <article role="region" aria-label="Visittkort" aria-expanded={erApnet}>
+                <VisittkortHeader person={person} toggleVisittkort={toggle} visittkortApent={erApnet} />
+                <VisittkortBodyWrapper className="hook-for-spesialstyling-i-gamlemodia-visittkortbodywrapper">
+                    <UnmountClosed isOpened={erApnet}>
+                        <VisittkortBody person={person} />
+                    </UnmountClosed>
+                </VisittkortBodyWrapper>
+            </article>
+        </ErrorBoundary>
+    );
 }
 
-function mapStateToProps(state: AppState): StateProps {
-    return {
-        visittkortErApent: state.ui.visittkort.apent,
-        person: (state.restResources.personinformasjon as HasData<PersonRespons>).data as Person
-    };
-}
-
-function mapDispatchToProps(dispatch: AsyncDispatch): DispatchProps {
-    return {
-        toggleVisittkort: (erApen?: boolean) => dispatch(toggleVisittkort(erApen))
-    };
-}
-
-export default connect(
-    mapStateToProps,
-    mapDispatchToProps
-)(VisittkortContainer);
+export default VisittkortContainer;

--- a/src/components/featureToggle/toggleIDs.ts
+++ b/src/components/featureToggle/toggleIDs.ts
@@ -1,6 +1,5 @@
 export enum FeatureToggles {
     Tooltip = 'tooltip',
     SaksoversiktNyttVindu = 'saksoversikt-nytt-vindu',
-    Kontrollspørsmål = 'kontrollsporsmal',
     VisTilbakemelding = 'vis-tilbakemelding'
 }

--- a/src/mock/featureToggle-mock.ts
+++ b/src/mock/featureToggle-mock.ts
@@ -5,8 +5,6 @@ export function mockFeatureToggle(toggleId: FeatureToggles): FeatureToggleRespon
     switch (toggleId) {
         case FeatureToggles.Tooltip:
             return false;
-        case FeatureToggles.Kontrollspørsmål:
-            return true;
         case FeatureToggles.SaksoversiktNyttVindu:
             return true;
         case FeatureToggles.VisTilbakemelding:


### PR DESCRIPTION
Kan godt ta en demo og en diskusjon på denne

commit-melding:
fjerner spinner som skjuler appen intill personinfo er lastet

pr nå vises en stor spinner på hele skjermen intill personinfo er ferdig lastet. Dette er egentlig en kunstig begrensning da vi helt fint kan vise mye annen informasjon før personinfo er ferdig lastet. Det betyr at saksbehandlere med denne endringen mye raskere kan komme igang med å scanne informasjon når vi ikke lenger trenger å vente på at dette ene rest-kallet er ferdig før appen kan vise noe av verdi.

Fikser samtidig duplikat kall mot personinfo