### PR TITLE
viser feilmelindg istedenfor evig spinner dersom roller-fetchkall feiler

### DIFF
--- a/src/app/personside/dialogpanel/HentOppgaveKnapp.tsx
+++ b/src/app/personside/dialogpanel/HentOppgaveKnapp.tsx
@@ -5,7 +5,7 @@ import { useDispatch, useSelector } from 'react-redux';
 import styled from 'styled-components';
 import KnappBase from 'nav-frontend-knapper';
 import { Select } from 'nav-frontend-skjema';
-import { AlertStripeAdvarsel, AlertStripeInfo } from 'nav-frontend-alertstriper';
+import { AlertStripeAdvarsel, AlertStripeFeil, AlertStripeInfo } from 'nav-frontend-alertstriper';
 import { velgTemagruppeForPlukk } from '../../../redux/session/session';
 import { AppState } from '../../../redux/reducers';
 import { settJobberMedSpørsmålOgSvar } from '../kontrollsporsmal/cookieUtils';
@@ -16,7 +16,7 @@ import { paths } from '../../routes/routing';
 import { INFOTABS } from '../infotabs/InfoTabEnum';
 import { Temagruppe, temagruppeTekst, TemaPlukkbare } from '../../../models/Temagrupper';
 import { useRestResource } from '../../../utils/customHooks';
-import { hasData } from '../../../rest/utils/restResource';
+import { hasData, isFailed } from '../../../rest/utils/restResource';
 import LazySpinner from '../../../components/LazySpinner';
 import { SaksbehandlerRoller } from '../../../utils/RollerUtils';
 import { loggEvent } from '../../../utils/frontendLogger';
@@ -61,6 +61,10 @@ function HentOppgaveKnapp(props: Props) {
     const valgtTemaGruppe = useSelector((state: AppState) => state.session.temagruppeForPlukk);
     const rollerResource = useRestResource(resources => resources.veilederRoller);
 
+    if (isFailed(rollerResource)) {
+        return <AlertStripeFeil>Kunne ikke hente roller</AlertStripeFeil>;
+    }
+
     if (!hasData(rollerResource)) {
         return (
             <SpinnerWrapper>
@@ -70,7 +74,7 @@ function HentOppgaveKnapp(props: Props) {
     }
 
     if (!rollerResource.data.roller.includes(SaksbehandlerRoller.HentOppgave)) {
-        return <AlertStripeInfo>Du har ikke tilgang til å hente oppgaver</AlertStripeInfo>;
+        return null;
     }
 
     const onPlukkOppgaver = () => {


### PR DESCRIPTION
viser ingen info-melding til de som ikke har rolle for plukk etter
tilbakemelding på at dette ikke skal vises da det kan være forvirrende
for lokal-kontor som ikke har noe forhold til denne rollen