### PR TITLE
[KAIZEN-0] tvinger core-js til versjon 3.5.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5507,16 +5507,6 @@
             "resolved": "https://registry.npmjs.org/babel-plugin-transform-react-remove-prop-types/-/babel-plugin-transform-react-remove-prop-types-0.4.24.tgz",
             "integrity": "sha512-eqj0hVcJUR57/Ug2zE1Yswsw4LhuqqHhD+8v120T1cl3kjg76QwtyBrdIk4WVwK+lAhBJVYCd/v+4nc4y+8JsA=="
         },
-        "babel-polyfill": {
-            "version": "6.26.0",
-            "resolved": "https://registry.npmjs.org/babel-polyfill/-/babel-polyfill-6.26.0.tgz",
-            "integrity": "sha1-N5k3q8Z9eJWXCtxiHyhM2WbPIVM=",
-            "requires": {
-                "babel-runtime": "^6.26.0",
-                "core-js": "^2.5.0",
-                "regenerator-runtime": "^0.10.5"
-            }
-        },
         "babel-preset-jest": {
             "version": "24.9.0",
             "resolved": "https://registry.npmjs.org/babel-preset-jest/-/babel-preset-jest-24.9.0.tgz",
@@ -5928,6 +5918,11 @@
                 "source-map-support": "^0.4.15"
             },
             "dependencies": {
+                "core-js": {
+                    "version": "3.5.0",
+                    "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.5.0.tgz",
+                    "integrity": "sha512-Ifh3kj78gzQ7NAoJXeTu+XwzDld0QRIwjBLRqAMhuLhP3d2Av5wmgE9ycfnvK6NAEjTkQ1sDPeoEZAWO3Hx1Uw=="
+                },
                 "source-map": {
                     "version": "0.5.7",
                     "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
@@ -5952,6 +5947,11 @@
                 "regenerator-runtime": "^0.11.0"
             },
             "dependencies": {
+                "core-js": {
+                    "version": "3.5.0",
+                    "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.5.0.tgz",
+                    "integrity": "sha512-Ifh3kj78gzQ7NAoJXeTu+XwzDld0QRIwjBLRqAMhuLhP3d2Av5wmgE9ycfnvK6NAEjTkQ1sDPeoEZAWO3Hx1Uw=="
+                },
                 "regenerator-runtime": {
                     "version": "0.11.1",
                     "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.11.1.tgz",
@@ -7008,9 +7008,9 @@
             "integrity": "sha1-Z29us8OZl8LuGsOpJP1hJHSPV40="
         },
         "core-js": {
-            "version": "2.6.9",
-            "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.6.9.tgz",
-            "integrity": "sha512-HOpZf6eXmnl7la+cUdMnLvUxKNqLUzJvgIziQ0DiF3JwSImNphIqdGqzj6hIKyX04MmV0poclQ7+wjWvxQyR2A=="
+            "version": "3.5.0",
+            "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.5.0.tgz",
+            "integrity": "sha512-Ifh3kj78gzQ7NAoJXeTu+XwzDld0QRIwjBLRqAMhuLhP3d2Av5wmgE9ycfnvK6NAEjTkQ1sDPeoEZAWO3Hx1Uw=="
         },
         "core-js-compat": {
             "version": "3.6.5",
@@ -7091,24 +7091,6 @@
                 "ripemd160": "^2.0.0",
                 "safe-buffer": "^5.0.1",
                 "sha.js": "^2.4.8"
-            }
-        },
-        "cross-fetch": {
-            "version": "2.2.3",
-            "resolved": "https://registry.npmjs.org/cross-fetch/-/cross-fetch-2.2.3.tgz",
-            "integrity": "sha512-PrWWNH3yL2NYIb/7WF/5vFG3DCQiXDOVf8k3ijatbrtnwNuhMWLC7YF7uqf53tbTFDzHIUD8oITw4Bxt8ST3Nw==",
-            "dev": true,
-            "requires": {
-                "node-fetch": "2.1.2",
-                "whatwg-fetch": "2.0.4"
-            },
-            "dependencies": {
-                "whatwg-fetch": {
-                    "version": "2.0.4",
-                    "resolved": "https://registry.npmjs.org/whatwg-fetch/-/whatwg-fetch-2.0.4.tgz",
-                    "integrity": "sha512-dcQ1GWpOD/eEQ97k66aiEVpNnapVj90/+R+SXTPYGHpYBBypfKJEQjLrvMZ7YXbKm21gXd4NcuxUTjiv1YtLng==",
-                    "dev": true
-                }
             }
         },
         "cross-spawn": {
@@ -9180,16 +9162,6 @@
                 "bser": "^2.0.0"
             }
         },
