### PR TITLE
[KAIZEN-0] la til eslint-curly for konsistent kodestil

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -2,6 +2,7 @@ module.exports = {
     extends: ['react-app', 'prettier'],
     rules: {
         'react/jsx-pascal-case': 0, // skrur av regelen for at æøå skal være greit i komponent-navn
-        'react-hooks/exhaustive-deps': 'error'
+        'react-hooks/exhaustive-deps': 'error',
+        curly: ['error', 'all']
     }
 };

--- a/package.json
+++ b/package.json
@@ -20,7 +20,8 @@
         "start": "craco start",
         "build": "craco build",
         "test": "craco test",
-        "test-bail": "craco test --watchAll=false --bail"
+        "test-bail": "craco test --watchAll=false --bail",
+        "lint": "eslint --ext js,jsx,ts,tsx src"
     },
     "husky": {
         "hooks": {


### PR DESCRIPTION
la samtidig inn `npm run lint` muligheten slik at man kan
verifisere om det er noen linting issues uten å starte appen.

Så det i en [PR](https://github.com/navikt/modiapersonoversikt/pull/1276/files#diff-3591d053393f239687b10af6c3bc3bb2R76) og stusset over at eslint ikke hadde reagert på det. 
Så er bare ett forslag på om vi ønsker enforcement av curly-braces i koden da vi per i dag alltid har curly-braces i koden ellers.

Lintingen generelt rapporterer bare noen urelaterte warning (:clap:) når jeg kjørte den med denne kodeendringen.

Discuss.