### PR TITLE
[KAIZEN-0] endre snapshots til å ha riktig tallformat

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -12,11 +12,11 @@ jobs:
     runs-on: ubuntu-latest
     if: github.ref != 'refs/heads/dev' && github.ref != 'refs/heads/master'
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v2
       - uses: actions/setup-node@v1
         with:
-          node-version: '14'
-      - uses: actions/cache@v1
+          node-version: '14.6.0'
+      - uses: actions/cache@v2
         with:
           path: ~/.npm
           key: ${{ runner.os }}-node-${{ hashFiles('package-lock.json') }}
@@ -34,11 +34,11 @@ jobs:
     if: github.ref == 'refs/heads/dev' || github.ref == 'refs/heads/master'
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v2
       - uses: actions/setup-node@v1
         with:
-          node-version: '14'
-      - uses: actions/cache@v1
+          node-version: '14.6.0'
+      - uses: actions/cache@v2
         with:
           path: ~/.npm
           key: ${{ runner.os }}-node-${{ hashFiles('package-lock.json') }}
@@ -67,7 +67,7 @@ jobs:
       matrix:
         namespace: [q0, q1, q6]
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v2
       - uses: nais/deploy/actions/deploy@v1
         env:
           APIKEY: ${{ secrets.NAIS_DEPLOY_APIKEY }}
