### PR TITLE
[KAIZEN-0] gjøre det mulig å resette `gjelder/underkategori` ved opprettelse av oppgave

### DIFF
--- a/src/app/personside/infotabs/meldinger/traadvisning/__snapshots__/TraadVisningWrapper.test.tsx.snap
+++ b/src/app/personside/infotabs/meldinger/traadvisning/__snapshots__/TraadVisningWrapper.test.tsx.snap
@@ -915,7 +915,6 @@ exports[`Viser traad med verktøylinje 1`] = `
                 value=""
               >
                 <option
-                  disabled={true}
                   value=""
                 >
                   Ingen tema valgt

--- a/src/app/personside/infotabs/meldinger/traadvisning/verktoylinje/oppgave/OppgaveSkjema.tsx
+++ b/src/app/personside/infotabs/meldinger/traadvisning/verktoylinje/oppgave/OppgaveSkjema.tsx
@@ -159,24 +159,24 @@ function OppgaveSkjema(props: OppgaveProps) {
                 <Element>Opprett oppgave</Element>
                 <Select
                     autoFocus={true}
-                    label={'Tema'}
+                    label="Tema"
                     {...state.fields.valgtTema.input}
                     feil={feilmelding(state.fields.valgtTema)}
                 >
                     <TemaOptions gsakTema={props.gsakTema} />
                 </Select>
-                <Select label={'Gjelder'} {...state.fields.valgtUnderkategori.input}>
+                <Select label="Gjelder" {...state.fields.valgtUnderkategori.input}>
                     <UnderkategoriOptions valgtGsakTema={valgtTema} />
                 </Select>
                 <Select
-                    label={'Type oppgave'}
+                    label="Type oppgave"
                     {...state.fields.valgtOppgavetype.input}
                     feil={feilmelding(state.fields.valgtOppgavetype)}
                 >
                     <OppgavetypeOptions valgtGsakTema={valgtTema} />
                 </Select>
                 <AutoComplete
-                    label={'Velg enhet'}
+                    label="Velg enhet"
                     suggestions={
                         hasData(enhetliste) ? enhetliste.data.map(enhet => `${enhet.enhetId} ${enhet.enhetNavn}`) : []
                     }
@@ -189,14 +189,14 @@ function OppgaveSkjema(props: OppgaveProps) {
                     feil={feilmelding(state.fields.valgtEnhet)}
                 />
                 <AutoComplete
-                    label={'Velg ansatt'}
+                    label="Velg ansatt"
                     suggestions={ansattliste.ansatte.map(
                         ansatt => `${ansatt.fornavn} ${ansatt.etternavn} (${ansatt.ident})`
                     )}
                     input={state.fields.valgtAnsatt.input}
                 />
                 <Select
-                    label={'Velg prioritet'}
+                    label="Velg prioritet"
                     {...state.fields.valgtPrioritet?.input}
                     feil={feilmelding(state.fields.valgtPrioritet)}
                 >
@@ -204,7 +204,7 @@ function OppgaveSkjema(props: OppgaveProps) {
                 </Select>
                 <Textarea
                     maxLength={0}
-                    label={'Beskrivelse'}
+                    label="Beskrivelse"
                     {...state.fields.beskrivelse.input}
                     feil={feilmelding(state.fields.beskrivelse)}
                 />

--- a/src/app/personside/infotabs/meldinger/traadvisning/verktoylinje/oppgave/SkjemaElementOptions.tsx
+++ b/src/app/personside/infotabs/meldinger/traadvisning/verktoylinje/oppgave/SkjemaElementOptions.tsx
@@ -23,7 +23,7 @@ export function UnderkategoriOptions(props: { valgtGsakTema?: GsakTema }) {
         </option>
     ));
     options.unshift(
-        <option value={''} key={''} disabled>
+        <option value={''} key={''}>
             {props.valgtGsakTema ? 'Ingen underkategori' : 'Ingen tema valgt'}
         </option>
     );

--- a/src/app/personside/infotabs/meldinger/traadvisning/verktoylinje/oppgave/__snapshots__/OpprettOppgaveContainer.test.tsx.snap
+++ b/src/app/personside/infotabs/meldinger/traadvisning/verktoylinje/oppgave/__snapshots__/OpprettOppgaveContainer.test.tsx.snap
@@ -176,7 +176,6 @@ exports[`Viser oppgavecontainer med alt innhold 1`] = `
           value=""
         >
           <option
-            disabled={true}
             value=""
           >
             Ingen tema valgt


### PR DESCRIPTION
Kom inn som ønske via teams, feltet er ikke påkrevd og har tidligere også vært mulig å sette tilbake til "Ingen underkategori".
Dette ble blokkert her https://github.com/navikt/modiapersonoversikt/commit/cf23c3519fb5323b1e888c09b59a108109f5ba38 når man la til sperre for å nullstille felt som er påkrevde.