### PR TITLE
[KAIZEN-0] legge til unntak for isso til CSP

### DIFF
--- a/.nais/prod.yaml
+++ b/.nais/prod.yaml
@@ -57,3 +57,5 @@ spec:
       value: "https://unleash.nais.io/api/"
     - name: WEBSOCKET_CSP
       value: "wss://veilederflatehendelser.adeo.no"
+    - name: ISSO_CSP
+      value: "isso.adeo.no"

--- a/.nais/qa-template.yaml
+++ b/.nais/qa-template.yaml
@@ -57,4 +57,6 @@ spec:
       value: "https://unleash.nais.io/api/"
     - name: WEBSOCKET_CSP
       value: "wss://veilederflatehendelser-{{ namespace }}.adeo.no"
+    - name: ISSO_CSP
+      value: "isso-q.adeo.no"
 

--- a/config.yaml
+++ b/config.yaml
@@ -6,7 +6,7 @@ csp:
   styleSrc: "'self' 'unsafe-inline'"
   imgSrc: "'self' data: https://*.hotjar.com https://*.hotjar.io"
   fontSrc: "'self' data: https://*.hotjar.com https://*.hotjar.io"
-  connectSrc: "'self' eumgw.adeo.no {{ WEBSOCKET_CSP }} https://*.hotjar.com https://*.hotjar.io"
+  connectSrc: "'self' eumgw.adeo.no {{ WEBSOCKET_CSP }} {{ ISSO_CSP }} https://*.hotjar.com https://*.hotjar.io"
   # PDF-visning lastes inn via blob-urler
   objectSrc: "blob:"
   frameSrc: "blob: https://*.hotjar.com https://*.hotjar.io"


### PR DESCRIPTION
ønsker å teste ut om vi kan resette jwt-token ved å "relaste" modia via  `fetch` slik at vi kan sikre oss mot at fpsak-frontend sitt token blir brukt i løsningen vår