### PR TITLE
fix/hotjar

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,5 @@ src/**/*.css
 npm-debug.log*
 yarn-debug.log*
 yarn-error.log*
+
+.eslintcache

--- a/public/index.html
+++ b/public/index.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="no">
+<html lang="no" data-hj-suppress>
 <head>
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
@@ -26,5 +26,17 @@
     You need to enable JavaScript to run this app.
 </noscript>
 <div id="root"></div>
+
+<!-- Hotjar Tracking Code for http://navlab.no/ -->
+<script>
+    (function(h,o,t,j,a,r){
+        h.hj=h.hj||function(){(h.hj.q=h.hj.q||[]).push(arguments)};
+        h._hjSettings={hjid:148751,hjsv:6};
+        a=o.getElementsByTagName('head')[0];
+        r=o.createElement('script');r.async=1;
+        r.src=t+h._hjSettings.hjid+j+h._hjSettings.hjsv;
+        a.appendChild(r);
+    })(window,document,'https://static.hotjar.com/c/hotjar-','.js?sv=');
+</script>
 </body>
 </html>

--- a/src/utils/hotjar.ts
+++ b/src/utils/hotjar.ts
@@ -1,0 +1,43 @@
+import { loggError } from './logger/frontendLogger';
+
+declare global {
+    interface Window {
+        hj?: (command: string, ...args: any[]) => void;
+    }
+}
+
+export enum HotjarTriggers {
+    BRUKSMONSTER = 'modia-hotjar-bruksmonster'
+}
+
+function requireHotjar(cmd: string, ...args: any[]) {
+    if (!window.hj) {
+        loggError(new Error('Prøvde å kalle hotjar kommando før hotjar var lastet: ' + cmd));
+    } else {
+        window.hj(cmd, ...args);
+    }
+}
+
+export function formSubmitSuccess() {
+    requireHotjar('formSubmitSuccessful');
+}
+
+export function formSubmitFailed() {
+    requireHotjar('formSubmitFailed');
+}
+
+export function stateChange(relativePath: string) {
+    requireHotjar('stateChange', relativePath);
+}
+
+export function tagRecording(tags: string[]) {
+    requireHotjar('tagRecording', tags);
+}
+
+export function trigger(event: HotjarTriggers): void {
+    requireHotjar('trigger', event);
+}
+
+export function virtualPageView(funnel: string) {
+    requireHotjar('vpv', funnel);
+}


### PR DESCRIPTION
- [KAIZEN-0] la til hotjar oppsett i index.html 180b114
data-hj-suppress legges på html-taggen for å sikre all tekst på siden blir maskert. surveys skal ikke sende side-innhold til hotjar, men tar med denne som litt ekstra sikkerhet.
script-tagen på bunnen er scriptet for å gjøre innlasting av hotjar-scriptet
- [KAIZEN-0] la til utils-funksjoner for å gjøre kall til hotjar 2d55d62
I førsteomgang bare `trigger` som vi kommer til å bruke, men resten er med for å vise api-et i sin helhet.