### PR TITLE
vi får avogtil feil som skyldes at både even.code og event.key er und…

### DIFF
--- a/src/utils/hooks/use-hotkey.ts
+++ b/src/utils/hooks/use-hotkey.ts
@@ -10,7 +10,7 @@ function toKeyDescription(value: string | KeyDescription): KeyDescription {
 function matches(keyDescription: KeyDescription, event: KeyboardEvent): boolean {
     const { altKey, ctrlKey, metaKey, shiftKey } = keyDescription;
     const wantedKey = keyDescription.char.toLowerCase();
-    const actualKey = (event.code ? event.code.replace('Key', '') : event.key).toLowerCase();
+    const actualKey = (event.code ? event.code.replace('Key', '') : event.key || '').toLowerCase();
 
     return [
         wantedKey === actualKey,


### PR DESCRIPTION
…efined. Håndterer dette ved å sette tom string som fallback. Tom string vil basically føre til at ingen hurtigtaster blir utløst, samme resultat som når den er undefined men uten at vi får feilmelding pga at toLowerCase kjøres på undefined

https://logs.adeo.no/goto/e4c2b95af3cff83462ba8f8752739466