### PR TITLE
[KAIZEN-0] nye korona-hotkeys etter bestilling via teams-kanal

### DIFF
--- a/src/components/autocomplete-textarea/autocomplete-textarea.tsx
+++ b/src/components/autocomplete-textarea/autocomplete-textarea.tsx
@@ -121,6 +121,16 @@ function useRules(): Regler {
             type: 'external',
             regex: /^korkonk$/i,
             externalId: 'f15b6b9b-0cb6-4c46-8c37-0069e681ecdc'
+        },
+        {
+            type: 'external',
+            regex: /^koroms$/i,
+            externalId: '056be54e-d93d-487c-a6c2-238c885bdfd8'
+        },
+        {
+            type: 'external',
+            regex: /^korosakt$/i,
+            externalId: '788b0492-a5e8-4883-a6af-6387ff1e46d6'
         }
     ];
 }
@@ -157,6 +167,8 @@ function AutoTekstTips() {
                     <li>mvh/aap + en + mellomrom: autofullfør på engelsk</li>
                     <li>korkonk + mellomrom: Informasjon ved konkurs</li>
                     <li>korperm + mellomrom: Informasjon ved permittering</li>
+                    <li>koroms + mellomrom: OMS - Korona stengt bhg/skole</li>
+                    <li>korosakt + mellomrom: OS - Korona aktivitet STO</li>
                 </ul>
             </HjelpetekstUnderHoyre>
         </HjelpetekstStyle>

--- a/src/components/autocomplete-textarea/autocomplete-textarea.tsx
+++ b/src/components/autocomplete-textarea/autocomplete-textarea.tsx
@@ -53,6 +53,13 @@ function useRules(): Regler {
                 return `${mvh}\n[saksbehandler.navn]\n${saksbehanderEnhet}`;
             }
         },
+        {
+            type: 'internal',
+            regex: /^mvhks$/i,
+            replacement: () => {
+                return `Med vennlig hilsen\n[saksbehandler.fornavn]\nNAV Kontaktsenter`;
+            }
+        },
         { type: 'internal', regex: /^foet$/i, replacement: () => '[bruker.navn] ' },
         {
             type: 'external',
@@ -156,6 +163,7 @@ function AutoTekstTips() {
                 <ul>
                     <li>foet + mellomrom: Brukers fulle navn</li>
                     <li>mvh + mellomrom: Signatur</li>
+                    <li>mvhks + mellomrom: Signatur som fra KS</li>
                     <li>hei + mellomrom: Hei bruker</li>
                     <li>vint + mellomrom: Videreformidle Internt</li>
                     <li>AAP + mellomrom: arbeidsavklaringspenger</li>


### PR DESCRIPTION
Bestilling;
```
Per nå har vi disse to ønskene: 

Familie - Omsorgspenger - Korona stengt bhg/skole
Tekst-id: 056be54e-d93d-487c-a6c2-238c885bdfd8
Ønsket titte/overskrift: OMS - Korona stengt bhg/skole
Ønsket hotkey: koroms

Familie - Overgangsstønad - Korona aktivitet STO
Tekst-id: 788b0492-a5e8-4883-a6af-6387ff1e46d6
Ønsket tittel/overskrift: OS - Korona aktivitet STO
Ønsket hotkey: korosakt
```