### PR TITLE
[KAIZEN-0] la til locale-støtte for external-hotkey-tekster

### DIFF
--- a/src/components/autocomplete-textarea/autocomplete-textarea.tsx
+++ b/src/components/autocomplete-textarea/autocomplete-textarea.tsx
@@ -127,6 +127,12 @@ function useRules(): Regler {
         },
         {
             type: 'external',
+            regex: /^korpermeng$/i,
+            externalId: 'af2e6816-391c-4b8b-b00e-27f116aa3de8',
+            locale: Locale.en_US
+        },
+        {
+            type: 'external',
             regex: /^korkonk$/i,
             externalId: 'f15b6b9b-0cb6-4c46-8c37-0069e681ecdc'
         },

--- a/src/components/autocomplete-textarea/autocomplete-textarea.tsx
+++ b/src/components/autocomplete-textarea/autocomplete-textarea.tsx
@@ -30,6 +30,7 @@ interface ExternalRegel {
     type: 'external';
     regex: RegExp;
     externalId: string;
+    locale?: Locale;
 }
 
 type Regel = InlineRegel | ExternalRegel;
@@ -270,9 +271,12 @@ function AutocompleteTextarea(props: TextareaProps) {
                                         settFeilmelding(`Ukjent tekst. Kontakt IT: ${rule.externalId}`);
                                         return acc + ' ';
                                     }
-                                    const innhold = tekst.innhold[Locale.nb_NO];
+                                    const locale = rule.locale || Locale.nb_NO;
+                                    const innhold = tekst.innhold[locale];
                                     if (innhold === undefined) {
-                                        settFeilmelding(`Fant ikke tekst. Kontakt IT: ${rule.externalId}`);
+                                        settFeilmelding(
+                                            `Fant ikke tekst. Kontakt IT: ${rule.externalId}@${rule.locale}`
+                                        );
                                         return acc + ' ';
                                     }
                                     return innhold;


### PR DESCRIPTION
Kan legge til tekster på følgende måte; 
```
        {
            type: 'external',
            regex: /^korosakt$/i,
            externalId: '788b0492-a5e8-4883-a6af-6387ff1e46d6',
            locale: Locale.en_US
        }
```

Om `locale` ikke er satt brukes `Locale.nb_NO` som default verdi