### PR TITLE
[OPP-1205] resetter sammensatte saker etter innsending av spørsmål

### DIFF
--- a/src/app/personside/dialogpanel/fortsettDialog/FortsettDialogContainer.tsx
+++ b/src/app/personside/dialogpanel/fortsettDialog/FortsettDialogContainer.tsx
@@ -34,6 +34,7 @@ import { isFinishedPosting } from '../../../../rest/utils/postResource';
 import ReflowBoundry from '../ReflowBoundry';
 import { Temagruppe } from '../../../../models/temagrupper';
 import useDraft, { Draft } from '../use-draft';
+import * as JournalforingUtils from '../../journalforings-use-fetch-utils';
 
 export type FortsettDialogType =
     | Meldingstype.SVAR_SKRIFTLIG
@@ -179,6 +180,7 @@ function FortsettDialogContainer(props: Props) {
             };
             post(`${apiBaseUri}/dialog/${fnr}/fortsett/ferdigstill`, request, 'Svar-Med-Spørsmål')
                 .then(() => {
+                    JournalforingUtils.slettCacheForSammensatteSaker(fnr);
                     callback();
                     setDialogStatus({ type: DialogPanelStatus.SVAR_SENDT, kvitteringsData: kvitteringsData });
                 })

--- a/src/app/personside/dialogpanel/sendMelding/DialogpanelVelgSak.tsx
+++ b/src/app/personside/dialogpanel/sendMelding/DialogpanelVelgSak.tsx
@@ -8,10 +8,9 @@ import { Normaltekst } from 'nav-frontend-typografi';
 import styled from 'styled-components/macro';
 import theme, { pxToRem } from '../../../../styles/personOversiktTheme';
 import { NedChevron, OppChevron } from 'nav-frontend-chevron';
-import { cache, createCacheKey } from '@nutgaard/use-fetch';
-import { apiBaseUri, includeCredentials } from '../../../../api/config';
 import { useClickOutside, useFødselsnummer, useOnMount } from '../../../../utils/customHooks';
 import SkjemaelementFeilmelding from 'nav-frontend-skjema/lib/skjemaelement-feilmelding';
