### PR TITLE
Opp 1116 temaskifte

### DIFF
--- a/src/app/personside/dialogpanel/fortsettDialog/FortsettDialogContainer.tsx
+++ b/src/app/personside/dialogpanel/fortsettDialog/FortsettDialogContainer.tsx
@@ -217,6 +217,7 @@ function FortsettDialogContainer(props: Props) {
                 {oppgaveId && (
                     <LeggTilbakepanel
                         oppgaveId={oppgaveId}
+                        traadId={props.traad.traadId}
                         status={dialogStatus}
                         setDialogStatus={setDialogStatus}
                         temagruppe={temagruppe}

--- a/src/app/personside/dialogpanel/fortsettDialog/leggTilbakePanel/LeggTilbakepanel.tsx
+++ b/src/app/personside/dialogpanel/fortsettDialog/leggTilbakePanel/LeggTilbakepanel.tsx
@@ -9,7 +9,7 @@ import Temavelger from '../../component/Temavelger';
 import { LeggTilbakeValidator } from './validatorer';
 import { useDispatch } from 'react-redux';
 import { LeggTilbakeOppgaveRequest } from '../../../../../models/oppgave';
-import { Temagruppe, TemaPlukkbare } from '../../../../../models/Temagrupper';
+import { Temagruppe, TemaLeggTilbake } from '../../../../../models/Temagrupper';
 import { apiBaseUri } from '../../../../../api/config';
 import { post } from '../../../../../api/api';
 import { AlertStripeFeil } from 'nav-frontend-alertstriper';
@@ -53,6 +53,7 @@ const Style = styled.div`
 
 interface Props {
     oppgaveId: string;
+    traadId: string;
     temagruppe?: Temagruppe | null;
     status: FortsettDialogPanelState;
     setDialogStatus: (status: FortsettDialogPanelState) => void;
@@ -130,6 +131,7 @@ function LeggTilbakepanel(props: Props) {
             const payload: LeggTilbakeOppgaveRequest = {
                 temagruppe: state.temagruppe,
                 oppgaveId: props.oppgaveId,
+                traadId: props.traadId,
                 type: 'FeilTema'
             };
             post(`${apiBaseUri}/oppgaver/legg-tilbake`, payload, 'LeggTilbakeOppgave-FeilTema')
@@ -164,7 +166,7 @@ function LeggTilbakepanel(props: Props) {
                             setTema={tema => updateState({ temagruppe: tema })}
                             valgtTema={state.temagruppe}
                             visFeilmelding={!LeggTilbakeValidator.tema(state) && state.visFeilmeldinger}
-                            temavalg={TemaPlukkbare}
+                            temavalg={TemaLeggTilbake}
                         />
                     </UnmountClosed>
                     <ÅrsakRadio årsak={LeggTilbakeÅrsak.AnnenÅrsak} />

--- a/src/app/personside/infotabs/meldinger/utils/meldingerUtils.ts
+++ b/src/app/personside/infotabs/meldinger/utils/meldingerUtils.ts
@@ -98,7 +98,8 @@ export function kanTraadJournalfores(traad: Traad): boolean {
         !erFeilsendt(traad) &&
         !erJournalfort(nyesteMeldingITraad) &&
         erBehandlet(traad) &&
-        !erDelsvar(nyesteMeldingITraad)
+        !erDelsvar(nyesteMeldingITraad) &&
+        !erKommunaleTjenester(nyesteMeldingITraad.temagruppe)
     );
 }
 

--- a/src/models/Temagrupper.ts
+++ b/src/models/Temagrupper.ts
@@ -33,6 +33,18 @@ export const TemaPlukkbare = [
     Temagruppe.Uføretrygd,
     Temagruppe.Utland
 ];
+export const TemaLeggTilbake = [
+    Temagruppe.Arbeid,
+    Temagruppe.Familie,
+    Temagruppe.Hjelpemiddel,
+    Temagruppe.Bil,
+    Temagruppe.OrtopediskHjelpemiddel,
+    Temagruppe.Pensjon,
+    Temagruppe.PleiepengerSyktBarn,
+    Temagruppe.Uføretrygd,
+    Temagruppe.Utland,
+    Temagruppe.ØkonomiskSosial
+];
 
 export const TemaKommunaleTjenester = [Temagruppe.AndreSosiale, Temagruppe.ØkonomiskSosial];
 

--- a/src/models/oppgave.ts
+++ b/src/models/oppgave.ts
@@ -1,8 +1,8 @@
 export interface Oppgave {
     oppgaveId: string;
     fødselsnummer: string;
-    traadId: string;
     fraGosys?: boolean;
+    traadId?: string;
 }
 
 interface LeggTilbakeOppgaveBaseRequest {
@@ -16,6 +16,7 @@ interface LeggTilbakeOppgaveInnhabilRequest extends LeggTilbakeOppgaveBaseReques
 
 interface LeggTilbakeOppgaveFeilTemaRequest extends LeggTilbakeOppgaveBaseRequest {
     type: 'FeilTema';
+    traadId: string;
     temagruppe: string;
 }
 


### PR DESCRIPTION
Støtte slik at når henvendelse blir lagt tilbake kan også henvendelsen skifte temagruppe, no er det kun oppgave som gjer dette. Forberedelse til økonomisk sosialhjelp. legger til temagruppe økonomisk sosialhjelp på tilbakeleggbare temagrupper.