@@ -82,7 +82,7 @@ jobs:
     if: github.ref == 'refs/heads/master'
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v2
       - uses: nais/deploy/actions/deploy@v1
         env:
           APIKEY: ${{ secrets.NAIS_DEPLOY_APIKEY }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -13,6 +13,9 @@ jobs:
     if: github.ref != 'refs/heads/dev' && github.ref != 'refs/heads/master'
     steps:
       - uses: actions/checkout@v1
+      - uses: actions/setup-node@v1
+        with:
+          node-version: '14'
       - uses: actions/cache@v1
         with:
           path: ~/.npm
@@ -32,6 +35,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v1
+      - uses: actions/setup-node@v1
+        with:
+          node-version: '14'
       - uses: actions/cache@v1
         with:
           path: ~/.npm

--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+engine-strict=true

--- a/package.json
+++ b/package.json
@@ -8,6 +8,9 @@
     "files": [
         "build/dist/"
     ],
+    "engines": {
+        "node": ">13.0.0"
+    },
     "publishConfig": {
         "registry": "https://repo.adeo.no/repository/npm-internal/"
     },

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
         "build/dist/"
     ],
     "engines": {
-        "node": ">13.0.0"
+        "node": ">=14.6.0"
     },
     "publishConfig": {
         "registry": "https://repo.adeo.no/repository/npm-internal/"

--- a/src/app/personside/infotabs/utbetalinger/__snapshots__/UtbetalingerContainer.test.tsx.snap
+++ b/src/app/personside/infotabs/utbetalinger/__snapshots__/UtbetalingerContainer.test.tsx.snap
@@ -872,17 +872,17 @@ exports[`Viser utbetalingercontainer med alt innhold 1`] = `
                           <td
                             role="cell"
                           >
-                            13,370.00
+                            13 370,00
                           </td>
                           <td
                             role="cell"
                           >
-                            -1,984.00
+                            −1 984,00
                           </td>
                           <td
                             role="cell"
                           >
-                            11,386.00
+                            11 386,00
                           </td>
                         </tr>
                       </tbody>
@@ -1036,19 +1036,19 @@ exports[`Viser utbetalingercontainer med alt innhold 1`] = `
                               className="sumBrutto"
                               role="cell"
                             >
-                              13,370.00
+                              13 370,00
                             </td>
                             <td
                               className="sumTrekk"
                               role="cell"
                             >
-                              -1,984.00
+                              −1 984,00
                             </td>
                             <td
                               className="sumNetto"
                               role="cell"
                             >
-                              11,386.00
+                              11 386,00
                             </td>
                             <td
                               className="periodeForYtelse"
@@ -1067,19 +1067,19 @@ exports[`Viser utbetalingercontainer med alt innhold 1`] = `
                                   Mouse
                                 </dt>
                                 <dd>
-                                  3,860.00
+                                  3 860,00
                                 </dd>
                                 <dt>
                                   Computer
                                 </dt>
                                 <dd>
-                                  3,930.00
+                                  3 930,00
                                 </dd>
                                 <dt>
                                   Bacon
                                 </dt>
                                 <dd>
-                                  5,580.00
+                                  5 580,00
                                 </dd>
                               </dl>
                             </td>
@@ -1169,7 +1169,7 @@ exports[`Viser utbetalingercontainer med alt innhold 1`] = `
                               <p
                                 className="typo-element"
                               >
-                                11,386.00
+                                11 386,00
                               </p>
                             </div>
                             <p
@@ -1330,17 +1330,17 @@ exports[`Viser utbetalingercontainer med alt innhold 1`] = `
                                           <td
                                             role="cell"
                                           >
-                                            13,370.00
+                                            13 370,00
                                           </td>
                                           <td
                                             role="cell"
                                           >
-                                            -1,984.00
+                                            −1 984,00
                                           </td>
                                           <td
                                             role="cell"
                                           >
-                                            11,386.00
+                                            11 386,00
                                           </td>
                                         </tr>
                                       </tbody>
@@ -1398,7 +1398,7 @@ exports[`Viser utbetalingercontainer med alt innhold 1`] = `
                                         <td
                                           role="cell"
                                         >
-                                          558.00
+                                          558,00
                                         </td>
                                         <td
                                           role="cell"
@@ -1408,7 +1408,7 @@ exports[`Viser utbetalingercontainer med alt innhold 1`] = `
                                         <td
                                           role="cell"
                                         >
-                                          5,580.00
+                                          5 580,00
                                         </td>
                                       </tr>
                                       <tr
@@ -1422,7 +1422,7 @@ exports[`Viser utbetalingercontainer med alt innhold 1`] = `
                                         <td
                                           role="cell"
                                         >
-                                          1,310.00
+                                          1 310,00
                                         </td>
                                         <td
                                           role="cell"
@@ -1432,7 +1432,7 @@ exports[`Viser utbetalingercontainer med alt innhold 1`] = `
                                         <td
                                           role="cell"
                                         >
-                                          3,930.00
+                                          3 930,00
                                         </td>
                                       </tr>
                                       <tr
@@ -1446,7 +1446,7 @@ exports[`Viser utbetalingercontainer med alt innhold 1`] = `
                                         <td
                                           role="cell"
                                         >
-                                          1,930.00
+                                          1 930,00
                                         </td>
                                         <td
                                           role="cell"
@@ -1456,7 +1456,7 @@ exports[`Viser utbetalingercontainer med alt innhold 1`] = `
                                         <td
                                           role="cell"
                                         >
-                                          3,860.00
+                                          3 860,00
                                         </td>
                                       </tr>
                                       <tr
@@ -1480,7 +1480,7 @@ exports[`Viser utbetalingercontainer med alt innhold 1`] = `
                                         <td
                                           role="cell"
                                         >
-                                          -730.00
+                                          −730,00
                                         </td>
                                       </tr>
                                       <tr
@@ -1504,7 +1504,7 @@ exports[`Viser utbetalingercontainer med alt innhold 1`] = `
                                         <td
                                           role="cell"
                                         >
-                                          -1,042.00
+                                          −1 042,00
                                         </td>
                                       </tr>
                                       <tr
@@ -1528,7 +1528,7 @@ exports[`Viser utbetalingercontainer med alt innhold 1`] = `
                                         <td
                                           role="cell"
                                         >
-                                          -212.00
+                                          −212,00
                                         </td>
                                       </tr>
                                     </tbody>

--- a/src/app/personside/infotabs/utbetalinger/totalt utbetalt/__snapshots__/TotaltUtbetaltDetaljer.test.tsx.snap
+++ b/src/app/personside/infotabs/utbetalinger/totalt utbetalt/__snapshots__/TotaltUtbetaltDetaljer.test.tsx.snap
@@ -386,19 +386,19 @@ Array [
                   className="sumBrutto"
                   role="cell"
                 >
-                  40,110.00
+                  40 110,00
                 </td>
                 <td
                   className="sumTrekk"
                   role="cell"
                 >
-                  -5,952.00
+                  −5 952,00
                 </td>
                 <td
                   className="sumNetto"
                   role="cell"
                 >
-                  34,158.00
+                  34 158,00
                 </td>
                 <td
                   className="periodeForYtelse"
@@ -417,19 +417,19 @@ Array [
                       Mouse
                     </dt>
                     <dd>
-                      11,580.00
+                      11 580,00
                     </dd>
                     <dt>
                       Computer
                     </dt>
                     <dd>
-                      11,790.00
+                      11 790,00
                     </dd>
                     <dt>
                       Bacon
                     </dt>
                     <dd>
-                      16,740.00
+                      16 740,00
                     </dd>
                   </dl>
                 </td>

--- a/src/app/personside/infotabs/utbetalinger/utbetaling/__snapshots__/SammensattUtbetaling.test.tsx.snap
+++ b/src/app/personside/infotabs/utbetalinger/utbetaling/__snapshots__/SammensattUtbetaling.test.tsx.snap
@@ -270,7 +270,7 @@ exports[`Viser utbetalingsdetaljer riktig med liste med ytelser og trekk 1`] = `
       <p
         className="typo-element"
       >
-        22,772.00
+        22 772,00
       </p>
     </div>
     <div
@@ -352,7 +352,7 @@ exports[`Viser utbetalingsdetaljer riktig med liste med ytelser og trekk 1`] = `
                 <p
                   className="typo-element"
                 >
-                  11,386.00
+                  11 386,00
                 </p>
               </div>
               <p
@@ -450,17 +450,17 @@ exports[`Viser utbetalingsdetaljer riktig med liste med ytelser og trekk 1`] = `
                           <td
                             role="cell"
                           >
-                            13,370.00
+                            13 370,00
                           </td>
                           <td
                             role="cell"
                           >
-                            -1,984.00
+                            −1 984,00
                           </td>
                           <td
                             role="cell"
                           >
-                            11,386.00
+                            11 386,00
                           </td>
                         </tr>
                       </tbody>
@@ -518,7 +518,7 @@ exports[`Viser utbetalingsdetaljer riktig med liste med ytelser og trekk 1`] = `
                         <td
                           role="cell"
                         >
-                          558.00
+                          558,00
                         </td>
                         <td
                           role="cell"
@@ -528,7 +528,7 @@ exports[`Viser utbetalingsdetaljer riktig med liste med ytelser og trekk 1`] = `
                         <td
                           role="cell"
                         >
-                          5,580.00
+                          5 580,00
                         </td>
                       </tr>
                       <tr
@@ -542,7 +542,7 @@ exports[`Viser utbetalingsdetaljer riktig med liste med ytelser og trekk 1`] = `
                         <td
                           role="cell"
                         >
-                          1,310.00
+                          1 310,00
                         </td>
                         <td
                           role="cell"
@@ -552,7 +552,7 @@ exports[`Viser utbetalingsdetaljer riktig med liste med ytelser og trekk 1`] = `
                         <td
                           role="cell"
                         >
-                          3,930.00
+                          3 930,00
                         </td>
                       </tr>
                       <tr
@@ -566,7 +566,7 @@ exports[`Viser utbetalingsdetaljer riktig med liste med ytelser og trekk 1`] = `
                         <td
                           role="cell"
                         >
-                          1,930.00
+                          1 930,00
                         </td>
                         <td
                           role="cell"
@@ -576,7 +576,7 @@ exports[`Viser utbetalingsdetaljer riktig med liste med ytelser og trekk 1`] = `
                         <td
                           role="cell"
                         >
-                          3,860.00
+                          3 860,00
                         </td>
                       </tr>
                       <tr
@@ -600,7 +600,7 @@ exports[`Viser utbetalingsdetaljer riktig med liste med ytelser og trekk 1`] = `
                         <td
                           role="cell"
                         >
-                          -730.00
+                          −730,00
                         </td>
                       </tr>
                       <tr
@@ -624,7 +624,7 @@ exports[`Viser utbetalingsdetaljer riktig med liste med ytelser og trekk 1`] = `
                         <td
                           role="cell"
                         >
-                          -1,042.00
+                          −1 042,00
                         </td>
                       </tr>
                       <tr
@@ -648,7 +648,7 @@ exports[`Viser utbetalingsdetaljer riktig med liste med ytelser og trekk 1`] = `
                         <td
                           role="cell"
                         >
-                          -212.00
+                          −212,00
                         </td>
                       </tr>
                     </tbody>
@@ -701,7 +701,7 @@ exports[`Viser utbetalingsdetaljer riktig med liste med ytelser og trekk 1`] = `
                 <p
                   className="typo-element"
                 >
-                  11,386.00
+                  11 386,00
                 </p>
               </div>
               <p
@@ -799,17 +799,17 @@ exports[`Viser utbetalingsdetaljer riktig med liste med ytelser og trekk 1`] = `
                           <td
                             role="cell"
                           >
-                            13,370.00
+                            13 370,00
                           </td>
                           <td
                             role="cell"
                           >
-                            -1,984.00
+                            −1 984,00
                           </td>
                           <td
                             role="cell"
                           >
-                            11,386.00
+                            11 386,00
                           </td>
                         </tr>
                       </tbody>
@@ -867,7 +867,7 @@ exports[`Viser utbetalingsdetaljer riktig med liste med ytelser og trekk 1`] = `
                         <td
                           role="cell"
                         >
-                          558.00
+                          558,00
                         </td>
                         <td
                           role="cell"
@@ -877,7 +877,7 @@ exports[`Viser utbetalingsdetaljer riktig med liste med ytelser og trekk 1`] = `
                         <td
                           role="cell"
                         >
-                          5,580.00
+                          5 580,00
                         </td>
                       </tr>
                       <tr
@@ -891,7 +891,7 @@ exports[`Viser utbetalingsdetaljer riktig med liste med ytelser og trekk 1`] = `
                         <td
                           role="cell"
                         >
-                          1,310.00
+                          1 310,00
                         </td>
                         <td
                           role="cell"
@@ -901,7 +901,7 @@ exports[`Viser utbetalingsdetaljer riktig med liste med ytelser og trekk 1`] = `
                         <td
                           role="cell"
                         >
-                          3,930.00
+                          3 930,00
                         </td>
                       </tr>
                       <tr
@@ -915,7 +915,7 @@ exports[`Viser utbetalingsdetaljer riktig med liste med ytelser og trekk 1`] = `
                         <td
                           role="cell"
                         >
-                          1,930.00
+                          1 930,00
                         </td>
                         <td
                           role="cell"
@@ -925,7 +925,7 @@ exports[`Viser utbetalingsdetaljer riktig med liste med ytelser og trekk 1`] = `
                         <td
                           role="cell"
                         >
-                          3,860.00
+                          3 860,00
                         </td>
                       </tr>
                       <tr
@@ -949,7 +949,7 @@ exports[`Viser utbetalingsdetaljer riktig med liste med ytelser og trekk 1`] = `
                         <td
                           role="cell"
                         >
-                          -730.00
+                          −730,00
                         </td>
                       </tr>
                       <tr
@@ -973,7 +973,7 @@ exports[`Viser utbetalingsdetaljer riktig med liste med ytelser og trekk 1`] = `
                         <td
                           role="cell"
                         >
-                          -1,042.00
+                          −1 042,00
                         </td>
                       </tr>
                       <tr
@@ -997,7 +997,7 @@ exports[`Viser utbetalingsdetaljer riktig med liste med ytelser og trekk 1`] = `
                         <td
                           role="cell"
                         >
-                          -212.00
+                          −212,00
                         </td>
                       </tr>
                     </tbody>

--- a/src/app/personside/infotabs/utbetalinger/utbetaling/__snapshots__/UtbetalingsDetaljer.test.tsx.snap
+++ b/src/app/personside/infotabs/utbetalinger/utbetaling/__snapshots__/UtbetalingsDetaljer.test.tsx.snap
@@ -70,17 +70,17 @@ exports[`Viser utbetalingsdetaljer riktig med liste med ytelser og trekk 1`] = `
             <td
               role="cell"
             >
-              13,370.00
+              13 370,00
             </td>
             <td
               role="cell"
             >
-              -1,984.00
+              −1 984,00
             </td>
             <td
               role="cell"
             >
-              11,386.00
+              11 386,00
             </td>
           </tr>
         </tbody>
@@ -138,7 +138,7 @@ exports[`Viser utbetalingsdetaljer riktig med liste med ytelser og trekk 1`] = `
           <td
             role="cell"
           >
-            558.00
+            558,00
           </td>
           <td
             role="cell"
@@ -148,7 +148,7 @@ exports[`Viser utbetalingsdetaljer riktig med liste med ytelser og trekk 1`] = `
           <td
             role="cell"
           >
-            5,580.00
+            5 580,00
           </td>
         </tr>
         <tr
@@ -162,7 +162,7 @@ exports[`Viser utbetalingsdetaljer riktig med liste med ytelser og trekk 1`] = `
           <td
             role="cell"
           >
-            1,310.00
+            1 310,00
           </td>
           <td
             role="cell"
@@ -172,7 +172,7 @@ exports[`Viser utbetalingsdetaljer riktig med liste med ytelser og trekk 1`] = `
           <td
             role="cell"
           >
-            3,930.00
+            3 930,00
           </td>
         </tr>
         <tr
@@ -186,7 +186,7 @@ exports[`Viser utbetalingsdetaljer riktig med liste med ytelser og trekk 1`] = `
           <td
             role="cell"
           >
-            1,930.00
+            1 930,00
           </td>
           <td
             role="cell"
@@ -196,7 +196,7 @@ exports[`Viser utbetalingsdetaljer riktig med liste med ytelser og trekk 1`] = `
           <td
             role="cell"
           >
-            3,860.00
+            3 860,00
           </td>
         </tr>
         <tr
@@ -220,7 +220,7 @@ exports[`Viser utbetalingsdetaljer riktig med liste med ytelser og trekk 1`] = `
           <td
             role="cell"
           >
-            -730.00
+            −730,00
           </td>
         </tr>
         <tr
@@ -244,7 +244,7 @@ exports[`Viser utbetalingsdetaljer riktig med liste med ytelser og trekk 1`] = `
           <td
             role="cell"
           >
-            -1,042.00
+            −1 042,00
           </td>
         </tr>
         <tr
@@ -268,7 +268,7 @@ exports[`Viser utbetalingsdetaljer riktig med liste med ytelser og trekk 1`] = `
           <td
             role="cell"
           >
-            -212.00
+            −212,00
           </td>
         </tr>
       </tbody>

--- a/src/app/personside/infotabs/ytelser/__snapshots__/ValgtYtelse.test.tsx.snap
+++ b/src/app/personside/infotabs/ytelser/__snapshots__/ValgtYtelse.test.tsx.snap
@@ -429,7 +429,7 @@ exports[`Om foreldrepenger matcher snapshot 1`] = `
                   <dd
                     className="typo-element"
                   >
-                    40,062.00 NOK
+                    40 062,00 NOK
                   </dd>
                 </div>
                 <div>
@@ -771,12 +771,12 @@ exports[`Om foreldrepenger matcher snapshot 1`] = `
                       <td
                         role="cell"
                       >
-                        705.00 NOK
+                        705,00 NOK
                       </td>
                       <td
                         role="cell"
                       >
-                        466.00 NOK
+                        466,00 NOK
                       </td>
                       <td
                         role="cell"
@@ -1173,7 +1173,7 @@ exports[`Om pleiepenger matcher snapshot 1`] = `
                   <dd
                     className="typo-element"
                   >
-                    45,029.00 NOK
+                    45 029,00 NOK
                   </dd>
                 </div>
                 <div>
@@ -1285,7 +1285,7 @@ exports[`Om pleiepenger matcher snapshot 1`] = `
                     <td
                       role="cell"
                     >
-                      120.00 NOK
+                      120,00 NOK
                     </td>
                     <td
                       role="cell"
@@ -1295,7 +1295,7 @@ exports[`Om pleiepenger matcher snapshot 1`] = `
                     <td
                       role="cell"
                     >
-                      5.00 NOK
+                      5,00 NOK
                     </td>
                     <td
                       role="cell"
@@ -1319,7 +1319,7 @@ exports[`Om pleiepenger matcher snapshot 1`] = `
                     <td
                       role="cell"
                     >
-                      596.00 NOK
+                      596,00 NOK
                     </td>
                     <td
                       role="cell"
@@ -1329,7 +1329,7 @@ exports[`Om pleiepenger matcher snapshot 1`] = `
                     <td
                       role="cell"
                     >
-                      27.00 NOK
+                      27,00 NOK
                     </td>
                     <td
                       role="cell"
@@ -1425,7 +1425,7 @@ exports[`Om pleiepenger matcher snapshot 1`] = `
                     <td
                       role="cell"
                     >
-                      69.00 NOK
+                      69,00 NOK
                     </td>
                     <td
                       role="cell"
@@ -1435,7 +1435,7 @@ exports[`Om pleiepenger matcher snapshot 1`] = `
                     <td
                       role="cell"
                     >
-                      12.00 NOK
+                      12,00 NOK
                     </td>
                     <td
                       role="cell"
@@ -1735,7 +1735,7 @@ exports[`Om sykepenger matcher snapshot 1`] = `
                 <dd
                   className="typo-element"
                 >
-                  837.00 NOK
+                  837,00 NOK
                 </dd>
               </div>
               <div>
@@ -1963,7 +1963,7 @@ exports[`Om sykepenger matcher snapshot 1`] = `
                   <dd
                     className="typo-element"
                   >
-                    39,691.00 NOK
+                    39 691,00 NOK
                   </dd>
                 </div>
                 <div>
@@ -2188,12 +2188,12 @@ exports[`Om sykepenger matcher snapshot 1`] = `
                 <td
                   role="cell"
                 >
-                  705.00 NOK
+                  705,00 NOK
                 </td>
                 <td
                   role="cell"
                 >
-                  466.00 NOK
+                  466,00 NOK
                 </td>
                 <td
                   role="cell"
@@ -2232,12 +2232,12 @@ exports[`Om sykepenger matcher snapshot 1`] = `
                 <td
                   role="cell"
                 >
-                  705.00 NOK
+                  705,00 NOK
                 </td>
                 <td
                   role="cell"
                 >
-                  466.00 NOK
+                  466,00 NOK
                 </td>
                 <td
                   role="cell"

--- a/src/app/personside/infotabs/ytelser/__snapshots__/Ytelser.test.tsx.snap
+++ b/src/app/personside/infotabs/ytelser/__snapshots__/Ytelser.test.tsx.snap
@@ -677,7 +677,7 @@ exports[`Om Ytelser matcher snapshot 1`] = `
                       <dd
                         className="typo-element"
                       >
-                        837.00 NOK
+                        837,00 NOK
                       </dd>
                     </div>
                     <div>
@@ -905,7 +905,7 @@ exports[`Om Ytelser matcher snapshot 1`] = `
                         <dd
                           className="typo-element"
                         >
-                          39,691.00 NOK
+                          39 691,00 NOK
                         </dd>
                       </div>
                       <div>
@@ -1130,12 +1130,12 @@ exports[`Om Ytelser matcher snapshot 1`] = `
                       <td
                         role="cell"
                       >
-                        705.00 NOK
+                        705,00 NOK
                       </td>
                       <td
                         role="cell"
                       >
-                        466.00 NOK
+                        466,00 NOK
                       </td>
                       <td
                         role="cell"
@@ -1174,12 +1174,12 @@ exports[`Om Ytelser matcher snapshot 1`] = `
                       <td
                         role="cell"
                       >
-                        705.00 NOK
+                        705,00 NOK
                       </td>
                       <td
                         role="cell"
                       >
-                        466.00 NOK
+                        466,00 NOK
                       </td>
                       <td
                         role="cell"

--- a/src/app/personside/infotabs/ytelser/arbeidsforhold/__snapshots__/ArbeidsforholdListe.test.tsx.snap
+++ b/src/app/personside/infotabs/ytelser/arbeidsforhold/__snapshots__/ArbeidsforholdListe.test.tsx.snap
@@ -97,7 +97,7 @@ exports[`ArbeidsforholdListe matcher snapshot 1`] = `
         <dd
           className="typo-element"
         >
-          39,691.00 NOK
+          39 691,00 NOK
         </dd>
       </div>
       <div>

--- a/src/app/personside/infotabs/ytelser/foreldrepenger/__snapshots__/ForeldrePenger.test.tsx.snap
+++ b/src/app/personside/infotabs/ytelser/foreldrepenger/__snapshots__/ForeldrePenger.test.tsx.snap
@@ -415,7 +415,7 @@ exports[`Foreldrepengeperiode matcher snapshot 1`] = `
                 <dd
                   className="typo-element"
                 >
-                  40,062.00 NOK
+                  40 062,00 NOK
                 </dd>
               </div>
               <div>
@@ -757,12 +757,12 @@ exports[`Foreldrepengeperiode matcher snapshot 1`] = `
                     <td
                       role="cell"
                     >
-                      705.00 NOK
+                      705,00 NOK
                     </td>
                     <td
                       role="cell"
                     >
-                      466.00 NOK
+                      466,00 NOK
                     </td>
                     <td
                       role="cell"

--- a/src/app/personside/infotabs/ytelser/foreldrepenger/__snapshots__/ForeldrepengePeriode.test.tsx.snap
+++ b/src/app/personside/infotabs/ytelser/foreldrepenger/__snapshots__/ForeldrepengePeriode.test.tsx.snap
@@ -380,12 +380,12 @@ exports[`Foreldrepengeperiode matcher snapshot 1`] = `
               <td
                 role="cell"
               >
-                705.00 NOK
+                705,00 NOK
               </td>
               <td
                 role="cell"
               >
-                466.00 NOK
+                466,00 NOK
               </td>
               <td
                 role="cell"

--- a/src/app/personside/infotabs/ytelser/pleiepenger/__snapshots__/pleiepenger.test.tsx.snap
+++ b/src/app/personside/infotabs/ytelser/pleiepenger/__snapshots__/pleiepenger.test.tsx.snap
@@ -245,7 +245,7 @@ exports[`Om Oversikten i pleiepengeretten matcher snapshot 1`] = `
             <dd
               className="typo-element"
             >
-              45,029.00 NOK
+              45 029,00 NOK
             </dd>
           </div>
           <div>
@@ -413,7 +413,7 @@ exports[`Om Pleiepengeperiode i pleiepengeretten matcher snapshot 1`] = `
             <td
               role="cell"
             >
-              120.00 NOK
+              120,00 NOK
             </td>
             <td
               role="cell"
@@ -423,7 +423,7 @@ exports[`Om Pleiepengeperiode i pleiepengeretten matcher snapshot 1`] = `
             <td
               role="cell"
             >
-              5.00 NOK
+              5,00 NOK
             </td>
             <td
               role="cell"
@@ -447,7 +447,7 @@ exports[`Om Pleiepengeperiode i pleiepengeretten matcher snapshot 1`] = `
             <td
               role="cell"
             >
-              596.00 NOK
+              596,00 NOK
             </td>
             <td
               role="cell"
@@ -457,7 +457,7 @@ exports[`Om Pleiepengeperiode i pleiepengeretten matcher snapshot 1`] = `
             <td
               role="cell"
             >
-              27.00 NOK
+              27,00 NOK
             </td>
             <td
               role="cell"

--- a/src/app/personside/infotabs/ytelser/pleiepenger/arbeidsforhold/__snapshots__/ArbeidsforholdListe.test.tsx.snap
+++ b/src/app/personside/infotabs/ytelser/pleiepenger/arbeidsforhold/__snapshots__/ArbeidsforholdListe.test.tsx.snap
@@ -121,7 +121,7 @@ exports[`ArbeidsforholdListe matcher snapshot 1`] = `
         <dd
           className="typo-element"
         >
-          10,856.00 NOK
+          10 856,00 NOK
         </dd>
       </div>
       <div>

--- a/src/app/personside/infotabs/ytelser/sykepenger/sykepengertilfellet/__snapshots__/Sykepengertilfellet.test.tsx.snap
+++ b/src/app/personside/infotabs/ytelser/sykepenger/sykepengertilfellet/__snapshots__/Sykepengertilfellet.test.tsx.snap
@@ -139,7 +139,7 @@ exports[`Sykepengertilfellet matcher snapshot 1`] = `
       <dd
         className="typo-element"
       >
-        837.00 NOK
+        837,00 NOK
       </dd>
     </div>
     <div>

--- a/src/app/personside/infotabs/ytelser/utbetalinger/kommendeUtbetalinger/__snapshots__/KommendeUtbetalinger.test.tsx.snap
+++ b/src/app/personside/infotabs/ytelser/utbetalinger/kommendeUtbetalinger/__snapshots__/KommendeUtbetalinger.test.tsx.snap
@@ -136,12 +136,12 @@ exports[`Kommende enkelutbetaling matcher snapshot 1`] = `
           <td
             role="cell"
           >
-            705.00 NOK
+            705,00 NOK
           </td>
           <td
             role="cell"
           >
-            466.00 NOK
+            466,00 NOK
           </td>
           <td
             role="cell"

--- a/src/utils/string-utils.test.ts
+++ b/src/utils/string-utils.test.ts
@@ -73,7 +73,7 @@ describe('datoEllerNull', () => {
 describe('NOKellerNull', () => {
     it('Returnerer Ja ved true', () => {
         const result = NOKellerNull(150);
-        expect(result).toEqual('150.00 NOK');
+        expect(result).toEqual('150,00 NOK');
     });
 
     it('Returnerer null ved null', () => {


### PR DESCRIPTION
Tallformat i norge er 123,00 imotsetning til 123.00
Det er også sånn vi viser det i browserenen (chrome) per i dag

Årsaken er at nodejs@<13 bare støttet engelsk locale(small-icu),
og dermed førte til at alt ble formattert på engelsk i testene.

Fra og med nodejs@13 bygges det med full-icu, altså alle locales,
og vi får derfor samme formattering i node som i browseren.

**Anbefaler alle derfor å oppdatere NodeJS til 14.6.0 eller nyere**
14.5.0 og eldre vil sannsynligvis ikke fungere da det har kommet noen feilfixes inn i 14.6.0 på formattering av tall på norsk.