### PR TITLE
OPP-1009 sender med hele saks-objektet for å støtte saker uten saksID

### DIFF
--- a/src/app/personside/dialogpanel/fortsettDialog/FortsettDialogContainer.tsx
+++ b/src/app/personside/dialogpanel/fortsettDialog/FortsettDialogContainer.tsx
@@ -146,7 +146,7 @@ function FortsettDialogContainer(props: Props) {
             const request: ForsettDialogRequest = {
                 ...commonPayload,
                 erOppgaveTilknyttetAnsatt: erOppgaveTilknyttetAnsatt,
-                saksId: state.sak ? state.sak.saksId : undefined
+                sak: state.sak ? state.sak : undefined
             };
             const kvitteringsData = {
                 fritekst: request.fritekst,

--- a/src/app/personside/dialogpanel/sendMelding/SendNyMeldingContainer.tsx
+++ b/src/app/personside/dialogpanel/sendMelding/SendNyMeldingContainer.tsx
@@ -83,7 +83,7 @@ function SendNyMeldingContainer() {
             setSendNyMeldingStatus({ type: SendNyMeldingStatus.POSTING });
             const request: SendSpørsmålRequest = {
                 fritekst: state.tekst,
-                saksID: state.sak.saksId,
+                sak: state.sak,
                 erOppgaveTilknyttetAnsatt: state.oppgaveListe === OppgavelisteValg.MinListe
             };
             post(`${apiBaseUri}/dialog/${fnr}/sendsporsmal`, request)

--- a/src/models/meldinger/meldinger.ts
+++ b/src/models/meldinger/meldinger.ts
@@ -1,4 +1,5 @@
 import { Temagruppe } from '../Temagrupper';
+import { JournalforingsSak } from '../../app/personside/infotabs/meldinger/traadvisning/verktoylinje/journalforing/JournalforingPanel';
 
 export interface Traad {
     traadId: string;
@@ -76,7 +77,7 @@ export interface SendReferatRequest {
 
 export interface SendSpørsmålRequest {
     fritekst: string;
-    saksID: string;
+    sak: JournalforingsSak;
     erOppgaveTilknyttetAnsatt: boolean;
 }
 
@@ -84,7 +85,7 @@ export interface ForsettDialogRequest {
     traadId: string;
     behandlingsId: string;
     fritekst: string;
-    saksId?: string;
+    sak?: JournalforingsSak;
     erOppgaveTilknyttetAnsatt: boolean;
     meldingstype: Meldingstype;
     oppgaveId?: string;


### PR DESCRIPTION
Det går ann å journalføre på generelle saker uten saksId. Da opprettes
en ny sak (med saksId) på sakstema som er valgt. For å støtte dette må
hele saksobjektet sendes med i request, ikke bare saksId som er null for
saker som enda ikke er opprettet.

Kan ikke merges før denne er prodsatt: https://github.com/navikt/modiabrukerdialog/pull/218