### PR TITLE
[OPP-1116] endringer ved introduksjon av oksos

### DIFF
--- a/src/app/personside/dialogpanel/fortsettDialog/FortsettDialog.tsx
+++ b/src/app/personside/dialogpanel/fortsettDialog/FortsettDialog.tsx
@@ -98,7 +98,7 @@ function FortsettDialog(props: Props) {
                     <BrukerKanSvare
                         formState={state}
                         updateFormState={updateState}
-                        visVelgSak={!erEldsteMeldingJournalfort(props.traad)}
+                        visVelgSak={!erEldsteMeldingJournalfort(props.traad) && !erOksosTraad}
                     />
                 </UnmountClosed>
                 <UnmountClosed isOpened={erDelsvar} hasNestedCollapse={true}>

--- a/src/app/personside/dialogpanel/fortsettDialog/leggTilbakePanel/LeggTilbakepanel.tsx
+++ b/src/app/personside/dialogpanel/fortsettDialog/leggTilbakePanel/LeggTilbakepanel.tsx
@@ -9,7 +9,7 @@ import Temavelger from '../../component/Temavelger';
 import { LeggTilbakeValidator } from './validatorer';
 import { useDispatch } from 'react-redux';
 import { LeggTilbakeOppgaveRequest } from '../../../../../models/oppgave';
-import { Temagruppe, TemaPlukkbare, TemaLeggTilbake } from '../../../../../models/Temagrupper';
+import { Temagruppe, TemaLeggTilbake, TemaPlukkbare } from '../../../../../models/Temagrupper';
 import { apiBaseUri } from '../../../../../api/config';
 import { post } from '../../../../../api/api';
 import { AlertStripeFeil } from 'nav-frontend-alertstriper';
@@ -18,6 +18,8 @@ import { useRestResource } from '../../../../../rest/consumer/useRestResource';
 import { usePostResource } from '../../../../../rest/consumer/usePostResource';
 import { FeatureToggles } from '../../../../../components/featureToggle/toggleIDs';
 import useFeatureToggle from '../../../../../components/featureToggle/useFeatureToggle';
+import { isLoadedPerson } from '../../../../../redux/restReducers/personinformasjon';
+import { Diskresjonskoder } from '../../../../../konstanter';
 
 export interface LeggTilbakeState {
     årsak?: LeggTilbakeÅrsak;
@@ -68,12 +70,17 @@ function LeggTilbakeFeilmelding(props: { status: FortsettDialogPanelState }) {
     return null;
 }
 function useGyldigTemagruppeListe() {
+    const personinformasjon = useRestResource(resources => resources.personinformasjon).resource;
     const sosialFT = useFeatureToggle(FeatureToggles.Sosial);
 
-    if (sosialFT.isOn) {
-        return TemaLeggTilbake;
+    const temagrupper = sosialFT.isOn ? TemaLeggTilbake : TemaPlukkbare;
+    const bevarOksos =
+        isLoadedPerson(personinformasjon) &&
+        personinformasjon.data.diskresjonskode?.kodeRef !== Diskresjonskoder.STRENGT_FORTROLIG_ADRESSE;
+    if (bevarOksos) {
+        return temagrupper;
     } else {
-        return TemaPlukkbare;
+        return temagrupper.filter(temagruppe => temagruppe !== Temagruppe.ØkonomiskSosial);
     }
 }
 

--- a/src/mock/featureToggle-mock.ts
+++ b/src/mock/featureToggle-mock.ts
@@ -9,6 +9,8 @@ export function mockFeatureToggle(toggleId: FeatureToggles): FeatureToggleRespon
             return true;
         case FeatureToggles.SvaksyntModus:
             return false;
+        case FeatureToggles.Sosial:
+            return true;
         default:
             return Math.random() > 0.5;
     }


### PR DESCRIPTION
* Ikke vis saks-velger på oppfølgingsspørmål når temagruppe er OKSOS,
siden disse ikke kan journalføres
* Fjern OKSOS som valg når man skal legge-tilbake og bruker har kode6