-        "fetch-mock": {
-            "version": "6.5.2",
-            "resolved": "https://registry.npmjs.org/fetch-mock/-/fetch-mock-6.5.2.tgz",
-            "integrity": "sha512-EIvbpCLBTYyDLu4HJiqD7wC8psDwTUaPaWXNKZbhNO/peUYKiNp5PkZGKRJtnTxaPQu71ivqafvjpM7aL+MofQ==",
-            "requires": {
-                "babel-polyfill": "^6.26.0",
-                "glob-to-regexp": "^0.4.0",
-                "path-to-regexp": "^2.2.1"
-            }
-        },
         "figgy-pudding": {
             "version": "3.5.1",
             "resolved": "https://registry.npmjs.org/figgy-pudding/-/figgy-pudding-3.5.1.tgz",
@@ -10252,11 +10224,6 @@
                     }
                 }
             }
-        },
-        "glob-to-regexp": {
-            "version": "0.4.1",
-            "resolved": "https://registry.npmjs.org/glob-to-regexp/-/glob-to-regexp-0.4.1.tgz",
-            "integrity": "sha512-lkX1HJXwyMcprw/5YUZc2s7DrpAiHB21/V+E1rHUrVNokkvB6bqMzT0VfV6/86ZNabt1k14YOIaT7nDvOX3Iiw=="
         },
         "global-modules": {
             "version": "2.0.0",
@@ -11926,16 +11893,6 @@
                 "enzyme-matchers": "^7.1.1",
                 "enzyme-to-json": "^3.3.0",
                 "jest-environment-enzyme": "^7.1.1"
-            }
-        },
-        "jest-fetch-mock": {
-            "version": "2.1.2",
-            "resolved": "https://registry.npmjs.org/jest-fetch-mock/-/jest-fetch-mock-2.1.2.tgz",
-            "integrity": "sha512-tcSR4Lh2bWLe1+0w/IwvNxeDocMI/6yIA2bijZ0fyWxC4kQ18lckQ1n7Yd40NKuisGmcGBRFPandRXrW/ti/Bw==",
-            "dev": true,
-            "requires": {
-                "cross-fetch": "^2.2.2",
-                "promise-polyfill": "^7.1.1"
             }
         },
         "jest-get-type": {
@@ -14044,12 +14001,6 @@
                 "tslib": "^1.10.0"
             }
         },
-        "node-fetch": {
-            "version": "2.1.2",
-            "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.1.2.tgz",
-            "integrity": "sha1-q4hOjn5X44qUR1POxwb3iNF2i7U=",
-            "dev": true
-        },
         "node-forge": {
             "version": "0.9.0",
             "resolved": "https://registry.npmjs.org/node-forge/-/node-forge-0.9.0.tgz",
@@ -15745,12 +15696,6 @@
             "resolved": "https://registry.npmjs.org/promise-inflight/-/promise-inflight-1.0.1.tgz",
             "integrity": "sha1-mEcocL8igTL8vdhoEputEsPAKeM="
         },
