### PR TITLE
Mulighet til å velge Samtalereferat-telefon/oppmøte selv om du er til…

### DIFF
--- a/src/app/internarbeidsflatedecorator/Decorator.tsx
+++ b/src/app/internarbeidsflatedecorator/Decorator.tsx
@@ -12,6 +12,7 @@ import { getSaksbehandlerEnhet } from '../../utils/loggInfo/saksbehandlersEnhetI
 import './personsokKnapp.less';
 import { useOnMount, useRestResource } from '../../utils/customHooks';
 import { parseQueryParams } from '../../utils/url-utils';
+import { settJobberIkkeMedSpørsmålOgSvar } from '../personside/kontrollsporsmal/cookieUtils';
 
 const InternflateDecorator = NAVSPA.importer<DecoratorProps>('internarbeidsflatefs');
 
@@ -33,6 +34,7 @@ function lagConfig(
             visVeilder: true
         },
         onSok(fnr: string | null): void {
+            settJobberIkkeMedSpørsmålOgSvar();
             if (fnr && fnr.length > 0) {
                 setNyBrukerIPath(history, fnr);
             } else {

--- a/src/app/personside/dialogpanel/fortsettDialog/VelgDialogType.tsx
+++ b/src/app/personside/dialogpanel/fortsettDialog/VelgDialogType.tsx
@@ -4,6 +4,7 @@ import { FortsettDialogType } from './FortsettDialogContainer';
 import { Radio } from 'nav-frontend-skjema';
 import { VelgDialogtypeStyle } from '../fellesStyling';
 import { FortsettDialogState } from './FortsettDialogTypes';
+import { jobberMedSpørsmålOgSvar } from '../../kontrollsporsmal/cookieUtils';
 
 interface Props {
     formState: FortsettDialogState;
@@ -45,6 +46,8 @@ function VelgDialogType(props: Props) {
                 {svar}
                 {spørsmål}
                 {delvisSvar}
+                {!jobberMedSpørsmålOgSvar() && svarTelefon}
+                {!jobberMedSpørsmålOgSvar() && svarOppmote}
             </VelgDialogtypeStyle>
         );
     }

--- a/src/mock/meldinger/henvendelseMock.ts
+++ b/src/mock/meldinger/henvendelseMock.ts
@@ -1,5 +1,7 @@
 import { OpprettHenvendelseResponse } from '../../models/meldinger/meldinger';
+import navfaker from 'nav-faker';
 
 export const henvendelseResponseMock: OpprettHenvendelseResponse = {
-    behandlingsId: '890'
+    behandlingsId: '890',
+    oppgaveId: navfaker.random.vektetSjanse(0.5) ? '123' : undefined
 };


### PR DESCRIPTION
…delt oppgave

Vi fjernet muligheten for dette fordi vi anntok at man aldri var på telefon/oppmøte når man sitter på plukk. Det vi ikke tok høyde for var at saksbehandler manuelt plukker oppgaven dersom noen som har sendt en henvendelse ringer inn på telefon/møter opp for å få fortgang i saken. Da pleier saksbehandler å trykke "Ny melding" for å besvare direkte på henvendelsen. Da blir man automatisk tildelt oppgaven, og frontenden "skjulte" mulighet for å velge Samtalereferat-telefon/oppmøte. Denne muligheten må de ha.

Løser dette ved å sjekke om saksbehandler jobber med spørsmål og svar. Dersom de jobber med spørsmål og svar antar vi at de ikke sitter på telefon, og referat-valgene skjules. (Dette er viktig fordi referat-valgene ikke sender varsel til brukere, det har vist vært problem med at saksbehandlere har valgt disse alternativene selv om de ikke sitter på telefon, og da får ikke bruker varsel om at de har fått svar)