### PR TITLE
[OPP-1147] hindre resetting av oppgaveId for visse merk-operasjoner

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9639,25 +9639,24 @@
             "dependencies": {
                 "abbrev": {
                     "version": "1.1.1",
-                    "resolved": false,
+                    "resolved": "",
                     "integrity": "sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q==",
                     "optional": true
                 },
                 "ansi-regex": {
                     "version": "2.1.1",
-                    "resolved": false,
-                    "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
-                    "optional": true
+                    "resolved": "",
+                    "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8="
                 },
                 "aproba": {
                     "version": "1.2.0",
-                    "resolved": false,
+                    "resolved": "",
                     "integrity": "sha512-Y9J6ZjXtoYh8RnXVCMOU/ttDmk1aBjunq9vO0ta5x85WDQiQfUF9sIPBITdbiiIVcBo03Hi3jMxigBtsddlXRw==",
                     "optional": true
                 },
                 "are-we-there-yet": {
                     "version": "1.1.5",
-                    "resolved": false,
+                    "resolved": "",
                     "integrity": "sha512-5hYdAkZlcG8tOLujVDTgCT+uPX0VnpAH28gWsLfzpXYm7wP6mp5Q/gYyR7YQ0cKVJcXJnl3j2kpBan13PtQf6w==",
                     "optional": true,
                     "requires": {
@@ -9667,15 +9666,13 @@
                 },
                 "balanced-match": {
                     "version": "1.0.0",
-                    "resolved": false,
-                    "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
-                    "optional": true
+                    "resolved": "",
+                    "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c="
                 },
                 "brace-expansion": {
                     "version": "1.1.11",
-                    "resolved": false,
+                    "resolved": "",
                     "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
-                    "optional": true,
                     "requires": {
                         "balanced-match": "^1.0.0",
                         "concat-map": "0.0.1"
@@ -9683,37 +9680,34 @@
                 },
                 "chownr": {
                     "version": "1.1.1",
-                    "resolved": false,
+                    "resolved": "",
                     "integrity": "sha512-j38EvO5+LHX84jlo6h4UzmOwi0UgW61WRyPtJz4qaadK5eY3BTS5TY/S1Stc3Uk2lIM6TPevAlULiEJwie860g==",
                     "optional": true
                 },
                 "code-point-at": {
                     "version": "1.1.0",
-                    "resolved": false,
-                    "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c=",
-                    "optional": true
+                    "resolved": "",
+                    "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c="
                 },
                 "concat-map": {
                     "version": "0.0.1",
-                    "resolved": false,
-                    "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
-                    "optional": true
+                    "resolved": "",
+                    "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s="
                 },
                 "console-control-strings": {
                     "version": "1.1.0",
-                    "resolved": false,
-                    "integrity": "sha1-PXz0Rk22RG6mRL9LOVB/mFEAjo4=",
-                    "optional": true
+                    "resolved": "",
+                    "integrity": "sha1-PXz0Rk22RG6mRL9LOVB/mFEAjo4="
                 },
                 "core-util-is": {
                     "version": "1.0.2",
-                    "resolved": false,
+                    "resolved": "",
                     "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=",
                     "optional": true
                 },
                 "debug": {
                     "version": "4.1.1",
-                    "resolved": false,
+                    "resolved": "",
                     "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
                     "optional": true,
                     "requires": {
@@ -9722,25 +9716,25 @@
                 },
                 "deep-extend": {
                     "version": "0.6.0",
-                    "resolved": false,
+                    "resolved": "",
                     "integrity": "sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA==",
                     "optional": true
                 },
                 "delegates": {
                     "version": "1.0.0",
-                    "resolved": false,
+                    "resolved": "",
                     "integrity": "sha1-hMbhWbgZBP3KWaDvRM2HDTElD5o=",
                     "optional": true
                 },
                 "detect-libc": {
                     "version": "1.0.3",
-                    "resolved": false,
+                    "resolved": "",
                     "integrity": "sha1-+hN8S9aY7fVc1c0CrFWfkaTEups=",
                     "optional": true
                 },
                 "fs-minipass": {
                     "version": "1.2.5",
-                    "resolved": false,
+                    "resolved": "",
                     "integrity": "sha512-JhBl0skXjUPCFH7x6x61gQxrKyXsxB5gcgePLZCwfyCGGsTISMoIeObbrvVeP6Xmyaudw4TT43qV2Gz+iyd2oQ==",
                     "optional": true,
                     "requires": {
@@ -9749,13 +9743,13 @@
                 },
                 "fs.realpath": {
                     "version": "1.0.0",
-                    "resolved": false,
+                    "resolved": "",
                     "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
                     "optional": true
                 },
                 "gauge": {
                     "version": "2.7.4",
-                    "resolved": false,
+                    "resolved": "",
                     "integrity": "sha1-LANAXHU4w51+s3sxcCLjJfsBi/c=",
                     "optional": true,
                     "requires": {
@@ -9771,7 +9765,7 @@
                 },
                 "glob": {
                     "version": "7.1.3",
-                    "resolved": false,
+                    "resolved": "",
                     "integrity": "sha512-vcfuiIxogLV4DlGBHIUOwI0IbrJ8HWPc4MU7HzviGeNho/UJDfi6B5p3sHeWIQ0KGIU0Jpxi5ZHxemQfLkkAwQ==",
                     "optional": true,
                     "requires": {
@@ -9785,13 +9779,13 @@
                 },
                 "has-unicode": {
                     "version": "2.0.1",
-                    "resolved": false,
+                    "resolved": "",
                     "integrity": "sha1-4Ob+aijPUROIVeCG0Wkedx3iqLk=",
                     "optional": true
                 },
                 "iconv-lite": {
                     "version": "0.4.24",
-                    "resolved": false,
+                    "resolved": "",
                     "integrity": "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==",
                     "optional": true,
                     "requires": {
@@ -9800,7 +9794,7 @@
                 },
                 "ignore-walk": {
                     "version": "3.0.1",
-                    "resolved": false,
+                    "resolved": "",
                     "integrity": "sha512-DTVlMx3IYPe0/JJcYP7Gxg7ttZZu3IInhuEhbchuqneY9wWe5Ojy2mXLBaQFUQmo0AW2r3qG7m1mg86js+gnlQ==",
                     "optional": true,
                     "requires": {
@@ -9809,7 +9803,7 @@
                 },
                 "inflight": {
                     "version": "1.0.6",
-                    "resolved": false,
+                    "resolved": "",
                     "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
                     "optional": true,
                     "requires": {
@@ -9819,51 +9813,46 @@
                 },
                 "inherits": {
                     "version": "2.0.3",
-                    "resolved": false,
-                    "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
-                    "optional": true
+                    "resolved": "",
+                    "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4="
                 },
                 "ini": {
                     "version": "1.3.5",
-                    "resolved": false,
+                    "resolved": "",
                     "integrity": "sha512-RZY5huIKCMRWDUqZlEi72f/lmXKMvuszcMBduliQ3nnWbx9X/ZBQO7DijMEYS9EhHBb2qacRUMtC7svLwe0lcw==",
                     "optional": true
                 },
                 "is-fullwidth-code-point": {
                     "version": "1.0.0",
-                    "resolved": false,
+                    "resolved": "",
                     "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
-                    "optional": true,
                     "requires": {
                         "number-is-nan": "^1.0.0"
                     }
                 },
                 "isarray": {
                     "version": "1.0.0",
-                    "resolved": false,
+                    "resolved": "",
                     "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
                     "optional": true
                 },
                 "minimatch": {
                     "version": "3.0.4",
-                    "resolved": false,
+                    "resolved": "",
                     "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
-                    "optional": true,
                     "requires": {
                         "brace-expansion": "^1.1.7"
                     }
                 },
                 "minimist": {
                     "version": "0.0.8",
-                    "resolved": false,
-                    "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
-                    "optional": true
+                    "resolved": "",
+                    "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0="
                 },
                 "minipass": {
                     "version": "2.3.5",
-                    "resolved": false,
+                    "resolved": "",
                     "integrity": "sha512-Gi1W4k059gyRbyVUZQ4mEqLm0YIUiGYfvxhF6SIlk3ui1WVxMTGfGdQ2SInh3PDrRTVvPKgULkpJtT4RH10+VA==",
-                    "optional": true,
                     "requires": {
                         "safe-buffer": "^5.1.2",
                         "yallist": "^3.0.0"
@@ -9871,7 +9860,7 @@
                 },
                 "minizlib": {
                     "version": "1.2.1",
-                    "resolved": false,
+                    "resolved": "",
                     "integrity": "sha512-7+4oTUOWKg7AuL3vloEWekXY2/D20cevzsrNT2kGWm+39J9hGTCBv8VI5Pm5lXZ/o3/mdR4f8rflAPhnQb8mPA==",
                     "optional": true,
                     "requires": {
@@ -9880,22 +9869,21 @@
                 },
                 "mkdirp": {
                     "version": "0.5.1",
-                    "resolved": false,
+                    "resolved": "",
                     "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
-                    "optional": true,
                     "requires": {
                         "minimist": "0.0.8"
                     }
                 },
                 "ms": {
                     "version": "2.1.1",
-                    "resolved": false,
+                    "resolved": "",
                     "integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg==",
                     "optional": true
                 },
                 "needle": {
                     "version": "2.3.0",
-                    "resolved": false,
+                    "resolved": "",
                     "integrity": "sha512-QBZu7aAFR0522EyaXZM0FZ9GLpq6lvQ3uq8gteiDUp7wKdy0lSd2hPlgFwVuW1CBkfEs9PfDQsQzZghLs/psdg==",
                     "optional": true,
                     "requires": {
@@ -9906,7 +9894,7 @@
                 },
                 "node-pre-gyp": {
                     "version": "0.12.0",
-                    "resolved": false,
+                    "resolved": "",
                     "integrity": "sha512-4KghwV8vH5k+g2ylT+sLTjy5wmUOb9vPhnM8NHvRf9dHmnW/CndrFXy2aRPaPST6dugXSdHXfeaHQm77PIz/1A==",
                     "optional": true,
                     "requires": {
@@ -9924,7 +9912,7 @@
                 },
                 "nopt": {
                     "version": "4.0.1",
-                    "resolved": false,
+                    "resolved": "",
                     "integrity": "sha1-0NRoWv1UFRk8jHUFYC0NF81kR00=",
                     "optional": true,
                     "requires": {
@@ -9934,13 +9922,13 @@
                 },
                 "npm-bundled": {
                     "version": "1.0.6",
-                    "resolved": false,
+                    "resolved": "",
                     "integrity": "sha512-8/JCaftHwbd//k6y2rEWp6k1wxVfpFzB6t1p825+cUb7Ym2XQfhwIC5KwhrvzZRJu+LtDE585zVaS32+CGtf0g==",
                     "optional": true
                 },
                 "npm-packlist": {
                     "version": "1.4.1",
-                    "resolved": false,
+                    "resolved": "",
                     "integrity": "sha512-+TcdO7HJJ8peiiYhvPxsEDhF3PJFGUGRcFsGve3vxvxdcpO2Z4Z7rkosRM0kWj6LfbK/P0gu3dzk5RU1ffvFcw==",
                     "optional": true,
                     "requires": {
@@ -9950,7 +9938,7 @@
                 },
                 "npmlog": {
                     "version": "4.1.2",
-                    "resolved": false,
+                    "resolved": "",
                     "integrity": "sha512-2uUqazuKlTaSI/dC8AzicUck7+IrEaOnN/e0jd3Xtt1KcGpwx30v50mL7oPyr/h9bL3E4aZccVwpwP+5W9Vjkg==",
                     "optional": true,
                     "requires": {
@@ -9962,40 +9950,38 @@
                 },
                 "number-is-nan": {
                     "version": "1.0.1",
-                    "resolved": false,
-                    "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0=",
-                    "optional": true
+                    "resolved": "",
+                    "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0="
                 },
                 "object-assign": {
                     "version": "4.1.1",
-                    "resolved": false,
+                    "resolved": "",
                     "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
                     "optional": true
                 },
                 "once": {
                     "version": "1.4.0",
-                    "resolved": false,
+                    "resolved": "",
                     "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
-                    "optional": true,
                     "requires": {
                         "wrappy": "1"
                     }
                 },
                 "os-homedir": {
                     "version": "1.0.2",
-                    "resolved": false,
+                    "resolved": "",
                     "integrity": "sha1-/7xJiDNuDoM94MFox+8VISGqf7M=",
                     "optional": true
                 },
                 "os-tmpdir": {
                     "version": "1.0.2",
-                    "resolved": false,
+                    "resolved": "",
                     "integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ=",
                     "optional": true
                 },
                 "osenv": {
                     "version": "0.1.5",
-                    "resolved": false,
+                    "resolved": "",
                     "integrity": "sha512-0CWcCECdMVc2Rw3U5w9ZjqX6ga6ubk1xDVKxtBQPK7wis/0F2r9T6k4ydGYhecl7YUBxBVxhL5oisPsNxAPe2g==",
                     "optional": true,
                     "requires": {
@@ -10005,19 +9991,19 @@
                 },
                 "path-is-absolute": {
                     "version": "1.0.1",
-                    "resolved": false,
+                    "resolved": "",
                     "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
                     "optional": true
                 },
                 "process-nextick-args": {
                     "version": "2.0.0",
-                    "resolved": false,
+                    "resolved": "",
                     "integrity": "sha512-MtEC1TqN0EU5nephaJ4rAtThHtC86dNN9qCuEhtshvpVBkAW5ZO7BASN9REnF9eoXGcRub+pFuKEpOHE+HbEMw==",
                     "optional": true
                 },
                 "rc": {
                     "version": "1.2.8",
-                    "resolved": false,
+                    "resolved": "",
                     "integrity": "sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==",
                     "optional": true,
                     "requires": {
@@ -10029,7 +10015,7 @@
                     "dependencies": {
                         "minimist": {
                             "version": "1.2.0",
-                            "resolved": false,
+                            "resolved": "",
                             "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
                             "optional": true
                         }
@@ -10037,7 +10023,7 @@
                 },
                 "readable-stream": {
                     "version": "2.3.6",
-                    "resolved": false,
+                    "resolved": "",
                     "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
                     "optional": true,
                     "requires": {
@@ -10052,7 +10038,7 @@
                 },
                 "rimraf": {
                     "version": "2.6.3",
-                    "resolved": false,
+                    "resolved": "",
                     "integrity": "sha512-mwqeW5XsA2qAejG46gYdENaxXjx9onRNCfn7L0duuP4hCuTIi/QO7PDK07KJfp1d+izWPrzEJDcSqBa0OZQriA==",
                     "optional": true,
                     "requires": {
@@ -10061,45 +10047,43 @@
                 },
                 "safe-buffer": {
                     "version": "5.1.2",
-                    "resolved": false,
-                    "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
-                    "optional": true
+                    "resolved": "",
+                    "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
                 },
                 "safer-buffer": {
                     "version": "2.1.2",
-                    "resolved": false,
+                    "resolved": "",
                     "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
                     "optional": true
                 },
                 "sax": {
                     "version": "1.2.4",
-                    "resolved": false,
+                    "resolved": "",
                     "integrity": "sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw==",
                     "optional": true
                 },
                 "semver": {
                     "version": "5.7.0",
-                    "resolved": false,
+                    "resolved": "",
                     "integrity": "sha512-Ya52jSX2u7QKghxeoFGpLwCtGlt7j0oY9DYb5apt9nPlJ42ID+ulTXESnt/qAQcoSERyZ5sl3LDIOw0nAn/5DA==",
                     "optional": true
                 },
                 "set-blocking": {
                     "version": "2.0.0",
-                    "resolved": false,
+                    "resolved": "",
                     "integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc=",
                     "optional": true
                 },
                 "signal-exit": {
                     "version": "3.0.2",
-                    "resolved": false,
+                    "resolved": "",
                     "integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0=",
                     "optional": true
                 },
                 "string-width": {
                     "version": "1.0.2",
-                    "resolved": false,
+                    "resolved": "",
                     "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
-                    "optional": true,
                     "requires": {
                         "code-point-at": "^1.0.0",
                         "is-fullwidth-code-point": "^1.0.0",
@@ -10108,7 +10092,7 @@
                 },
                 "string_decoder": {
                     "version": "1.1.1",
-                    "resolved": false,
+                    "resolved": "",
                     "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
                     "optional": true,
                     "requires": {
@@ -10117,22 +10101,21 @@
                 },
                 "strip-ansi": {
                     "version": "3.0.1",
-                    "resolved": false,
+                    "resolved": "",
                     "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
-                    "optional": true,
                     "requires": {
                         "ansi-regex": "^2.0.0"
                     }
                 },
                 "strip-json-comments": {
                     "version": "2.0.1",
-                    "resolved": false,
+                    "resolved": "",
                     "integrity": "sha1-PFMZQukIwml8DsNEhYwobHygpgo=",
                     "optional": true
                 },
                 "tar": {
                     "version": "4.4.8",
-                    "resolved": false,
+                    "resolved": "",
                     "integrity": "sha512-LzHF64s5chPQQS0IYBn9IN5h3i98c12bo4NCO7e0sGM2llXQ3p2FGC5sdENN4cTW48O915Sh+x+EXx7XW96xYQ==",
                     "optional": true,
                     "requires": {
@@ -10147,13 +10130,13 @@
                 },
                 "util-deprecate": {
                     "version": "1.0.2",
-                    "resolved": false,
+                    "resolved": "",
                     "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=",
                     "optional": true
                 },
                 "wide-align": {
                     "version": "1.1.3",
-                    "resolved": false,
+                    "resolved": "",
                     "integrity": "sha512-QGkOQc8XL6Bt5PwnsExKBPuMKBxnGxWWW3fU55Xt4feHozMUhdUMaBCk290qpm/wG5u/RSKzwdAC4i51YigihA==",
                     "optional": true,
                     "requires": {
@@ -10162,15 +10145,13 @@
                 },
                 "wrappy": {
                     "version": "1.0.2",
-                    "resolved": false,
-                    "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
-                    "optional": true
+                    "resolved": "",
+                    "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8="
                 },
                 "yallist": {
                     "version": "3.0.3",
-                    "resolved": false,
-                    "integrity": "sha512-S+Zk8DEWE6oKpV+vI3qWkaK+jSbIK86pCwe2IF/xwIpQ8jEuxpw9NyaGjmp9+BoJv5FV2piqCDcoCtStppiq2A==",
-                    "optional": true
+                    "resolved": "",
+                    "integrity": "sha512-S+Zk8DEWE6oKpV+vI3qWkaK+jSbIK86pCwe2IF/xwIpQ8jEuxpw9NyaGjmp9+BoJv5FV2piqCDcoCtStppiq2A=="
                 }
             }
         },


### PR DESCRIPTION
Noen merk-operasjoner (se `DialogMerkController`) ferdigstiller oppgave
i gsak. Når det gjøres er det greit å nullstille oppgaven i frontend
også.

Men majoriteten av operasjonene der gjør ingenting med oppgaven, og det
skaper derfor hodebry for brukerene at de må relaste siden for å få
kvittert ut oppgaven etter en merk-operasjon