### PR TITLE
[opp-1318] Tilgjengeliggjøring av Øvirg som plukkbar temagruppe f

### DIFF
--- a/src/models/temagrupper.ts
+++ b/src/models/temagrupper.ts
@@ -35,7 +35,8 @@ export const TemaPlukkbare = [
     Temagruppe.Pensjon,
     Temagruppe.PleiepengerSyktBarn,
     Temagruppe.Uføretrygd,
-    Temagruppe.Utland
+    Temagruppe.Utland,
+    Temagruppe.Øvrig
 ];
 
 export const TemaLeggTilbake = [


### PR DESCRIPTION
for bruk i NKS Utland som miderltidig fiks før Utland er brukbar i heile verdikjeda.