### PR TITLE
Oppdatere avsluttetUtenSvar dato

### DIFF
--- a/src/app/personside/infotabs/meldinger/traadvisning/TraadVisning.tsx
+++ b/src/app/personside/infotabs/meldinger/traadvisning/TraadVisning.tsx
@@ -49,7 +49,7 @@ function Topplinje({ valgtTraad }: { valgtTraad: Traad }) {
         return (
             <AlertStripeInfo>
                 Henvendelsen er avsluttet uten å svare bruker av {saksbehandlerTekst(melding.ferdigstiltUtenSvarAv)}{' '}
-                {melding.ferdigstiltDato && formatterDatoMedMaanedsnavn(melding.ferdigstiltDato)}
+                {melding.ferdigstiltUtenSvarDato && formatterDatoMedMaanedsnavn(melding.ferdigstiltUtenSvarDato)}
             </AlertStripeInfo>
         );
     }

--- a/src/app/personside/infotabs/meldinger/traadvisning/__snapshots__/TraadVisningWrapper.test.tsx.snap
+++ b/src/app/personside/infotabs/meldinger/traadvisning/__snapshots__/TraadVisningWrapper.test.tsx.snap
@@ -953,7 +953,6 @@ exports[`Viser traad med verktøylinje 1`] = `
         Henvendelsen er avsluttet uten å svare bruker av 
         Ukjent saksbehandler
          
-        07. juli 2019
       </div>
     </div>
     <h3

--- a/src/mock/meldinger/meldinger-mock.ts
+++ b/src/mock/meldinger/meldinger-mock.ts
@@ -95,6 +95,9 @@ function getMelding(temagruppe: Temagruppe): Melding {
         opprettetDato: moment(faker.date.recent(40)).format(backendDatoTidformat),
         ferdigstiltDato: moment(faker.date.recent(40)).format(backendDatoTidformat),
         erFerdigstiltUtenSvar: ferdigstilUtenSvar,
+        ferdigstiltUtenSvarDato: ferdigstilUtenSvar
+            ? moment(faker.date.recent(40)).format(backendDatoTidformat)
+            : undefined,
         ferdigstiltUtenSvarAv: ferdigstilUtenSvar ? getSaksbehandler() : undefined,
         kontorsperretAv: visKontrosperre ? getSaksbehandler() : undefined,
         kontorsperretEnhet: visKontrosperre ? faker.company.companyName() : undefined,

--- a/src/models/meldinger/meldinger.ts
+++ b/src/models/meldinger/meldinger.ts
@@ -29,6 +29,7 @@ export interface Melding {
     kontorsperretAv?: Saksbehandler;
     markertSomFeilsendtAv?: Saksbehandler;
     erDokumentMelding: boolean;
+    ferdigstiltUtenSvarDato?: string;
 }
 
 export interface Saksbehandler {


### PR DESCRIPTION
riktig dato blir ikke hentet ut fra backend, ligger en PR i brukerdialog (https://github.com/navikt/modiabrukerdialog/pull/228/files) som må prodsettes før vi kan få ut riktig dato her. idag brukes ferdigstilltDato, som er feil og kan skape forvirring for brukeren.

