### PR TITLE
resetter dialogpanelet etter merket traad. brukere opplevde at dialog…

### DIFF
--- a/src/app/personside/infotabs/meldinger/traadvisning/verktoylinje/merk/MerkPanel.tsx
+++ b/src/app/personside/infotabs/meldinger/traadvisning/verktoylinje/merk/MerkPanel.tsx
@@ -125,6 +125,7 @@ function MerkPanel(props: Props) {
     const reloadMeldinger = tråderResource.actions.reload;
     const reloadTildelteOppgaver = useRestResource(resources => resources.tildelteOppgaver).actions.reload;
     const resetPlukkOppgaveResource = usePostResource(resources => resources.plukkNyeOppgaver).actions.reset;
+    const dialogpanelTraad = useAppState(state => state.oppgaver.dialogpanelTraad);
 
     const [valgtOperasjon, settValgtOperasjon] = useState<MerkOperasjon | undefined>(undefined);
     const [resultat, settResultat] = useState<Resultat | undefined>(undefined);
@@ -185,16 +186,20 @@ function MerkPanel(props: Props) {
         dispatch(resetPlukkOppgaveResource);
     };
 
+    const resetDialogpanel = () => {
+        if (valgtTraad !== dialogpanelTraad || valgtOperasjon == MerkOperasjon.BISYS) {
+            return;
+        }
+        dispatch(setIngenValgtTraadDialogpanel());
+    };
+
     function merkPost(url: string, object: any, name: string) {
         post(url, object, 'MerkPanel-' + name)
             .then(() => {
                 settResultat(Resultat.VELLYKKET);
                 setSubmitting(false);
-
-                if (url !== MERK_BISYS_URL) {
-                    dispatch(setIngenValgtTraadDialogpanel());
-                }
                 callback();
+                resetDialogpanel();
             })
             .catch((error: Error) => {
                 settResultat(Resultat.FEIL);

--- a/src/app/personside/infotabs/meldinger/traadvisning/verktoylinje/merk/MerkPanel.tsx
+++ b/src/app/personside/infotabs/meldinger/traadvisning/verktoylinje/merk/MerkPanel.tsx
@@ -187,7 +187,7 @@ function MerkPanel(props: Props) {
     };
 
     const resetDialogpanel = () => {
-        if (valgtTraad !== dialogpanelTraad || valgtOperasjon == MerkOperasjon.BISYS) {
+        if (valgtTraad !== dialogpanelTraad || valgtOperasjon === MerkOperasjon.BISYS) {
             return;
         }
         dispatch(setIngenValgtTraadDialogpanel());

--- a/src/app/personside/infotabs/meldinger/traadvisning/verktoylinje/merk/MerkPanel.tsx
+++ b/src/app/personside/infotabs/meldinger/traadvisning/verktoylinje/merk/MerkPanel.tsx
@@ -37,6 +37,7 @@ import { useFetchWithLog } from '../../../../../../../utils/hooks/useFetchWithLo
 import { useRestResource } from '../../../../../../../rest/consumer/useRestResource';
 import { usePostResource } from '../../../../../../../rest/consumer/usePostResource';
 import { useFocusOnFirstInputOnMount } from '../../../../../../../utils/hooks/useFocusOnFirstInputOnMount';
+import { setIngenValgtTraadDialogpanel } from '../../../../../../../redux/oppgave/actions';
 
 interface Props {
     lukkPanel: () => void;
@@ -182,6 +183,7 @@ function MerkPanel(props: Props) {
         dispatch(reloadMeldinger);
         dispatch(reloadTildelteOppgaver);
         dispatch(resetPlukkOppgaveResource);
+        dispatch(setIngenValgtTraadDialogpanel());
     };
 
     function merkPost(url: string, object: any, name: string) {

--- a/src/app/personside/infotabs/meldinger/traadvisning/verktoylinje/merk/MerkPanel.tsx
+++ b/src/app/personside/infotabs/meldinger/traadvisning/verktoylinje/merk/MerkPanel.tsx
@@ -183,7 +183,6 @@ function MerkPanel(props: Props) {
         dispatch(reloadMeldinger);
         dispatch(reloadTildelteOppgaver);
         dispatch(resetPlukkOppgaveResource);
-        dispatch(setIngenValgtTraadDialogpanel());
     };
 
     function merkPost(url: string, object: any, name: string) {
@@ -191,6 +190,10 @@ function MerkPanel(props: Props) {
             .then(() => {
                 settResultat(Resultat.VELLYKKET);
                 setSubmitting(false);
+
+                if (url !== MERK_BISYS_URL) {
+                    dispatch(setIngenValgtTraadDialogpanel());
+                }
                 callback();
             })
             .catch((error: Error) => {


### PR DESCRIPTION
…panelet beholdt meldingen som ble market som feilsendt, men med F5 fikk de SendNyMelding skjerm. Nå sette vi ingen traad til bruker når man merker og da kommer dialogpanel tilbake til første siden