+import * as JournalforingUtils from '../../journalforings-use-fetch-utils';
 
 interface Props {
     valgtSak?: JournalforingsSak;
@@ -57,10 +56,8 @@ function getTittel(sak: JournalforingsSak) {
 function usePreFetchJournalforingsSaker() {
     const fnr = useFødselsnummer();
     useOnMount(() => {
-        const sammensattUrl = `${apiBaseUri}/journalforing/${fnr}/saker/sammensatte`;
-        const pensjonUrl = `${apiBaseUri}/journalforing/${fnr}/saker/pensjon`;
-        cache.fetch(createCacheKey(sammensattUrl, includeCredentials), sammensattUrl, includeCredentials);
-        cache.fetch(createCacheKey(pensjonUrl, includeCredentials), pensjonUrl, includeCredentials);
+        JournalforingUtils.prefetchSammensatteSaker(fnr);
+        JournalforingUtils.prefetchPensjonsaker(fnr);
     });
 }
 

--- a/src/app/personside/dialogpanel/sendMelding/SendNyMeldingContainer.tsx
+++ b/src/app/personside/dialogpanel/sendMelding/SendNyMeldingContainer.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import { FormEvent, useCallback, useMemo, useState } from 'react';
-import SendNyMelding, { SendNyMeldingState, OppgavelisteValg } from './SendNyMelding';
+import SendNyMelding, { OppgavelisteValg, SendNyMeldingState } from './SendNyMelding';
 import { NyMeldingValidator } from './validatorer';
 import { Meldingstype, SendReferatRequest, SendSpørsmålRequest } from '../../../../models/meldinger/meldinger';
 import { useFødselsnummer } from '../../../../utils/customHooks';
@@ -12,6 +12,7 @@ import { SendNyMeldingPanelState, SendNyMeldingStatus } from './SendNyMeldingTyp
 import { useRestResource } from '../../../../rest/consumer/useRestResource';
 import useDraft, { Draft } from '../use-draft';
 import { feilMeldinger } from './FeilMeldinger';
+import * as JournalforingUtils from '../../journalforings-use-fetch-utils';
 
 const initialState: SendNyMeldingState = {
     tekst: '',
@@ -116,6 +117,7 @@ function SendNyMeldingContainer() {
             };
             post(`${apiBaseUri}/dialog/${fnr}/sendsporsmal`, request, 'Send-Sporsmal')
                 .then(() => {
+                    JournalforingUtils.slettCacheForSammensatteSaker(fnr);
                     callback();
                     setSendNyMeldingStatus({ type: SendNyMeldingStatus.SPORSMAL_SENDT, fritekst: request.fritekst });
                 })

--- a/src/app/personside/infotabs/meldinger/traadvisning/verktoylinje/journalforing/JournalforSak.tsx
+++ b/src/app/personside/infotabs/meldinger/traadvisning/verktoylinje/journalforing/JournalforSak.tsx
@@ -13,6 +13,7 @@ import { loggError } from '../../../../../../../utils/logger/frontendLogger';
 import { useDispatch } from 'react-redux';
 import { useRestResource } from '../../../../../../../rest/consumer/useRestResource';
 import { useFødselsnummer } from '../../../../../../../utils/customHooks';
+import * as JournalforingUtils from '../../../../../journalforings-use-fetch-utils';
 
 interface Props {
     sak: JournalforingsSak;
@@ -59,6 +60,7 @@ export function JournalforSak(props: Props) {
         setSubmitting(true);
         post(`${apiBaseUri}/journalforing/${fnr}/${props.traad.traadId}`, props.sak, 'Journalføring')
             .then(() => {
+                JournalforingUtils.slettCacheForSammensatteSaker(fnr);
                 setSubmitting(false);
                 setJournalforingSuksess(true);
                 dispatch(tråderResource.actions.reload);

--- a/src/app/personside/infotabs/meldinger/traadvisning/verktoylinje/journalforing/VelgSak.tsx
+++ b/src/app/personside/infotabs/meldinger/traadvisning/verktoylinje/journalforing/VelgSak.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import useFetch, { AsyncResult, FetchResult, hasData, hasError, isPending } from '@nutgaard/use-fetch';
+import { AsyncResult, FetchResult, hasData, hasError, isPending } from '@nutgaard/use-fetch';
 import { JournalforingsSak, Kategorier, SakKategori, Tema } from './JournalforingPanel';
 import useFieldState, { FieldState } from '../../../../../../../utils/hooks/use-field-state';
 import { Radio, RadioProps } from 'nav-frontend-skjema';
@@ -8,10 +8,10 @@ import TemaTable from './TemaTabell';
 import styled from 'styled-components/macro';
 import visibleIf from '../../../../../../../components/visibleIfHoc';
 import { Group, groupBy } from '../../../../../../../utils/groupArray';
-import { apiBaseUri, includeCredentials } from '../../../../../../../api/config';
 import Spinner from 'nav-frontend-spinner';
 import { useSelector } from 'react-redux';
 import { fnrSelector } from '../../../../../../../redux/gjeldendeBruker/selectors';
+import * as JournalforingUtils from '../../../../../journalforings-use-fetch-utils';
 
 const Form = styled.form`
     display: flex;
@@ -92,14 +92,8 @@ export function sakKategori(sak: JournalforingsSak): SakKategori {
 function VelgSak(props: Props) {
     const fnr = useSelector(fnrSelector);
     const valgtKategori = useFieldState(SakKategori.FAG);
-    const gsakSaker: FetchResult<Array<JournalforingsSak>> = useFetch<Array<JournalforingsSak>>(
-        `${apiBaseUri}/journalforing/${fnr}/saker/sammensatte`,
-        includeCredentials
-    );
-    const psakSaker: FetchResult<Array<JournalforingsSak>> = useFetch<Array<JournalforingsSak>>(
-        `${apiBaseUri}/journalforing/${fnr}/saker/pensjon`,
-        includeCredentials
-    );
+    const gsakSaker: FetchResult<Array<JournalforingsSak>> = JournalforingUtils.useSammensatteSaker(fnr);
+    const psakSaker: FetchResult<Array<JournalforingsSak>> = JournalforingUtils.usePensjonSaker(fnr);
 
     const saker = getSaker(gsakSaker, psakSaker);
     const fordelteSaker = fordelSaker(saker);

--- a/src/app/personside/journalforings-use-fetch-utils.ts
+++ b/src/app/personside/journalforings-use-fetch-utils.ts
@@ -1,0 +1,31 @@
+import useFetch, { cache, createCacheKey, FetchResult } from '@nutgaard/use-fetch';
+import { apiBaseUri, includeCredentials } from '../../api/config';
+import { JournalforingsSak } from './infotabs/meldinger/traadvisning/verktoylinje/journalforing/JournalforingPanel';
+
+const sammensatteSakerUrl = (fnr: string) => `${apiBaseUri}/journalforing/${fnr}/saker/sammensatte`;
+const pensjonSakerUrl = (fnr: string) => `${apiBaseUri}/journalforing/${fnr}/saker/pensjon`;
+
+function prefetch(url: string) {
+    const cachekey = createCacheKey(url, includeCredentials);
+    cache.fetch(cachekey, url, includeCredentials);
+}
+
+function remove(url: string) {
+    const cachekey = createCacheKey(url, includeCredentials);
+    cache.remove(cachekey);
+}
+
+function useFetchHook<TYPE>(url: string, lazy: boolean = false): FetchResult<TYPE> {
+    return useFetch<TYPE>(url, includeCredentials, { lazy, cacheKey: createCacheKey(url, includeCredentials) });
+}
+
+export const prefetchSammensatteSaker = (fnr: string) => prefetch(sammensatteSakerUrl(fnr));
+export const prefetchPensjonsaker = (fnr: string) => prefetch(pensjonSakerUrl(fnr));
+export const slettCacheForSammensatteSaker = (fnr: string) => remove(sammensatteSakerUrl(fnr));
+export const slettCacheForPensjonSaker = (fnr: string) => remove(pensjonSakerUrl(fnr));
+export function useSammensatteSaker(fnr: string, lazy: boolean = false): FetchResult<Array<JournalforingsSak>> {
+    return useFetchHook(sammensatteSakerUrl(fnr), lazy);
+}
+export function usePensjonSaker(fnr: string, lazy: boolean = false): FetchResult<Array<JournalforingsSak>> {
+    return useFetchHook(pensjonSakerUrl(fnr), lazy);
+}


### PR DESCRIPTION
ved journalføring, enten via sending av spørsmål eller
journalføringspanel, så kan en sak bli opprettet. I disse tilfellene vil
frontend ikke være oppdatert, og ved neste journalføring vil backend
derfor prøve å opprette saken på nytt. Ved å slette cachen av
sammensatte saker så kan vi unngå dette, da listen av saker blir
oppdatert mellom hver innsending.