### PR TITLE
[KAIZEN-0] lenker i fritekst apnes i ny fane

### DIFF
--- a/src/components/tekstomrade/parser/rules.ts
+++ b/src/components/tekstomrade/parser/rules.ts
@@ -94,7 +94,7 @@ export const LinkRule: Rule = {
 
         return {
             type: Lenke,
-            props: { href }
+            props: { href, target: '_blank' }
         };
     }
 };


### PR DESCRIPTION
Pga innmeldt sak der lenke i standardtekst gjorde at saksbehandler
mistet tidligere skrevet data da lenken ble klikket.
Endringer pavirker ogsa visning av lenker i meldinger-lamellen,
slik at disse ogsa apnes i egen fane na