### PR TITLE
forhindrer loop ved merk som kontorsperret (og andre opperasjoner som…

### DIFF
--- a/src/app/personside/infotabs/meldinger/MeldingerContainer.tsx
+++ b/src/app/personside/infotabs/meldinger/MeldingerContainer.tsx
@@ -40,10 +40,16 @@ function useHuskValgtTraad() {
     const dispatch = useDispatch();
     const valgtTraad = useValgtTraadIUrl();
     const forrigeValgteTraad = useAppState(state => state.meldinger.forrigeValgteTraad);
+    const meldingerResource = useRestResource(resources => resources.tråderOgMeldinger);
+    const forrigeTraadErFjernet =
+        hasData(meldingerResource) && forrigeValgteTraad && !meldingerResource.data.includes(forrigeValgteTraad);
 
     useEffect(() => {
+        if (forrigeTraadErFjernet) {
+            dispatch(huskForrigeValgtTraad(undefined));
+        }
         valgtTraad && dispatch(huskForrigeValgtTraad(valgtTraad));
-    }, [dispatch, valgtTraad]);
+    }, [dispatch, valgtTraad, forrigeTraadErFjernet]);
 
     return forrigeValgteTraad;
 }

--- a/src/redux/meldinger/actions.ts
+++ b/src/redux/meldinger/actions.ts
@@ -1,7 +1,7 @@
 import { Traad } from '../../models/meldinger/meldinger';
 import { MeldingerActionTypes, HuskValgtTraad } from './types';
 
-export function huskForrigeValgtTraad(traad: Traad): HuskValgtTraad {
+export function huskForrigeValgtTraad(traad?: Traad): HuskValgtTraad {
     return {
         type: MeldingerActionTypes.HuskValgtTraad,
         traad: traad

--- a/src/redux/meldinger/types.ts
+++ b/src/redux/meldinger/types.ts
@@ -14,7 +14,7 @@ export enum MeldingerActionTypes {
 
 export interface HuskValgtTraad {
     type: MeldingerActionTypes.HuskValgtTraad;
-    traad: Traad;
+    traad?: Traad;
 }
 
 export type MeldingerActions = HuskValgtTraad;


### PR DESCRIPTION
… vil føre til at meldinger forsvinner fra meldingslista)

da gjøres det en refetch av brukerens meldinger, og den åpnede meldingen vil ikke lenger eksistere i den nye lista.
Men den forrige meldingen ligger fortsatt som forrigeValgteTraad i redux, og da prøver meldingercontainer å vise denne. Siden den ikke lenger finnes havner appen i en evig loop.