### PR TITLE
[OPP-1177] bump nav-frontend-skjema

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13942,9 +13942,9 @@
             "integrity": "sha512-S3ikh+s/1ta86YKSqw/1m6r2j4vD5E9MpyD2XgDKXcaO0JaHDBc/WKRuJGbCtnKHdkm0NdFpOk9Hp77Y2bNZiQ=="
         },
         "nav-frontend-skjema": {
-            "version": "3.0.1",
-            "resolved": "https://registry.npmjs.org/nav-frontend-skjema/-/nav-frontend-skjema-3.0.1.tgz",
-            "integrity": "sha512-bZ7UEdXUzyBeR6RNFF83MuxPqmCakw/r50rDxqEGYBDoY4Xxmma8qIWvIKlJp3wmk6XPZyfQvdnaMZcB7r7J+Q=="
+            "version": "3.0.5",
+            "resolved": "https://registry.npmjs.org/nav-frontend-skjema/-/nav-frontend-skjema-3.0.5.tgz",
+            "integrity": "sha512-MXuB1tJy7nrlwtrLX/5AS9IOkdKUSoC2JkGpehU1MeAP/PkPTxdDRt70BFnHzGyTL3ol5oAzNU0xrmvKE33wpw=="
         },
         "nav-frontend-skjema-style": {
             "version": "2.0.6",

--- a/package.json
+++ b/package.json
@@ -78,7 +78,7 @@
         "nav-frontend-modal-style": "^0.3.31",
         "nav-frontend-paneler": "^2.0.2",
         "nav-frontend-paneler-style": "^0.3.19",
-        "nav-frontend-skjema": "^3.0.1",
+        "nav-frontend-skjema": "^3.0.5",
         "nav-frontend-skjema-style": "^2.0.6",
         "nav-frontend-snakkeboble": "^2.0.2",
         "nav-frontend-snakkeboble-style": "^0.2.25",
@@ -109,6 +109,7 @@
     },
     "devDependencies": {
         "@craco/craco": "^5.6.2",
+        "@testing-library/react-hooks": "^2.0.1",
         "@types/classnames": "^2.2.4",
         "@types/detect-browser": "^2.0.1",
         "@types/enzyme": "^3.9.3",
@@ -141,8 +142,7 @@
         "lint-staged": "^8.1.5",
         "prettier": "^1.19.1",
         "react-test-renderer": "^16.8.6",
-        "typescript": "^3.8.0",
-        "@testing-library/react-hooks": "^2.0.1"
+        "typescript": "^3.8.0"
     },
     "browserslist": {
         "production": [

--- a/src/app/personside/dialogpanel/__snapshots__/DialogPanel.test.tsx.snap
+++ b/src/app/personside/dialogpanel/__snapshots__/DialogPanel.test.tsx.snap
@@ -293,6 +293,14 @@ exports[`viser dialogpanel 1`] = `
                   <div
                     className="textarea--medMeta__wrapper"
                   >
+                    <span
+                      className="sr-only"
+                      id="Helt tilfeldig ID"
+                    >
+                      Tekstområde med plass til 
+                      5000
+                       tegn.
+                    </span>
                     <textarea
                       aria-describedby="Helt tilfeldig ID"
                       aria-invalid={false}
@@ -306,12 +314,10 @@ exports[`viser dialogpanel 1`] = `
                           "height": "30px",
                         }
                       }
-                      type="text"
                       value=""
                     />
                     <p
                       className="textarea--medMeta__teller"
-                      id="Helt tilfeldig ID"
                     >
                       <span
                         className="teller-tekst"

--- a/src/app/personside/dialogpanel/sendMelding/__snapshots__/SendNyMelding.test.tsx.snap
+++ b/src/app/personside/dialogpanel/sendMelding/__snapshots__/SendNyMelding.test.tsx.snap
@@ -282,6 +282,14 @@ exports[`viser send ny melding 1`] = `
                 <div
                   className="textarea--medMeta__wrapper"
                 >
+                  <span
+                    className="sr-only"
+                    id="Helt tilfeldig ID"
+                  >
+                    Tekstområde med plass til 
+                    5000
+                     tegn.
+                  </span>
                   <textarea
                     aria-describedby="Helt tilfeldig ID"
                     aria-invalid={false}
@@ -295,12 +303,10 @@ exports[`viser send ny melding 1`] = `
                         "height": "30px",
                       }
                     }
-                    type="text"
                     value=""
                   />
                   <p
                     className="textarea--medMeta__teller"
-                    id="Helt tilfeldig ID"
                   >
                     <span
                       className="teller-tekst"

--- a/src/app/personside/infotabs/meldinger/traadvisning/__snapshots__/TraadVisningWrapper.test.tsx.snap
+++ b/src/app/personside/infotabs/meldinger/traadvisning/__snapshots__/TraadVisningWrapper.test.tsx.snap
@@ -1104,7 +1104,7 @@ exports[`Viser traad med verktøylinje 1`] = `
             className="textarea--medMeta__wrapper"
           >
             <textarea
-              aria-describedby="Helt tilfeldig ID"
+              aria-describedby=""
               aria-invalid={false}
               className="skjemaelement__input textarea--medMeta"
               id="Helt tilfeldig ID"
@@ -1114,7 +1114,6 @@ exports[`Viser traad med verktøylinje 1`] = `
                   "height": "30px",
                 }
               }
-              type="text"
               value=""
             />
           </div>

--- a/src/app/personside/infotabs/meldinger/traadvisning/verktoylinje/oppgave/__snapshots__/OpprettOppgaveContainer.test.tsx.snap
+++ b/src/app/personside/infotabs/meldinger/traadvisning/verktoylinje/oppgave/__snapshots__/OpprettOppgaveContainer.test.tsx.snap
@@ -368,7 +368,7 @@ exports[`Viser oppgavecontainer med alt innhold 1`] = `
         className="textarea--medMeta__wrapper"
       >
         <textarea
-          aria-describedby="Helt tilfeldig ID"
+          aria-describedby=""
           aria-invalid={false}
           className="skjemaelement__input textarea--medMeta"
           id="Helt tilfeldig ID"
@@ -378,7 +378,6 @@ exports[`Viser oppgavecontainer med alt innhold 1`] = `
               "height": "30px",
             }
           }
-          type="text"
           value=""
         />
       </div>


### PR DESCRIPTION
aria-describedby som referer til ett HTMLElement som endres på (id og
innhold) førte til at teksten ble lest opp av NVDA/JAWS.

Løst av https://github.com/navikt/nav-frontend-moduler/pull/736