### PR TITLE
OPP-1017 Saksbehandler får "ingen enhet" på alle brukere

### DIFF
--- a/src/redux/restReducers/navkontor.ts
+++ b/src/redux/restReducers/navkontor.ts
@@ -4,6 +4,7 @@ import { AppState } from '../reducers';
 import { isLoadedPerson } from './personinformasjon';
 import { NavKontorResponse } from '../../models/navkontor';
 import { Kodeverk } from '../../models/kodeverk';
+import { abortFetch } from '../../rest/utils/utils';
 
 export function getUrl(geografiskTilknytning?: string, diskresjonsKode?: Kodeverk) {
     return `${apiBaseUri}/enheter?gt=${geografiskTilknytning || ''}${
@@ -14,7 +15,7 @@ export function getUrl(geografiskTilknytning?: string, diskresjonsKode?: Kodever
 function getBrukersNavkontorFetchUri(state: AppState) {
     const personResource = state.restResources.personinformasjon;
     if (!isLoadedPerson(personResource)) {
-        return `${apiBaseUri}/enheter?gt=`;
+        return abortFetch;
     }
     const geografiskTilknytning = personResource.data.geografiskTilknytning;
     const diskresjonsKode = personResource.data.diskresjonskode;

--- a/src/rest/utils/utils.ts
+++ b/src/rest/utils/utils.ts
@@ -5,6 +5,7 @@ import { AppState } from '../../redux/reducers';
 import { loggError } from '../../utils/frontendLogger';
 
 const notFound = new Error();
+export const abortFetch = '';
 
 export enum STATUS {
     NOT_STARTED = 'NOT_STARTED',
@@ -78,6 +79,10 @@ export function fetchDataAndDispatchToRedux<T>(
 ) {
     return (dispatch: AsyncDispatch, getState: () => AppState) => {
         const uri = fetchUriCreator(getState());
+        if (uri === abortFetch) {
+            console.info('Empty fetch-uri, aborting fetch in: ' + actionNames.STARTING);
+            return Promise.resolve();
+        }
         dispatch({ type: reload ? actionNames.RELOADING : actionNames.STARTING, fetchUrl: uri });
         return fetch(uri, { credentials: 'include' })
             .then(parseResponse)


### PR DESCRIPTION
Greier ikke gjennskape dette lokalt. Kan virke som at det er noen race conditions som fører til at dette slår ut for denne ene brukeren. Ønsker derfor å dytte ut denne fiksen i prod for å se om situasjonen bedrer seg for bruker.

Tror dette er en feil med hvordan vi har fetchet navkontor. Navkontor er avhengig av geografisk tilknhytning som ligger i personinfo-objektet, men her har det blitt fetchet før personinfo-objektet er ferdig, noe som har ført til at navkontor har blitt fetchet med tom string som enhet. Da har backenden returnet "Not Found" og vi viser ingen enhet til bruker. Legger derfor til mulighet for å "escape" et fetch-kall ved å sende inn tom string som fetch-url.