### PR TITLE
Fikser problem med loop når saksbehandlerinnstillingercookie ikke er …

### DIFF
--- a/src/utils/frontendLogger.ts
+++ b/src/utils/frontendLogger.ts
@@ -22,10 +22,19 @@ function uselogger(): boolean {
 }
 
 export function loggEvent(action: string, location: string, extraTags?: ValuePairs, fields?: ValuePairs) {
+    loggEventUtenIdentHash(action, location, extraTags, fields, md5(getSaksbehandlerIdent() || ''));
+}
+
+function loggEventUtenIdentHash(
+    action: string,
+    location: string,
+    extraTags?: ValuePairs,
+    fields?: ValuePairs,
+    identHash?: string
+) {
     if (!uselogger()) {
         return;
     }
-    const identHash = md5(getSaksbehandlerIdent() || '');
     const event = {
         table: 'modiapersonoversikt',
         fields: { ...fields, identHash: identHash },
@@ -67,7 +76,7 @@ export function loggErrorUtenSaksbehandlerIdent(error: Error, message?: string, 
     };
     if (uselogger()) {
         // @ts-ignore
-        loggEvent('Error', 'Logger');
+        loggEventUtenIdentHash('Error', 'Logger');
         window['frontendlogger'].error(info);
     } else {
         console.error(error, info);


### PR DESCRIPTION
…definert

Da logges en feil som så logger en event. Eventen prøver å logge en event med bla identHash som lages basert på cookien den tidligere ikke fant. Dette skaper en ny loggError og så er loopen i gang.