### PR TITLE
OPP-975 sørger for at valge ytelser og mottakere ikke oppdateres onMo…

### DIFF
--- a/src/app/personside/infotabs/utbetalinger/filter/UtbetaltTilValg.tsx
+++ b/src/app/personside/infotabs/utbetalinger/filter/UtbetaltTilValg.tsx
@@ -14,9 +14,11 @@ interface Props {
 class UtbetaltTilValg extends React.Component<Props> {
     constructor(props: Props) {
         super(props);
-        this.props.onChange({
-            utbetaltTil: [...this.getUnikeMottakere(props.utbetalinger)]
-        });
+        if (props.filterState.utbetaltTil.length === 0) {
+            this.props.onChange({
+                utbetaltTil: [...this.getUnikeMottakere(props.utbetalinger)]
+            });
+        }
     }
 
     componentDidUpdate(prevProps: Props) {

--- a/src/app/personside/infotabs/utbetalinger/filter/YtelseValg.tsx
+++ b/src/app/personside/infotabs/utbetalinger/filter/YtelseValg.tsx
@@ -14,9 +14,11 @@ interface Props {
 class YtelseValg extends React.Component<Props> {
     constructor(props: Props) {
         super(props);
-        this.props.onChange({
-            ytelser: [...this.getUnikeYtelser(props.utbetalinger)]
-        });
+        if (props.filterState.ytelser.length === 0) {
+            this.props.onChange({
+                ytelser: [...this.getUnikeYtelser(props.utbetalinger)]
+            });
+        }
     }
 
     componentDidUpdate(prevProps: Props) {


### PR DESCRIPTION
…unt med mindre ingen ytelser/mottakere er valgt.

Før ble alle checboxene automatisk checked onMount.
Nå vil brukeren i større grad oppleve at utbetalingeroversikten holder seg slik de forlot den ved navigering mellom faner