### PR TITLE
paginering meldinger, sørger for å vise riktig side on mount

### DIFF
--- a/src/app/personside/infotabs/meldinger/traadliste/TraadListe.tsx
+++ b/src/app/personside/infotabs/meldinger/traadliste/TraadListe.tsx
@@ -63,7 +63,7 @@ function TraadListe(props: Props) {
     const [erForsteRender, setErForsteRender] = useState(true);
     const inputRef = React.useRef<HTMLInputElement>();
     const traaderEtterSok = useSokEtterMeldinger(props.traader, props.sokeord);
-    const paginering = usePaginering(traaderEtterSok, 50, 'melding');
+    const paginering = usePaginering(traaderEtterSok, 50, 'melding', props.valgtTraad);
 
     useOnMount(() => {
         setErForsteRender(false);

--- a/src/utils/hooks/usePaginering.tsx
+++ b/src/utils/hooks/usePaginering.tsx
@@ -46,20 +46,32 @@ const HoyrejustertPrevNextButton = styled(PrevNextButton)`
     margin-left: auto;
 `;
 
-function usePaginering<T>(list: T[], pageSize: number, itemLabel: string): PagineringsData<T> {
+function usePaginering<T>(list: T[], pageSize: number, itemLabel: string, selectedItem?: T): PagineringsData<T> {
     const selectRef = useRef<HTMLSelectElement | null>();
     const [currentPage, setCurrentPage] = useState(0);
 
     const numberOfPages = Math.ceil(list.length / pageSize);
 
     useEffect(() => {
+        // Dersom listen blir kortet inn og man står på en side som ikke har innhold lenger flyttes man til første side
         if (currentPage >= numberOfPages) {
             setCurrentPage(0);
         }
     }, [numberOfPages, currentPage]);
 
+    const prevSelectedItem = usePrevious(selectedItem);
+    useEffect(() => {
+        // skifter til riktig side dersom selected-item settes programatisk, og viser riktig side ved mount
+        if (selectedItem && prevSelectedItem !== selectedItem) {
+            const index = list.findIndex(item => item === selectedItem);
+            const newPage = Math.floor(index / pageSize);
+            setCurrentPage(newPage);
+        }
+    });
+
     const prevPage = usePrevious(currentPage);
     useEffect(() => {
+        // Dersom man har byttet side med prevNextButton flyttes fokus til pageSelect for å komme til toppen av listen
         if (prevPage !== undefined && prevPage !== currentPage) {
             selectRef.current && selectRef.current.focus();
         }


### PR DESCRIPTION
det kan være man blir sendt til personoversikten med lenke til en melding som ikke er på første side i paginering. Dette kan også skje dersom man er tildelt en oppgave tilknyttet en melding som ikke er på første side. Da må vi vise riktig side i paginering så det ikke blir forvirring rundt hvor meldingen ligger.

Denne løsningen vil i prakis alltid slå opp på riktig side on mount, så da vil navigering internt i appen også funke fint. Det vil også bli slått opp på riktig hvis valgt melding/selected Item settes programatisk.