### PR TITLE
[KAIZEN-0] forhindrer melding-fokus å bli satt flere ganger

### DIFF
--- a/src/app/personside/dialogpanel/fortsettDialog/useVisTraadTilknyttetPlukketOppgave.tsx
+++ b/src/app/personside/dialogpanel/fortsettDialog/useVisTraadTilknyttetPlukketOppgave.tsx
@@ -1,4 +1,3 @@
-import { useEffect } from 'react';
 import { Traad } from '../../../../models/meldinger/meldinger';
 import useTildelteOppgaver from '../../../../utils/hooks/useTildelteOppgaver';
 import { useDispatch } from 'react-redux';
@@ -8,6 +7,7 @@ import { loggError } from '../../../../utils/logger/frontendLogger';
 import { useHistory } from 'react-router';
 import { useRestResource } from '../../../../rest/consumer/useRestResource';
 import { eldsteMelding, kanBesvares } from '../../infotabs/meldinger/utils/meldingerUtils';
+import { useJustOnceEffect } from '../../../../utils/customHooks';
 
 interface Pending {
     pending: true;
@@ -27,8 +27,8 @@ function useVisTraadTilknyttetPlukketOppgave(dialogpanelTraad?: Traad): Response
     const dyplenker = useInfotabsDyplenker();
     const history = useHistory();
 
-    useEffect(
-        function visTraadTilknyttetOppgaveIDialogpanel() {
+    useJustOnceEffect(
+        function visTraadTilknyttetOppgaveIDialogpanel(done: () => void) {
             const oppgave = tildelteOppgaver.nettopTildelt[0];
             const åpneTrådIFortsettDialogpanel = !dialogpanelTraad && !!oppgave;
             if (!åpneTrådIFortsettDialogpanel || !traaderResource.data) {
@@ -43,6 +43,7 @@ function useVisTraadTilknyttetPlukketOppgave(dialogpanelTraad?: Traad): Response
 
             if (traadTilknyttetOppgave) {
                 history.push(dyplenker.meldinger.link(traadTilknyttetOppgave));
+                done();
             } else {
                 const debugKanBesvares = traadTilknyttetOppgave
                     ? eldsteMelding(traadTilknyttetOppgave).meldingstype

--- a/src/utils/customHooks.ts
+++ b/src/utils/customHooks.ts
@@ -19,6 +19,20 @@ export function useOnMount(effect: EffectCallback) {
     useEffect(effect, []);
 }
 
+export type JustOnceEffectCallback = (done: () => void) => void | (() => void | undefined);
+export function useJustOnceEffect(effect: JustOnceEffectCallback, deps?: DependencyList) {
+    const done = useRef(false);
+    const setDone = useCallback(() => {
+        done.current = true;
+    }, [done]);
+    useEffect(() => {
+        debugger;
+        if (!done.current) {
+            return effect(setDone);
+        }
+    }, deps); // eslint-disable-line react-hooks/exhaustive-deps
+}
+
 export function useOnUpdate(effect: EffectCallback, deps: DependencyList) {
     const firstMount = useRef(true);
 


### PR DESCRIPTION
i visse edgecases kunne man havne i en setting hvor man alltid hoppet tilbake til melding-lamellen for å sette fokus.
Det er kun ønskelig at dette skal skje en gang ved sidelast, men siden dataene (oppgave/traader) kan ta tid å laste inn
så kan vi ikke bruke useOnMount.