### PR TITLE
[KAIZEN-0] tester ut beta-versjon av yet-another-fetch-mock sitt nye api

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9596,25 +9596,24 @@
             "dependencies": {
                 "abbrev": {
                     "version": "1.1.1",
-                    "resolved": false,
+                    "resolved": "",
                     "integrity": "sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q==",
                     "optional": true
                 },
                 "ansi-regex": {
                     "version": "2.1.1",
-                    "resolved": false,
-                    "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
-                    "optional": true
+                    "resolved": "",
+                    "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8="
                 },
                 "aproba": {
                     "version": "1.2.0",
-                    "resolved": false,
+                    "resolved": "",
                     "integrity": "sha512-Y9J6ZjXtoYh8RnXVCMOU/ttDmk1aBjunq9vO0ta5x85WDQiQfUF9sIPBITdbiiIVcBo03Hi3jMxigBtsddlXRw==",
                     "optional": true
                 },
                 "are-we-there-yet": {
                     "version": "1.1.5",
-                    "resolved": false,
+                    "resolved": "",
                     "integrity": "sha512-5hYdAkZlcG8tOLujVDTgCT+uPX0VnpAH28gWsLfzpXYm7wP6mp5Q/gYyR7YQ0cKVJcXJnl3j2kpBan13PtQf6w==",
                     "optional": true,
                     "requires": {
@@ -9624,15 +9623,13 @@
                 },
                 "balanced-match": {
                     "version": "1.0.0",
-                    "resolved": false,
-                    "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
-                    "optional": true
+                    "resolved": "",
+                    "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c="
                 },
                 "brace-expansion": {
                     "version": "1.1.11",
-                    "resolved": false,
+                    "resolved": "",
                     "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
-                    "optional": true,
                     "requires": {
                         "balanced-match": "^1.0.0",
                         "concat-map": "0.0.1"
@@ -9640,37 +9637,34 @@
                 },
                 "chownr": {
                     "version": "1.1.1",
-                    "resolved": false,
+                    "resolved": "",
                     "integrity": "sha512-j38EvO5+LHX84jlo6h4UzmOwi0UgW61WRyPtJz4qaadK5eY3BTS5TY/S1Stc3Uk2lIM6TPevAlULiEJwie860g==",
                     "optional": true
                 },
                 "code-point-at": {
                     "version": "1.1.0",
-                    "resolved": false,
-                    "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c=",
-                    "optional": true
+                    "resolved": "",
+                    "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c="
                 },
                 "concat-map": {
                     "version": "0.0.1",
-                    "resolved": false,
-                    "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
-                    "optional": true
+                    "resolved": "",
+                    "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s="
                 },
                 "console-control-strings": {
                     "version": "1.1.0",
-                    "resolved": false,
-                    "integrity": "sha1-PXz0Rk22RG6mRL9LOVB/mFEAjo4=",
-                    "optional": true
+                    "resolved": "",
+                    "integrity": "sha1-PXz0Rk22RG6mRL9LOVB/mFEAjo4="
                 },
                 "core-util-is": {
                     "version": "1.0.2",
-                    "resolved": false,
+                    "resolved": "",
                     "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=",
                     "optional": true
                 },
                 "debug": {
                     "version": "4.1.1",
-                    "resolved": false,
+                    "resolved": "",
                     "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
                     "optional": true,
                     "requires": {
@@ -9679,25 +9673,25 @@
                 },
                 "deep-extend": {
                     "version": "0.6.0",
-                    "resolved": false,
+                    "resolved": "",
                     "integrity": "sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA==",
                     "optional": true
                 },
                 "delegates": {
                     "version": "1.0.0",
-                    "resolved": false,
+                    "resolved": "",
                     "integrity": "sha1-hMbhWbgZBP3KWaDvRM2HDTElD5o=",
                     "optional": true
                 },
                 "detect-libc": {
                     "version": "1.0.3",
-                    "resolved": false,
+                    "resolved": "",
                     "integrity": "sha1-+hN8S9aY7fVc1c0CrFWfkaTEups=",
                     "optional": true
                 },
                 "fs-minipass": {
                     "version": "1.2.5",
-                    "resolved": false,
+                    "resolved": "",
                     "integrity": "sha512-JhBl0skXjUPCFH7x6x61gQxrKyXsxB5gcgePLZCwfyCGGsTISMoIeObbrvVeP6Xmyaudw4TT43qV2Gz+iyd2oQ==",
                     "optional": true,
                     "requires": {
@@ -9706,13 +9700,13 @@
                 },
                 "fs.realpath": {
                     "version": "1.0.0",
-                    "resolved": false,
+                    "resolved": "",
                     "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
                     "optional": true
                 },
                 "gauge": {
                     "version": "2.7.4",
-                    "resolved": false,
+                    "resolved": "",
                     "integrity": "sha1-LANAXHU4w51+s3sxcCLjJfsBi/c=",
                     "optional": true,
                     "requires": {
@@ -9728,7 +9722,7 @@
                 },
                 "glob": {
                     "version": "7.1.3",
-                    "resolved": false,
+                    "resolved": "",
                     "integrity": "sha512-vcfuiIxogLV4DlGBHIUOwI0IbrJ8HWPc4MU7HzviGeNho/UJDfi6B5p3sHeWIQ0KGIU0Jpxi5ZHxemQfLkkAwQ==",
                     "optional": true,
                     "requires": {
@@ -9742,13 +9736,13 @@
                 },
                 "has-unicode": {
                     "version": "2.0.1",
-                    "resolved": false,
+                    "resolved": "",
                     "integrity": "sha1-4Ob+aijPUROIVeCG0Wkedx3iqLk=",
                     "optional": true
                 },
                 "iconv-lite": {
                     "version": "0.4.24",
-                    "resolved": false,
+                    "resolved": "",
                     "integrity": "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==",
                     "optional": true,
                     "requires": {
@@ -9757,7 +9751,7 @@
                 },
                 "ignore-walk": {
                     "version": "3.0.1",
-                    "resolved": false,
+                    "resolved": "",
                     "integrity": "sha512-DTVlMx3IYPe0/JJcYP7Gxg7ttZZu3IInhuEhbchuqneY9wWe5Ojy2mXLBaQFUQmo0AW2r3qG7m1mg86js+gnlQ==",
                     "optional": true,
                     "requires": {
@@ -9766,7 +9760,7 @@
                 },
                 "inflight": {
                     "version": "1.0.6",
-                    "resolved": false,
+                    "resolved": "",
                     "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
                     "optional": true,
                     "requires": {
@@ -9776,51 +9770,46 @@
                 },
                 "inherits": {
                     "version": "2.0.3",
-                    "resolved": false,
-                    "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
-                    "optional": true
+                    "resolved": "",
+                    "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4="
                 },
                 "ini": {
                     "version": "1.3.5",
-                    "resolved": false,
+                    "resolved": "",
                     "integrity": "sha512-RZY5huIKCMRWDUqZlEi72f/lmXKMvuszcMBduliQ3nnWbx9X/ZBQO7DijMEYS9EhHBb2qacRUMtC7svLwe0lcw==",
                     "optional": true
                 },
                 "is-fullwidth-code-point": {
                     "version": "1.0.0",
-                    "resolved": false,
+                    "resolved": "",
                     "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
-                    "optional": true,
                     "requires": {
                         "number-is-nan": "^1.0.0"
                     }
                 },
                 "isarray": {
                     "version": "1.0.0",
-                    "resolved": false,
+                    "resolved": "",
                     "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
                     "optional": true
                 },
                 "minimatch": {
                     "version": "3.0.4",
-                    "resolved": false,
+                    "resolved": "",
                     "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
-                    "optional": true,
                     "requires": {
                         "brace-expansion": "^1.1.7"
                     }
                 },
                 "minimist": {
                     "version": "0.0.8",
-                    "resolved": false,
-                    "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
-                    "optional": true
+                    "resolved": "",
+                    "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0="
                 },
                 "minipass": {
                     "version": "2.3.5",
-                    "resolved": false,
+                    "resolved": "",
                     "integrity": "sha512-Gi1W4k059gyRbyVUZQ4mEqLm0YIUiGYfvxhF6SIlk3ui1WVxMTGfGdQ2SInh3PDrRTVvPKgULkpJtT4RH10+VA==",
-                    "optional": true,
                     "requires": {
                         "safe-buffer": "^5.1.2",
                         "yallist": "^3.0.0"
@@ -9828,7 +9817,7 @@
                 },
                 "minizlib": {
                     "version": "1.2.1",
-                    "resolved": false,
+                    "resolved": "",
                     "integrity": "sha512-7+4oTUOWKg7AuL3vloEWekXY2/D20cevzsrNT2kGWm+39J9hGTCBv8VI5Pm5lXZ/o3/mdR4f8rflAPhnQb8mPA==",
                     "optional": true,
                     "requires": {
@@ -9837,22 +9826,21 @@
                 },
                 "mkdirp": {
                     "version": "0.5.1",
-                    "resolved": false,
+                    "resolved": "",
                     "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
-                    "optional": true,
                     "requires": {
                         "minimist": "0.0.8"
                     }
                 },
                 "ms": {
                     "version": "2.1.1",
-                    "resolved": false,
+                    "resolved": "",
                     "integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg==",
                     "optional": true
                 },
                 "needle": {
                     "version": "2.3.0",
-                    "resolved": false,
+                    "resolved": "",
                     "integrity": "sha512-QBZu7aAFR0522EyaXZM0FZ9GLpq6lvQ3uq8gteiDUp7wKdy0lSd2hPlgFwVuW1CBkfEs9PfDQsQzZghLs/psdg==",
                     "optional": true,
                     "requires": {
@@ -9863,7 +9851,7 @@
                 },
                 "node-pre-gyp": {
                     "version": "0.12.0",
-                    "resolved": false,
+                    "resolved": "",
                     "integrity": "sha512-4KghwV8vH5k+g2ylT+sLTjy5wmUOb9vPhnM8NHvRf9dHmnW/CndrFXy2aRPaPST6dugXSdHXfeaHQm77PIz/1A==",
                     "optional": true,
                     "requires": {
@@ -9881,7 +9869,7 @@
                 },
                 "nopt": {
                     "version": "4.0.1",
-                    "resolved": false,
+                    "resolved": "",
                     "integrity": "sha1-0NRoWv1UFRk8jHUFYC0NF81kR00=",
                     "optional": true,
                     "requires": {
@@ -9891,13 +9879,13 @@
                 },
                 "npm-bundled": {
                     "version": "1.0.6",
-                    "resolved": false,
+                    "resolved": "",
                     "integrity": "sha512-8/JCaftHwbd//k6y2rEWp6k1wxVfpFzB6t1p825+cUb7Ym2XQfhwIC5KwhrvzZRJu+LtDE585zVaS32+CGtf0g==",
                     "optional": true
                 },
                 "npm-packlist": {
                     "version": "1.4.1",
-                    "resolved": false,
+                    "resolved": "",
                     "integrity": "sha512-+TcdO7HJJ8peiiYhvPxsEDhF3PJFGUGRcFsGve3vxvxdcpO2Z4Z7rkosRM0kWj6LfbK/P0gu3dzk5RU1ffvFcw==",
                     "optional": true,
                     "requires": {
@@ -9907,7 +9895,7 @@
                 },
                 "npmlog": {
                     "version": "4.1.2",
-                    "resolved": false,
+                    "resolved": "",
                     "integrity": "sha512-2uUqazuKlTaSI/dC8AzicUck7+IrEaOnN/e0jd3Xtt1KcGpwx30v50mL7oPyr/h9bL3E4aZccVwpwP+5W9Vjkg==",
                     "optional": true,
                     "requires": {
@@ -9919,40 +9907,38 @@
                 },
                 "number-is-nan": {
                     "version": "1.0.1",
-                    "resolved": false,
-                    "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0=",
-                    "optional": true
+                    "resolved": "",
+                    "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0="
                 },
                 "object-assign": {
                     "version": "4.1.1",
-                    "resolved": false,
+                    "resolved": "",
                     "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
                     "optional": true
                 },
                 "once": {
                     "version": "1.4.0",
-                    "resolved": false,
+                    "resolved": "",
                     "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
-                    "optional": true,
                     "requires": {
                         "wrappy": "1"
                     }
                 },
                 "os-homedir": {
                     "version": "1.0.2",
-                    "resolved": false,
+                    "resolved": "",
                     "integrity": "sha1-/7xJiDNuDoM94MFox+8VISGqf7M=",
                     "optional": true
                 },
                 "os-tmpdir": {
                     "version": "1.0.2",
-                    "resolved": false,
+                    "resolved": "",
                     "integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ=",
                     "optional": true
                 },
                 "osenv": {
                     "version": "0.1.5",
-                    "resolved": false,
+                    "resolved": "",
                     "integrity": "sha512-0CWcCECdMVc2Rw3U5w9ZjqX6ga6ubk1xDVKxtBQPK7wis/0F2r9T6k4ydGYhecl7YUBxBVxhL5oisPsNxAPe2g==",
                     "optional": true,
                     "requires": {
@@ -9962,19 +9948,19 @@
                 },
                 "path-is-absolute": {
                     "version": "1.0.1",
-                    "resolved": false,
+                    "resolved": "",
                     "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
                     "optional": true
                 },
                 "process-nextick-args": {
                     "version": "2.0.0",
-                    "resolved": false,
+                    "resolved": "",
                     "integrity": "sha512-MtEC1TqN0EU5nephaJ4rAtThHtC86dNN9qCuEhtshvpVBkAW5ZO7BASN9REnF9eoXGcRub+pFuKEpOHE+HbEMw==",
                     "optional": true
                 },
                 "rc": {
                     "version": "1.2.8",
-                    "resolved": false,
+                    "resolved": "",
                     "integrity": "sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==",
                     "optional": true,
                     "requires": {
@@ -9986,7 +9972,7 @@
                     "dependencies": {
                         "minimist": {
                             "version": "1.2.0",
-                            "resolved": false,
+                            "resolved": "",
                             "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
                             "optional": true
                         }
@@ -9994,7 +9980,7 @@
                 },
                 "readable-stream": {
                     "version": "2.3.6",
-                    "resolved": false,
+                    "resolved": "",
                     "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
                     "optional": true,
                     "requires": {
@@ -10009,7 +9995,7 @@
                 },
                 "rimraf": {
                     "version": "2.6.3",
-                    "resolved": false,
+                    "resolved": "",
                     "integrity": "sha512-mwqeW5XsA2qAejG46gYdENaxXjx9onRNCfn7L0duuP4hCuTIi/QO7PDK07KJfp1d+izWPrzEJDcSqBa0OZQriA==",
                     "optional": true,
                     "requires": {
@@ -10018,45 +10004,43 @@
                 },
                 "safe-buffer": {
                     "version": "5.1.2",
-                    "resolved": false,
-                    "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
-                    "optional": true
+                    "resolved": "",
+                    "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
                 },
                 "safer-buffer": {
                     "version": "2.1.2",
-                    "resolved": false,
+                    "resolved": "",
                     "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
                     "optional": true
                 },
                 "sax": {
                     "version": "1.2.4",
-                    "resolved": false,
+                    "resolved": "",
                     "integrity": "sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw==",
                     "optional": true
                 },
                 "semver": {
                     "version": "5.7.0",
-                    "resolved": false,
+                    "resolved": "",
                     "integrity": "sha512-Ya52jSX2u7QKghxeoFGpLwCtGlt7j0oY9DYb5apt9nPlJ42ID+ulTXESnt/qAQcoSERyZ5sl3LDIOw0nAn/5DA==",
                     "optional": true
                 },
                 "set-blocking": {
                     "version": "2.0.0",
-                    "resolved": false,
+                    "resolved": "",
                     "integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc=",
                     "optional": true
                 },
                 "signal-exit": {
                     "version": "3.0.2",
-                    "resolved": false,
+                    "resolved": "",
                     "integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0=",
                     "optional": true
                 },
                 "string-width": {
                     "version": "1.0.2",
-                    "resolved": false,
+                    "resolved": "",
                     "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
-                    "optional": true,
                     "requires": {
                         "code-point-at": "^1.0.0",
                         "is-fullwidth-code-point": "^1.0.0",
@@ -10065,7 +10049,7 @@
                 },
                 "string_decoder": {
                     "version": "1.1.1",
-                    "resolved": false,
+                    "resolved": "",
                     "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
                     "optional": true,
                     "requires": {
@@ -10074,22 +10058,21 @@
                 },
                 "strip-ansi": {
                     "version": "3.0.1",
-                    "resolved": false,
+                    "resolved": "",
                     "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
-                    "optional": true,
                     "requires": {
                         "ansi-regex": "^2.0.0"
                     }
                 },
                 "strip-json-comments": {
                     "version": "2.0.1",
-                    "resolved": false,
+                    "resolved": "",
                     "integrity": "sha1-PFMZQukIwml8DsNEhYwobHygpgo=",
                     "optional": true
                 },
                 "tar": {
                     "version": "4.4.8",
-                    "resolved": false,
+                    "resolved": "",
                     "integrity": "sha512-LzHF64s5chPQQS0IYBn9IN5h3i98c12bo4NCO7e0sGM2llXQ3p2FGC5sdENN4cTW48O915Sh+x+EXx7XW96xYQ==",
                     "optional": true,
                     "requires": {
@@ -10104,13 +10087,13 @@
                 },
                 "util-deprecate": {
                     "version": "1.0.2",
-                    "resolved": false,
+                    "resolved": "",
                     "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=",
                     "optional": true
                 },
                 "wide-align": {
                     "version": "1.1.3",
-                    "resolved": false,
+                    "resolved": "",
                     "integrity": "sha512-QGkOQc8XL6Bt5PwnsExKBPuMKBxnGxWWW3fU55Xt4feHozMUhdUMaBCk290qpm/wG5u/RSKzwdAC4i51YigihA==",
                     "optional": true,
                     "requires": {
@@ -10119,15 +10102,13 @@
                 },
                 "wrappy": {
                     "version": "1.0.2",
-                    "resolved": false,
-                    "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
-                    "optional": true
+                    "resolved": "",
+                    "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8="
                 },
                 "yallist": {
                     "version": "3.0.3",
-                    "resolved": false,
-                    "integrity": "sha512-S+Zk8DEWE6oKpV+vI3qWkaK+jSbIK86pCwe2IF/xwIpQ8jEuxpw9NyaGjmp9+BoJv5FV2piqCDcoCtStppiq2A==",
-                    "optional": true
+                    "resolved": "",
+                    "integrity": "sha512-S+Zk8DEWE6oKpV+vI3qWkaK+jSbIK86pCwe2IF/xwIpQ8jEuxpw9NyaGjmp9+BoJv5FV2piqCDcoCtStppiq2A=="
                 }
             }
         },
@@ -20533,9 +20514,9 @@
             }
         },
         "yet-another-fetch-mock": {
-            "version": "3.2.0",
-            "resolved": "https://registry.npmjs.org/yet-another-fetch-mock/-/yet-another-fetch-mock-3.2.0.tgz",
-            "integrity": "sha512-FB7osdnHoWDTI2Z53iTAzhBpSPa+3shVIVsQHJ0juD3Ug2u38Hd2Xou/TGk3/YETzanxQp47az24UL3zeSf4Bg==",
+            "version": "4.0.0-beta.0",
+            "resolved": "https://registry.npmjs.org/yet-another-fetch-mock/-/yet-another-fetch-mock-4.0.0-beta.0.tgz",
+            "integrity": "sha512-HJcKKg7HbsrKTjaxaQJqTTTS36mdY2J+rLuRNP2NxE+yb0OBynnloLiM7U6BAh5c+5KOl/jc5GgCFG1jsnuPcg==",
             "requires": {
                 "path-to-regexp": "^2.1.0",
                 "query-string": "^5.1.0"

--- a/package.json
+++ b/package.json
@@ -105,7 +105,7 @@
         "redux-devtools-extension": "^2.13.7",
         "redux-thunk": "^2.3.0",
         "styled-components": "^5.1.1",
-        "yet-another-fetch-mock": "^3.2.0"
+        "yet-another-fetch-mock": "^4.0.0-beta.0"
     },
     "devDependencies": {
         "@craco/craco": "^5.6.2",

--- a/src/mock/draft-mock.ts
+++ b/src/mock/draft-mock.ts
@@ -1,7 +1,8 @@
-import FetchMock, { JSONObject, MockHandler, ResponseUtils } from 'yet-another-fetch-mock';
+import FetchMock, { Handler } from 'yet-another-fetch-mock';
 import { getMockInnloggetSaksbehandler } from './innloggetSaksbehandler-mock';
 import { Draft, DraftContext } from '../app/personside/dialogpanel/use-draft';
 import { randomDelay } from './index';
+import { delayed } from './utils';
 
 const innloggetSaksbehandler = getMockInnloggetSaksbehandler();
 const storage = window.localStorage;
@@ -20,7 +21,7 @@ if (!storage.getItem(storageKey)) {
         ])
     );
 }
-let drafts: Array<Draft & JSONObject> = JSON.parse(storage.getItem('modiapersonoversikt-drafts-mock')!);
+let drafts: Array<Draft> = JSON.parse(storage.getItem('modiapersonoversikt-drafts-mock')!);
 
 function matchContext(context: DraftContext, other: DraftContext, exact: boolean = true): boolean {
     const keys = Object.keys(context);
@@ -38,19 +39,17 @@ function matchContext(context: DraftContext, other: DraftContext, exact: boolean
     });
 }
 
-const findDrafts: MockHandler = ({ queryParams }) => {
+const findDrafts: Handler = ({ queryParams }, res, ctx) => {
     const exact = !(queryParams['exact'] === 'false');
     const context: DraftContext = { ...queryParams };
     delete context['exact'];
-    const matchedDrafts: Array<Draft & JSONObject> = drafts.filter((draft: Draft) =>
-        matchContext(draft.context, context, exact)
-    );
+    const matchedDrafts: Array<Draft> = drafts.filter((draft: Draft) => matchContext(draft.context, context, exact));
 
-    return ResponseUtils.jsonPromise(matchedDrafts);
+    return res(ctx.json(matchedDrafts));
 };
 
-const updateDraft: MockHandler = ({ body }) => {
-    const newDraft: Draft & JSONObject = {
+const updateDraft: Handler = ({ body }, res, ctx) => {
+    const newDraft: Draft = {
         owner: innloggetSaksbehandler.ident,
         content: body.content,
         context: body.context,
@@ -61,20 +60,20 @@ const updateDraft: MockHandler = ({ body }) => {
     drafts.push(newDraft);
     storage.setItem(storageKey, JSON.stringify(drafts));
 
-    return ResponseUtils.jsonPromise(newDraft);
+    return res(ctx.json(newDraft));
 };
 
-const deleteDraft: MockHandler = ({ body }) => {
+const deleteDraft: Handler = ({ body }, res, ctx) => {
     const context: DraftContext = { ...body };
     drafts = drafts.filter((draft: Draft) => !matchContext(draft.context, context, true));
     storage.setItem(storageKey, JSON.stringify(drafts));
 
-    return ResponseUtils.jsonPromise({ status: 200 });
+    return res(ctx.status(200));
 };
 
 export function setupDraftMock(mock: FetchMock) {
     // console.log(findDrafts, updateDraft, deleteDraft);
-    mock.get('/modiapersonoversikt-draft/api/draft', ResponseUtils.delayed(2 * randomDelay(), findDrafts));
-    mock.post('/modiapersonoversikt-draft/api/draft', ResponseUtils.delayed(2 * randomDelay(), updateDraft));
-    mock.delete('/modiapersonoversikt-draft/api/draft', ResponseUtils.delayed(2 * randomDelay(), deleteDraft));
+    mock.get('/modiapersonoversikt-draft/api/draft', delayed(2 * randomDelay(), findDrafts));
+    mock.post('/modiapersonoversikt-draft/api/draft', delayed(2 * randomDelay(), updateDraft));
+    mock.delete('/modiapersonoversikt-draft/api/draft', delayed(2 * randomDelay(), deleteDraft));
 }

--- a/src/mock/index.ts
+++ b/src/mock/index.ts
@@ -1,15 +1,8 @@
 import faker from 'faker/locale/nb_NO';
 import navfaker from 'nav-faker';
 import Cookies from 'js-cookie';
-import FetchMock, {
-    HandlerArgument,
-    Middleware,
-    MiddlewareUtils,
-    MockHandler,
-    ResponseUtils
-} from 'yet-another-fetch-mock';
+import FetchMock, { Handler, HandlerRequest, Middleware, MiddlewareUtils } from 'yet-another-fetch-mock';
 import { erGyldigFødselsnummer } from 'nav-faker/dist/personidentifikator/helpers/fodselsnummer-utils';
-
 import { apiBaseUri } from '../api/config';
 import { getPerson } from './person/personMock';
 import { getMockKontaktinformasjon } from './person/krrKontaktinformasjon/kontaktinformasjon-mock';
@@ -48,6 +41,7 @@ import { setupSaksbehandlerInnstillingerMock } from './saksbehandlerinnstillinge
 import { failurerateMiddleware } from './utils/failureMiddleware';
 import { setupDraftMock } from './draft-mock';
 import tilgangskontrollMock from './tilgangskontroll-mock';
+import { delayed } from './utils';
 
 const STATUS_OK = () => 200;
 const STATUS_BAD_REQUEST = () => 400;
@@ -62,8 +56,8 @@ export function randomDelay() {
     return faker.random.number(750);
 }
 
-const fødselsNummerErGyldigStatus = (args: HandlerArgument) =>
-    erGyldigFødselsnummer(args.pathParams.fodselsnummer) ? STATUS_OK() : STATUS_BAD_REQUEST();
+const fødselsNummerErGyldigStatus = (req: HandlerRequest) =>
+    erGyldigFødselsnummer(req.pathParams.fodselsnummer) ? STATUS_OK() : STATUS_BAD_REQUEST();
 
 function setupInnloggetSaksbehandlerMock(mock: FetchMock) {
     mock.get(
@@ -205,17 +199,17 @@ function setupVarselMock(mock: FetchMock) {
         )
     );
 
-    const dittnaveventHandler: MockHandler = ({ init }) => {
-        const headers: any = init?.headers;
+    const dittnaveventHandler: Handler = (req, res, ctx) => {
+        const headers: any = req.init?.headers;
         const fnr = headers.fodselsnummer;
         if (!erGyldigFødselsnummer(fnr)) {
-            return Promise.resolve({ status: 400 });
+            return res(ctx.status(400));
         }
-        return Promise.resolve({ status: 200, body: JSON.stringify(getDittNavVarsler(fnr)) });
+        return res(ctx.status(200), ctx.json(getDittNavVarsler(fnr)));
     };
 
-    mock.get('/dittnav-eventer-modia/fetch/beskjed/all', ResponseUtils.delayed(randomDelay(), dittnaveventHandler));
-    mock.get('/dittnav-eventer-modia/fetch/oppgave/all', ResponseUtils.delayed(randomDelay(), dittnaveventHandler));
+    mock.get('/dittnav-eventer-modia/fetch/beskjed/all', delayed(randomDelay(), dittnaveventHandler));
+    mock.get('/dittnav-eventer-modia/fetch/oppgave/all', delayed(randomDelay(), dittnaveventHandler));
 }
 
 function setupMeldingerMock(mock: FetchMock) {
@@ -284,14 +278,14 @@ function setupGeografiskTilknytningMock(mock: FetchMock) {
         apiBaseUri + '/enheter',
         withDelayedResponse(
             randomDelay(),
-            (args: HandlerArgument) => {
+            (args: HandlerRequest) => {
                 if (isNaN(args.queryParams.gt) && !args.queryParams.dkode) {
                     return 404;
                 } else {
                     return 200;
                 }
             },
-            (args: HandlerArgument) => getMockNavKontor(args.queryParams.gt, args.queryParams.dkode)
+            (args: HandlerRequest) => getMockNavKontor(args.queryParams.gt, args.queryParams.dkode)
         )
     );
 }
@@ -303,7 +297,7 @@ function setupPersonsokMock(mock: FetchMock) {
     );
 }
 
-function setSaksbehandlerinnstillingerMockBackend(args: HandlerArgument) {
+function setSaksbehandlerinnstillingerMockBackend(args: HandlerRequest) {
     Cookies.set(saksbehandlerCookieNavnPrefix + '-Z990099', args.body);
     return args.body;
 }

--- a/src/mock/saksbehandlerinnstillinger-mock.ts
+++ b/src/mock/saksbehandlerinnstillinger-mock.ts
@@ -1,7 +1,7 @@
-import FetchMock, { JSONObject, ResponseUtils } from 'yet-another-fetch-mock';
+import FetchMock from 'yet-another-fetch-mock';
 import { SaksbehandlerInnstillinger } from '../redux/innstillinger';
 
-let innstillinger: SaksbehandlerInnstillinger & JSONObject = {
+let innstillinger: SaksbehandlerInnstillinger = {
     sistLagret: '2020-04-07T12:12:54',
     innstillinger: {
         defaultTagsStandardtekster: 'sto'
@@ -11,21 +11,15 @@ let innstillinger: SaksbehandlerInnstillinger & JSONObject = {
 export function setupSaksbehandlerInnstillingerMock(mock: FetchMock) {
     mock.get(
         '/modiapersonoversikt-innstillinger/api/innstillinger',
-        ResponseUtils.delayed(500, () => ResponseUtils.jsonPromise(innstillinger))
+        (req, res, ctx) => res(ctx.delay(500), ctx.json(innstillinger))
         // ResponseUtils.delayed(500, () => Promise.resolve({ status: 404 }))
     );
 
-    mock.post(
-        '/modiapersonoversikt-innstillinger/api/innstillinger',
-        ResponseUtils.delayed(500, ({ body }) => {
-            innstillinger = {
-                sistLagret: new Date().toISOString(),
-                innstillinger: body
-            };
-            return Promise.resolve({
-                status: 200,
-                body: JSON.stringify(innstillinger)
-            });
-        })
-    );
+    mock.post('/modiapersonoversikt-innstillinger/api/innstillinger', (req, res, ctx) => {
+        innstillinger = {
+            sistLagret: new Date().toISOString(),
+            innstillinger: req.body
+        };
+        return res(ctx.status(200), ctx.json(innstillinger));
+    });
 }

--- a/src/mock/utils.ts
+++ b/src/mock/utils.ts
@@ -1,0 +1,8 @@
+import { Handler } from 'yet-another-fetch-mock';
+
+export function delayed(ms: number, handler: Handler): Handler {
+    return async (req, res, ctx) => {
+        await new Promise(resolve => setTimeout(resolve, ms));
+        return handler(req, res, ctx);
+    };
+}

--- a/src/mock/utils/failureMiddleware.ts
+++ b/src/mock/utils/failureMiddleware.ts
@@ -1,4 +1,5 @@
-import { HandlerArgument, Middleware, ResponseData } from 'yet-another-fetch-mock';
+import { Middleware, ResponseData } from 'yet-another-fetch-mock';
+import { HandlerRequest } from 'yet-another-fetch-mock/dist/types/types';
 
 const failures: ResponseData[] = [
     {
@@ -16,7 +17,7 @@ const failures: ResponseData[] = [
 ];
 
 export function failurerateMiddleware(probabilityOfFailure: number): Middleware {
-    return (request: HandlerArgument, response: ResponseData) => {
+    return (request: HandlerRequest, response: ResponseData) => {
         return new Promise<ResponseData>(resolve => {
             const rnd = Math.random();
             if (rnd < probabilityOfFailure) {

--- a/src/mock/utils/fetch-utils.ts
+++ b/src/mock/utils/fetch-utils.ts
@@ -1,27 +1,17 @@
-import { HandlerArgument, JSONValue, ResponseData, ResponseUtils } from 'yet-another-fetch-mock';
+import { Handler, HandlerRequest } from 'yet-another-fetch-mock';
 
 export function withDelayedResponse(
     delay: number,
-    statusCode: (args: HandlerArgument) => number,
-    genererMockData: (args: HandlerArgument) => object | object[] | undefined
-) {
-    return ResponseUtils.delayed(delay, (args: HandlerArgument) => lagPromise(statusCode(args), genererMockData(args)));
-}
-
-function lagPromise(statusCode: number, data: object | object[] | undefined): Promise<ResponseData> {
-    return new Promise(resolve => {
-        if (statusCode >= 200 && statusCode < 300) {
-            resolve(ResponseUtils.jsonPromise(data as JSONValue));
-        } else {
-            resolve({ status: statusCode });
-        }
-    });
+    statusCode: (args: HandlerRequest) => number,
+    genererMockData: (args: HandlerRequest) => object | object[] | undefined
+): Handler {
+    return (req, res, ctx) => res(ctx.delay(delay), ctx.status(statusCode(req)), ctx.json(genererMockData(req)));
 }
 
 export function mockGeneratorMedFødselsnummer(fn: (fødselsnummer: string) => object | object[] | undefined) {
-    return (args: HandlerArgument) => fn(args.pathParams.fodselsnummer);
+    return (args: HandlerRequest) => fn(args.pathParams.fodselsnummer);
 }
 
 export function mockGeneratorMedEnhetId(fn: (enhetId: string) => object | object[] | undefined) {
-    return (args: HandlerArgument) => fn(args.pathParams.enhetId);
+    return (args: HandlerRequest) => fn(args.pathParams.enhetId);
 }


### PR DESCRIPTION
Tester ut oppgrader yet-another-fetch-mock bibliotek med enklere api.

Mock-funksjonen var tidligere definert og brukt sånn;
```
export type MockHandler =
  | ((args: HandlerArgument) => Promise<ResponseData>)
  | ((args: HandlerArgument) => JSONValue)
  | JSONValue;

mock.get('url', () => ResponseUtils.jsonPromise(myJsonObject));
mock.get('url', () => myJsonObject);
mock.get('url', myJsonObject);
```

Behovet for å støtte de ulike måtene å skrive det på er erstattet med dette api-et;
```
export type Handler = (
  req: HandlerRequest,
  res: HandlerResponse,
  ctx: HandlerContext
) => Promise<ResponseData>;

mock.get('url', (req, res, ctx) =>res(
  ctx.json(myJsonObject)
));
``` 

Dette er sterkt inspirert fra https://redd.gitbook.io/msw/tutorials/mocking-rest-api (eksempel ca midt på siden), og gir i fremtiden en mulig enkel migrering til det biblioteket om ønskelig.