-        "promise-polyfill": {
-            "version": "7.1.2",
-            "resolved": "https://registry.npmjs.org/promise-polyfill/-/promise-polyfill-7.1.2.tgz",
-            "integrity": "sha512-FuEc12/eKqqoRYIGBrUptCBRhobL19PS2U31vMNTfyck1FxPyMfgsXyW4Mav85y/ZN1hop3hOwRlUDok23oYfQ==",
-            "dev": true
-        },
         "prompts": {
             "version": "2.3.2",
             "resolved": "https://registry.npmjs.org/prompts/-/prompts-2.3.2.tgz",
@@ -15977,9 +15922,9 @@
             },
             "dependencies": {
                 "core-js": {
-                    "version": "3.6.5",
-                    "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.6.5.tgz",
-                    "integrity": "sha512-vZVEEwZoIsI+vPEuoF9Iqf5H7/M3eeQqWlQnYa8FSKKePuYTf5MWnxb5SDAzCa60b3JBRS5g9b+Dq7b1y/RCrA=="
+                    "version": "3.5.0",
+                    "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.5.0.tgz",
+                    "integrity": "sha512-Ifh3kj78gzQ7NAoJXeTu+XwzDld0QRIwjBLRqAMhuLhP3d2Av5wmgE9ycfnvK6NAEjTkQ1sDPeoEZAWO3Hx1Uw=="
                 },
                 "promise": {
                     "version": "8.1.0",
@@ -17216,11 +17161,6 @@
             "requires": {
                 "regenerate": "^1.4.0"
             }
-        },
-        "regenerator-runtime": {
-            "version": "0.10.5",
-            "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.10.5.tgz",
-            "integrity": "sha1-M2w+/BIgrc7dosn6tntaeVWjNlg="
         },
         "regenerator-transform": {
             "version": "0.14.4",

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
         "url": "git+https://github.com/navikt/modiapersonoversikt"
     },
     "scripts": {
+        "preinstall": "npx npm-force-resolutions",
         "start": "craco start",
         "build": "craco build",
         "test": "craco test",
@@ -39,12 +40,11 @@
         "@nutgaard/use-fetch": "^2.3.1",
         "@nutgaard/use-formstate": "^2.2.1",
         "classnames": "^2.2.6",
-        "core-js": "^2.5.7",
+        "core-js": "3.5.0",
         "craco-less": "^1.15.0",
         "detect-browser": "^3.0.1",
         "downshift": "^5.0.5",
         "faker": "^4.1.0",
-        "fetch-mock": "^6.5.0",
         "history": "^4.7.2",
         "js-cookie": "^2.2.0",
         "lodash.debounce": "^4.0.8",
@@ -137,12 +137,14 @@
         "eslint-config-prettier": "^4.3.0",
         "husky": "^2.2.0",
         "jest-enzyme": "^7.0.2",
-        "jest-fetch-mock": "^2.1.2",
         "jest-styled-components": "^7.0.2",
         "lint-staged": "^8.1.5",
         "prettier": "^1.19.1",
         "react-test-renderer": "^16.8.6",
         "typescript": "^3.8.0"
+    },
+    "resolutions": {
+        "core-js": "3.5.0"
     },
     "browserslist": {
         "production": [

--- a/src/setupTests.ts
+++ b/src/setupTests.ts
@@ -1,7 +1,7 @@
+import 'core-js/stable';
 import { configure } from 'enzyme';
 import EnzymeReactAdapter from 'enzyme-adapter-react-16';
 import 'jest-enzyme';
-import 'babel-polyfill';
 import 'jest-styled-components';
 
 configure({ adapter: new EnzymeReactAdapter() });


### PR DESCRIPTION
Gjøres pga følgende issues;
https://github.com/github/fetch/issues/750
https://github.com/github/fetch/issues/748
https://github.com/zloirock/core-js/issues/751
https://github.com/zloirock/core-js/issues/741

I bunn og grunn, core-js@^3.6.0 introduserte støtte for
String.prototype.split med regex som har sticky-flag. Pga bug her så
fungerer ikke funksjonen som forventet noe mer i eldre IE11 versjoner.

E.g `"test".split(/e/) === ['t', 'e', 's', 't']`, denne burde gitt
`['t', 'st']`