### PR TITLE
[FAGSYSTEM-123716] legge til fallback om ønsket NORM_prioritet ikke finnes

### DIFF
--- a/src/app/personside/infotabs/meldinger/traadvisning/verktoylinje/oppgave/oppgave-utils.ts
+++ b/src/app/personside/infotabs/meldinger/traadvisning/verktoylinje/oppgave/oppgave-utils.ts
@@ -10,9 +10,12 @@ export function useNormalPrioritet(
     const prioritetFieldName = state.fields.valgtPrioritet.input.name;
     const prioritetOnChange = state.fields.valgtPrioritet.input.onChange;
     useEffect(() => {
-        const normalOppgaveprioritet = valgtTema?.prioriteter.find(prioritet => prioritet.kode.includes('NORM'));
-        if (normalOppgaveprioritet) {
-            prioritetOnChange(changeEvent(prioritetFieldName, normalOppgaveprioritet.kode));
+        const onsketPrioritet =
+            valgtTema?.prioriteter.find(prioritet => prioritet.kode.includes('NORM')) ??
+            valgtTema?.prioriteter.find(() => true);
+
+        if (onsketPrioritet) {
+            prioritetOnChange(changeEvent(prioritetFieldName, onsketPrioritet.kode));
         }
     }, [valgtTema, prioritetFieldName, prioritetOnChange]);
 }


### PR DESCRIPTION
I tilfeller hvor saksbehandler bytter til tema som ikke har NORM_* prioritet så ville effekten `useNormalPrioritet` ikke endre på state-verdiene (siden den ikke fant NORM_*).

Dette medfører at den gamle prioritet-verdien blir liggende i form-state om man ikke gjør manuelle endringer til prioritet. Dette fører videre til at vi havner i situasjoner hvor vi risikerer å sende inn tema:BID prioritet:NORM_BAR 