### PR TITLE
[OPP-1248] henter oppgave-data fra backend ved overgang fra gosys

### DIFF
--- a/src/app/internarbeidsflatedecorator/useHandleGosysUrl.ts
+++ b/src/app/internarbeidsflatedecorator/useHandleGosysUrl.ts
@@ -7,6 +7,8 @@ import { useHistory } from 'react-router';
 import { INFOTABS } from '../personside/infotabs/InfoTabEnum';
 import { paths } from '../routes/routing';
 import { Oppgave } from '../../models/meldinger/oppgave';
+import { apiBaseUri } from '../../api/config';
+import { fetchToJson, hasData } from '../../utils/fetchToJson';
 
 function useHandleGosysUrl() {
     const queryParams = useQueryParams<{ sokFnr?: string; oppgaveid?: string; behandlingsid?: string }>();
@@ -16,14 +18,12 @@ function useHandleGosysUrl() {
 
     useOnMount(() => {
         if (queryParams.oppgaveid && queryParams.behandlingsid && queryParams.sokFnr) {
-            const oppgave: Oppgave = {
-                oppgaveId: queryParams.oppgaveid,
-                fødselsnummer: queryParams.sokFnr,
-                traadId: queryParams.behandlingsid,
-                fraGosys: true
-            };
-            dispatch(plukkOppgaverResource.actions.setResponse([oppgave]));
-            loggEvent('Oppgave', 'FraGosys');
+            fetchToJson<Oppgave>(`${apiBaseUri}/oppgaver/oppgavedata/${queryParams.oppgaveid}`).then(response => {
+                if (hasData(response)) {
+                    dispatch(plukkOppgaverResource.actions.setResponse([response.data]));
+                    loggEvent('Oppgave', 'FraGosys');
+                }
+            });
         } else if (queryParams.sokFnr && queryParams.behandlingsid) {
             const linkTilValgtHenvendelse = `${paths.personUri}/${
                 queryParams.sokFnr

--- a/src/app/personside/Personoversikt.tsx
+++ b/src/app/personside/Personoversikt.tsx
@@ -32,8 +32,8 @@ function Personoversikt() {
     useOnMount(() => {
         if (isFinishedPosting(oppgaveResource)) {
             const oppgaver = oppgaveResource.response;
-            const harSattOppgaveFraGosysUrl = oppgaver.some(oppgave => oppgave.fraGosys === true);
-            dispatch(setJobberMedSTO(!harSattOppgaveFraGosysUrl));
+            const harSTOOppgave = oppgaver.some(oppgave => oppgave.erSTOOppgave);
+            dispatch(setJobberMedSTO(!harSTOOppgave));
         } else {
             dispatch(setJobberMedSTO(false));
         }

--- a/src/app/personside/dialogpanel/fortsettDialog/FortsettDialogContainer.tsx
+++ b/src/app/personside/dialogpanel/fortsettDialog/FortsettDialogContainer.tsx
@@ -103,10 +103,10 @@ function FortsettDialogContainer(props: Props) {
     if (opprettHenvendelse.success === false) {
         return opprettHenvendelse.placeholder;
     }
-    const oppgaveFraGosys =
-        isFinishedPosting(plukkOppgaveResource) && plukkOppgaveResource.response.find(it => it.fraGosys);
-    const oppgaveIdFraGosys = oppgaveFraGosys && oppgaveFraGosys.oppgaveId;
-    const oppgaveId = oppgaveIdFraGosys ? oppgaveIdFraGosys : opprettHenvendelse.henvendelse.oppgaveId;
+    const harPlukketSTOOppgave =
+        isFinishedPosting(plukkOppgaveResource) && plukkOppgaveResource.response.find(it => it.erSTOOppgave);
+    const STOOppgaveId = harPlukketSTOOppgave && harPlukketSTOOppgave.oppgaveId;
+    const oppgaveId = STOOppgaveId ? STOOppgaveId : opprettHenvendelse.henvendelse.oppgaveId;
 
     const handleAvbryt = () => {
         removeDraft();

--- a/src/app/personside/infotabs/meldinger/traadvisning/verktoylinje/oppgave/AvsluttGosysOppgaveSkjema.tsx
+++ b/src/app/personside/infotabs/meldinger/traadvisning/verktoylinje/oppgave/AvsluttGosysOppgaveSkjema.tsx
@@ -31,20 +31,20 @@ function AvsluttGosysOppgaveSkjema() {
     const [avsluttOppgaveSuksess, setAvsluttOppgaveSuksess] = useState(false);
     const [error, setError] = useState(false);
     const dispatch = useDispatch();
-    const oppgaveFraGosys =
-        isFinishedPosting(plukkOppgaveResource) && plukkOppgaveResource.response.find(it => it.fraGosys);
+    const harSTOOppgave =
+        isFinishedPosting(plukkOppgaveResource) && plukkOppgaveResource.response.find(it => it.erSTOOppgave);
     const ref = useRef<HTMLElement>(null);
     useFocusOnMount(ref);
 
-    const handleOppgaveFraGosys = () => {
+    const handleSubmit = () => {
         if (submitting) {
             return;
         }
         setSubmitting(true);
-        if (oppgaveFraGosys) {
+        if (harSTOOppgave) {
             const request: AvsluttGosysOppgaveRequest = {
-                fnr: oppgaveFraGosys.fødselsnummer,
-                oppgaveid: oppgaveFraGosys.oppgaveId,
+                fnr: harSTOOppgave.fødselsnummer,
+                oppgaveid: harSTOOppgave.oppgaveId,
                 beskrivelse: gosysBeskrivelse,
                 saksbehandlerValgtEnhet: saksbehandlersEnhet
             };
@@ -78,7 +78,7 @@ function AvsluttGosysOppgaveSkjema() {
         );
     }
 
-    if (!oppgaveFraGosys) {
+    if (!harSTOOppgave) {
         return null;
     }
     return (
@@ -90,7 +90,7 @@ function AvsluttGosysOppgaveSkjema() {
                 maxLength={0}
                 onChange={e => setGosysBeskrivelse(e.currentTarget.value)}
             />
-            <Hovedknapp onClick={handleOppgaveFraGosys} spinner={submitting}>
+            <Hovedknapp onClick={handleSubmit} spinner={submitting}>
                 Avslutt oppgave
             </Hovedknapp>
         </StyledArticle>

--- a/src/mock/oppgave-mock.ts
+++ b/src/mock/oppgave-mock.ts
@@ -30,6 +30,7 @@ function lagOppgave(fodselsnummer: string): Oppgave {
     return {
         fødselsnummer: fodselsnummer,
         traadId: faker.random.alphaNumeric(5),
-        oppgaveId: faker.random.alphaNumeric(5)
+        oppgaveId: faker.random.alphaNumeric(5),
+        erSTOOppgave: true
     };
 }

--- a/src/models/meldinger/oppgave.ts
+++ b/src/models/meldinger/oppgave.ts
@@ -26,7 +26,7 @@ export interface GsakTemaUnderkategori {
 export interface Oppgave {
     oppgaveId: string;
     fødselsnummer: string;
-    fraGosys?: boolean;
+    erSTOOppgave: boolean;
     traadId?: string;
 }
 


### PR DESCRIPTION
ved å hente ut data om oppgaven kan vi gjøre en bedre sjekk av hva som skal være lov i løsning.
F.eks kan vi sikre at ikke-KNA/STO-oppgaver ikke lukkes fra modia, og at saksbehandlere som kommer fra gosys med sånne oppgaver får riktig visning.