### PR TITLE
[KAIZEN-0] utvide sjekk for når jobberMedSTO blir satt

### DIFF
--- a/src/app/personside/Personoversikt.tsx
+++ b/src/app/personside/Personoversikt.tsx
@@ -17,6 +17,7 @@ import FillCenterAndFadeIn from '../../components/FillCenterAndFadeIn';
 import AlertStripe from 'nav-frontend-alertstriper';
 import BegrensetTilgangSide from './BegrensetTilgangSide';
 import useTokenRefresher from '../../utils/hooks/use-token-refresher';
+import { Oppgave } from '../../models/oppgave';
 
 const onError = (
     <FillCenterAndFadeIn>
@@ -32,9 +33,10 @@ function Personoversikt() {
     useTokenRefresher(fnr);
 
     useOnMount(() => {
-        const harHentetOppgave = isFinishedPosting(oppgaveResource);
-        if (harHentetOppgave) {
-            dispatch(setJobberMedSTO(true));
+        if (isFinishedPosting(oppgaveResource)) {
+            const oppgaver = oppgaveResource.payload as Oppgave[];
+            const harSattOppgaveFraGosysUrl = oppgaver.some(oppgave => oppgave.fraGosys === true);
+            dispatch(setJobberMedSTO(!harSattOppgaveFraGosysUrl));
         } else {
             dispatch(setJobberMedSTO(false));
         }


### PR DESCRIPTION
flagget `fraGosys` blir kun satt i oppgavene når oppgaven blir håndtert
av `useHandleGosysUrl`. I disse tilfellene setter vi ikke `jobberMedSTO`
til `true` siden saksbehandler ikke har plukket en oppgave i dette
tilfellet.