### PR TITLE
sørger for at rest-resources, useFetch og annen data som må resettes …

### DIFF
--- a/src/app/PersonOppslagHandler/LyttPåNyttFnrIReduxOgHentAllPersoninfo.tsx
+++ b/src/app/PersonOppslagHandler/LyttPåNyttFnrIReduxOgHentAllPersoninfo.tsx
@@ -1,11 +1,8 @@
 import { useEffect } from 'react';
-import { reset } from '../../redux/reducer-utils';
 import { useDispatch, useSelector } from 'react-redux';
-import { cache } from '@nutgaard/use-fetch';
 import { useGjeldendeBruker } from '../../redux/gjeldendeBruker/types';
 import { AppState } from '../../redux/reducers';
 import { useFetchFeatureTogglesOnNewFnr } from './FetchFeatureToggles';
-import { resetKeepScroll } from '../../utils/hooks/useKeepScroll';
 
 function LyttPåNyttFnrIReduxOgHentAllPersoninfo() {
     const dispatch = useDispatch();
@@ -20,9 +17,6 @@ function LyttPåNyttFnrIReduxOgHentAllPersoninfo() {
     const tildDelteOppgaverFetch = restResources.tildelteOppgaver.actions.fetch;
 
     useEffect(() => {
-        cache.clear();
-        dispatch(reset());
-        resetKeepScroll();
         if (fnr.length !== 0) {
             dispatch(personinformasjonFetch);
             dispatch(tråderFetch);
@@ -42,7 +36,6 @@ function LyttPåNyttFnrIReduxOgHentAllPersoninfo() {
         tråderFetch
     ]);
     useFetchFeatureTogglesOnNewFnr();
-
     return null;
 }
 

--- a/src/app/PersonOppslagHandler/SetFnrIRedux.tsx
+++ b/src/app/PersonOppslagHandler/SetFnrIRedux.tsx
@@ -1,29 +1,19 @@
 import setGjeldendeBrukerIRedux from '../../redux/gjeldendeBruker/actions';
-import { connect } from 'react-redux';
-import { AsyncDispatch } from '../../redux/ThunkTypes';
+import { useDispatch } from 'react-redux';
+import { useFødselsnummer } from '../../utils/customHooks';
 
-interface OwnProps {
+interface Props {
     fødselsnummer: string;
 }
 
-interface DispatchProps {
-    setFnrIRedux: (fnr: string) => void;
-}
-
-type Props = DispatchProps & OwnProps;
-
 function SetFnrIRedux(props: Props) {
-    props.setFnrIRedux(props.fødselsnummer);
+    const fnr = useFødselsnummer();
+    const dispatch = useDispatch();
+
+    if (fnr !== props.fødselsnummer) {
+        dispatch(setGjeldendeBrukerIRedux(props.fødselsnummer));
+    }
     return null;
 }
 
-function mapDispatchToProps(dispatch: AsyncDispatch): DispatchProps {
-    return {
-        setFnrIRedux: (fnr: string) => dispatch(setGjeldendeBrukerIRedux(fnr))
-    };
-}
-
-export default connect(
-    null,
-    mapDispatchToProps
-)(SetFnrIRedux);
+export default SetFnrIRedux;

--- a/src/redux/gjeldendeBruker/actions.ts
+++ b/src/redux/gjeldendeBruker/actions.ts
@@ -1,11 +1,25 @@
 import { SetNyGjeldendeBrukerAction, SetNyGjeldendeBrukerActionTypes } from './types';
+import { AsyncAction, AsyncDispatch } from '../ThunkTypes';
+import { cache } from '@nutgaard/use-fetch';
+import { reset } from '../reducer-utils';
+import { resetKeepScroll } from '../../utils/hooks/useKeepScroll';
+import { AppState } from '../reducers';
 
 // Det er neppe denne du har lyst til å bruke
-// Denne brukes kun til å sette gjeldende fnr i redux, den vil ikke oppdatere url med nytt fnr
+// Denne vil ikke oppdatere url med nytt fnr
 // Sansynligvis ønsker du å bruke setNyBrukerIPath som propagerer videre til resten av appen
-export default function setGjeldendeBrukerIRedux(fødselsnummer: string): SetNyGjeldendeBrukerAction {
-    return {
-        type: SetNyGjeldendeBrukerActionTypes.SetNyPerson,
-        fnr: fødselsnummer
+export default function setGjeldendeBrukerIRedux(fødselsnummer: string): AsyncAction {
+    return (dispatch: AsyncDispatch, getState: () => AppState) => {
+        if (getState().gjeldendeBruker.fødselsnummer !== fødselsnummer) {
+            dispatch(reset());
+            cache.clear();
+            resetKeepScroll();
+
+            const setGjeldendeBrukerAction: SetNyGjeldendeBrukerAction = {
+                type: SetNyGjeldendeBrukerActionTypes.SetNyPerson,
+                fnr: fødselsnummer
+            };
+            dispatch(setGjeldendeBrukerAction);
+        }
     };
 }

--- a/src/test/testStore.ts
+++ b/src/test/testStore.ts
@@ -1,4 +1,4 @@
-import { applyMiddleware, createStore, Store } from 'redux';
+import { applyMiddleware, createStore, Dispatch, Store } from 'redux';
 import reducers, { AppState } from '../redux/reducers';
 import thunkMiddleware from 'redux-thunk';
 import { aremark } from '../mock/person/aremark';
@@ -32,36 +32,35 @@ export function getTestStore(): Store<AppState> {
     const restResources = testStore.getState().restResources;
     const aremarkFnr = aremark.fødselsnummer;
 
-    testStore.dispatch(restResources.personinformasjon.actions.setData(getPerson(aremarkFnr)));
-    testStore.dispatch(restResources.innloggetSaksbehandler.actions.setData(getMockInnloggetSaksbehandler()));
-    testStore.dispatch(restResources.brukersNavKontor.actions.setData(getMockNavKontor('0118', undefined)));
-    testStore.dispatch(restResources.kontaktinformasjon.actions.setData(getMockKontaktinformasjon(aremarkFnr)));
-    testStore.dispatch(restResources.egenAnsatt.actions.setData(erEgenAnsatt(aremarkFnr)));
-    testStore.dispatch(restResources.vergemal.actions.setData(mockVergemal(aremarkFnr)));
-    testStore.dispatch(restResources.baseUrl.actions.setData(mockBaseUrls()));
-    testStore.dispatch(restResources.veilederRoller.actions.setData({ roller: [SaksbehandlerRoller.HentOppgave] }));
-    testStore.dispatch(
-        restResources.tilrettelagtKommunikasjonKodeverk.actions.setData(mockTilrettelagtKommunikasjonKodeverk())
-    );
-    testStore.dispatch(restResources.retningsnummer.actions.setData(mockRetningsnummereKodeverk()));
-    testStore.dispatch(restResources.postnummer.actions.setData(mockPostnummere()));
-    testStore.dispatch(restResources.land.actions.setData(mockLandKodeverk()));
-    testStore.dispatch(restResources.valuta.actions.setData(mockValutaKodeverk()));
-    testStore.dispatch(restResources.utbetalinger.actions.setData(statiskMockUtbetalingRespons));
-    testStore.dispatch(restResources.utbetalingerOversikt.actions.setData(statiskMockUtbetalingRespons));
-    testStore.dispatch(restResources.sakstema.actions.setData(getStaticMockSaksoversikt()));
-    testStore.dispatch(restResources.brukersVarsler.actions.setData(statiskVarselMock));
-    testStore.dispatch(setGjeldendeBrukerIRedux(aremarkFnr));
-    testStore.dispatch(restResources.oppfolging.actions.setData(statiskOppfolgingMock));
-    testStore.dispatch(restResources.oppgaveGsakTema.actions.setData(getMockGsakTema()));
-    testStore.dispatch(
+    const dispatch = testStore.dispatch as Dispatch<any>;
+    dispatch(setGjeldendeBrukerIRedux(aremarkFnr));
+    dispatch(restResources.personinformasjon.actions.setData(getPerson(aremarkFnr)));
+    dispatch(restResources.innloggetSaksbehandler.actions.setData(getMockInnloggetSaksbehandler()));
+    dispatch(restResources.brukersNavKontor.actions.setData(getMockNavKontor('0118', undefined)));
+    dispatch(restResources.kontaktinformasjon.actions.setData(getMockKontaktinformasjon(aremarkFnr)));
+    dispatch(restResources.egenAnsatt.actions.setData(erEgenAnsatt(aremarkFnr)));
+    dispatch(restResources.vergemal.actions.setData(mockVergemal(aremarkFnr)));
+    dispatch(restResources.baseUrl.actions.setData(mockBaseUrls()));
+    dispatch(restResources.veilederRoller.actions.setData({ roller: [SaksbehandlerRoller.HentOppgave] }));
+    dispatch(restResources.tilrettelagtKommunikasjonKodeverk.actions.setData(mockTilrettelagtKommunikasjonKodeverk()));
+    dispatch(restResources.retningsnummer.actions.setData(mockRetningsnummereKodeverk()));
+    dispatch(restResources.postnummer.actions.setData(mockPostnummere()));
+    dispatch(restResources.land.actions.setData(mockLandKodeverk()));
+    dispatch(restResources.valuta.actions.setData(mockValutaKodeverk()));
+    dispatch(restResources.utbetalinger.actions.setData(statiskMockUtbetalingRespons));
+    dispatch(restResources.utbetalingerOversikt.actions.setData(statiskMockUtbetalingRespons));
+    dispatch(restResources.sakstema.actions.setData(getStaticMockSaksoversikt()));
+    dispatch(restResources.brukersVarsler.actions.setData(statiskVarselMock));
+    dispatch(restResources.oppfolging.actions.setData(statiskOppfolgingMock));
+    dispatch(restResources.oppgaveGsakTema.actions.setData(getMockGsakTema()));
+    dispatch(
         restResources.featureToggles.actions.setData({
             [FeatureToggles.SaksoversiktNyttVindu]: true
         })
     );
-    testStore.dispatch(restResources.tråderOgMeldinger.actions.setData([statiskTraadMock]));
-    testStore.dispatch(restResources.pleiepenger.actions.setData({ pleiepenger: [pleiepengerTestData] }));
-    testStore.dispatch(restResources.foreldrepenger.actions.setData({ foreldrepenger: [statiskForeldrepengeMock] }));
-    testStore.dispatch(restResources.sykepenger.actions.setData({ sykepenger: [statiskSykepengerMock] }));
+    dispatch(restResources.tråderOgMeldinger.actions.setData([statiskTraadMock]));
+    dispatch(restResources.pleiepenger.actions.setData({ pleiepenger: [pleiepengerTestData] }));
+    dispatch(restResources.foreldrepenger.actions.setData({ foreldrepenger: [statiskForeldrepengeMock] }));
+    dispatch(restResources.sykepenger.actions.setData({ sykepenger: [statiskSykepengerMock] }));
     return testStore;
 }


### PR DESCRIPTION
…ved oppslag på ny person blir resatt før nytt fnr blir lagt i redux

i en tidligere flyt ble dette resatt som en reaksjon på at fnr i redux (gjeldendeBruker) endret seg. Da har vi et øyeblikk der det ligger gammel data men et nytt fnr i redux, og dette førte til noen rare sideeffekter som at bla. henvendelser ble opprettet på forrige tråd som var slått opp men med nytt fnr. Dette ga feil fra backenden da det var feil kombo av fnr og tråd, men dette bør ikke kunne skje. Resetter derfor data før nytt fnr legges i redux.