### PR TITLE
[KAIZEN-0] erstattet moment med dayjs

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12525,11 +12525,6 @@
             "integrity": "sha512-iniQP4rj1FhBdBYS/+eQv7j1tadJ9lJtdzgOpvsOHng/GbcDh2Fhdeq+ZRldrPYdXvCyfFUmFeEwEGXZB5I/AQ==",
             "dev": true
         },
-        "moment": {
-            "version": "2.29.1",
-            "resolved": "https://registry.npmjs.org/moment/-/moment-2.29.1.tgz",
-            "integrity": "sha512-kHmoybcPV8Sqy59DwNDY3Jefr64lK/by/da0ViFcuA4DH0vQg5Q6Ze5VimxkfQNSC+Mls/Kx53s7TjP1RhFEDQ=="
-        },
         "moo": {
             "version": "0.5.1",
             "resolved": "https://registry.npmjs.org/moo/-/moo-0.5.1.tgz",

--- a/package.json
+++ b/package.json
@@ -53,7 +53,6 @@
         "js-cookie": "^2.2.1",
         "lodash.debounce": "^4.0.8",
         "md5": "^2.2.1",
-        "moment": "^2.22.2",
         "nav-datovelger": "^10.1.2",
         "nav-faker": "^3.2.1",
         "nav-frontend-alertstriper": "^3.0.20",

--- a/src/app/internarbeidsflatedecorator/EasterEggs/DecoratorEasterEgg.tsx
+++ b/src/app/internarbeidsflatedecorator/EasterEggs/DecoratorEasterEgg.tsx
@@ -4,7 +4,7 @@ import Nisselue from './nisselue/Nisselue';
 import Partyhatt from './partyhatt/Partyhatt';
 import { easterEggs, useListenForEasterEgg } from './useListenForEasterEgg';
 import ErrorBoundary from '../../../components/ErrorBoundary';
-import moment from 'moment';
+import dayjs from 'dayjs';
 import PaaskeEgg from './paskeegg/PaaskeEgg';
 import { erPaaske } from './paskeegg/erPaaske';
 import DelayRender from '../../../components/DelayRender';
@@ -15,7 +15,7 @@ function useDefaultEasterEgg() {
         return '';
     }
 
-    const today = moment();
+    const today = dayjs();
     const erJul = today.month() === 11 && 20 <= today.date() && today.date() <= 28;
     const erNyttårsaften = today.month() === 11 && today.date() === 31;
 

--- a/src/app/internarbeidsflatedecorator/EasterEggs/paskeegg/erPaaske.ts
+++ b/src/app/internarbeidsflatedecorator/EasterEggs/paskeegg/erPaaske.ts
@@ -1,7 +1,7 @@
-import moment from 'moment';
+import dayjs from 'dayjs';
 
 export function erPaaske() {
-    const date = moment();
+    const date = dayjs();
     const month = date.month();
     const day = date.date();
     const year = date.year();

--- a/src/app/personside/infotabs/dyplenker.ts
+++ b/src/app/personside/infotabs/dyplenker.ts
@@ -1,4 +1,4 @@
-import moment from 'moment';
+import dayjs from 'dayjs';
 import { usePaths } from '../../routes/routing';
 import { Utbetaling } from '../../../models/utbetalinger';
 import { useParams } from 'react-router';
@@ -47,11 +47,11 @@ export function useInfotabsDyplenker(): Dyplenker {
     return useMemo(
         () => ({
             utbetaling: {
-                link: (utbetaling: Utbetaling) => `${paths.utbetlainger}/${moment(utbetaling.posteringsdato).unix()}`,
+                link: (utbetaling: Utbetaling) => `${paths.utbetlainger}/${dayjs(utbetaling.posteringsdato).unix()}`,
                 route: `${paths.utbetlainger}/:posteringsdato?`,
                 erValgt: (utbetaling: Utbetaling) => {
-                    const posteringsdatoFraUrl = moment.unix((posteringsdato as unknown) as number);
-                    return moment(utbetaling.posteringsdato).isSame(posteringsdatoFraUrl);
+                    const posteringsdatoFraUrl = dayjs.unix((posteringsdato as unknown) as number);
+                    return dayjs(utbetaling.posteringsdato).isSame(posteringsdatoFraUrl);
                 }
             },
             meldinger: {

--- a/src/app/personside/infotabs/oversikt/UtbetalingerOversikt.tsx
+++ b/src/app/personside/infotabs/oversikt/UtbetalingerOversikt.tsx
@@ -13,7 +13,7 @@ import VisMerKnapp from '../../../../components/VisMerKnapp';
 import { CenteredLazySpinner } from '../../../../components/LazySpinner';
 import { useInfotabsDyplenker } from '../dyplenker';
 import { utbetalingerTest } from '../dyplenkeTest/utils-dyplenker-test';
-import moment from 'moment';
+import dayjs from 'dayjs';
 import { ReactNode } from 'react';
 
 const ListStyle = styled.ol`
@@ -39,7 +39,12 @@ function UtbetalingerOversikt(props: Props) {
 }
 
 function datoEldreEnn30Dager(utbetaling: Utbetaling) {
-    return moment(getGjeldendeDatoForUtbetaling(utbetaling)) < moment().subtract(30, 'days');
+    return (
+        dayjs(getGjeldendeDatoForUtbetaling(utbetaling)).toDate() <
+        dayjs()
+            .subtract(30, 'days')
+            .toDate()
+    );
 }
 
 function UtbetalingerPanel(props: { utbetalinger: UtbetalingerResponse } & Props) {

--- a/src/app/personside/infotabs/saksoversikt/saksdokumenter/JournalpostLiseElement.tsx
+++ b/src/app/personside/infotabs/saksoversikt/saksdokumenter/JournalpostLiseElement.tsx
@@ -9,7 +9,7 @@ import {
 } from '../../../../../models/saksoversikt/journalpost';
 import styled, { css } from 'styled-components/macro';
 import theme from '../../../../../styles/personOversiktTheme';
-import moment from 'moment';
+import dayjs from 'dayjs';
 import { saksdatoSomDate } from '../../../../../models/saksoversikt/fellesSak';
 import { Normaltekst } from 'nav-frontend-typografi';
 import DokumentIkon from '../../../../../svg/DokumentIkon';
@@ -93,7 +93,7 @@ function utgåendeTekst(mottaker: Entitet, mottakernavn: string) {
 }
 
 function formaterDatoOgAvsender(brukernavn: string, dokument: Journalpost) {
-    const dato = moment(saksdatoSomDate(dokument.dato)).format('DD.MM.YYYY');
+    const dato = dayjs(saksdatoSomDate(dokument.dato)).format('DD.MM.YYYY');
     return `${dato} / ${tekstBasertPåRetning(brukernavn, dokument)}`;
 }
 

--- a/src/app/personside/infotabs/saksoversikt/utils/saksoversiktUtils.ts
+++ b/src/app/personside/infotabs/saksoversikt/utils/saksoversiktUtils.ts
@@ -1,6 +1,6 @@
 import { Journalpost } from '../../../../../models/saksoversikt/journalpost';
 import { Behandlingskjede, Sakstema } from '../../../../../models/saksoversikt/sakstema';
-import moment from 'moment';
+import dayjs from 'dayjs';
 import { sakstemakodeAlle } from '../sakstemaliste/SakstemaListe';
 import { saksdatoSomDate } from '../../../../../models/saksoversikt/fellesSak';
 import { useMemo } from 'react';
@@ -66,7 +66,7 @@ function hentSenesteDatoForBehandling(behandlingskjede: Behandlingskjede[]) {
 }
 
 function formatterDato(date: Date) {
-    return moment(date).format('DD.MM.YYYY');
+    return dayjs(date).format('DD.MM.YYYY');
 }
 
 export function getUnikSakstemaKey(sakstema: Sakstema) {

--- a/src/app/personside/infotabs/utbetalinger/totalt utbetalt/TotaltUtbetaltDetaljer.tsx
+++ b/src/app/personside/infotabs/utbetalinger/totalt utbetalt/TotaltUtbetaltDetaljer.tsx
@@ -19,7 +19,7 @@ import {
 } from '../utils/utbetalinger-utils';
 import { formaterDato } from '../../../../../utils/string-utils';
 import ErrorBoundary from '../../../../../components/ErrorBoundary';
-import moment from 'moment';
+import dayjs from 'dayjs';
 import { sorterAlfabetisk } from '../../../../../utils/string-utils';
 import DetaljerCollapse from '../../../../../components/DetaljerCollapse';
 
@@ -144,7 +144,7 @@ function getAlleUtbetalteYtelserFraUtbetalinger(utbetalinger: Utbetaling[]) {
 }
 
 function getTypeOgAarFromYtelse(ytelse: Ytelse): string {
-    return getTypeFromYtelse(ytelse) + ' ' + moment(ytelse.periode.slutt).year();
+    return getTypeFromYtelse(ytelse) + ' ' + dayjs(ytelse.periode.slutt).year();
 }
 
 function getYtelserSammendrag(utbetalinger: Utbetaling[]) {

--- a/src/app/personside/infotabs/utbetalinger/utils/utbetalinger-utils.test.tsx
+++ b/src/app/personside/infotabs/utbetalinger/utils/utbetalinger-utils.test.tsx
@@ -17,11 +17,10 @@ import {
     summertBeløpStringFraUtbetalinger,
     utbetalingDatoComparator
 } from './utbetalinger-utils';
-import moment from 'moment';
+import dayjs from 'dayjs';
 import { statiskMockUtbetaling, statiskMockYtelse } from '../../../../../mock/utbetalinger/statiskMockUtbetaling';
 import { Periode } from '../../../../../models/tid';
 import { PeriodeValg, UtbetalingFilterState } from '../../../../../redux/utbetalinger/types';
-import dayjs from 'dayjs';
 import { ISO_DATE_STRING_FORMAT } from 'nav-datovelger/lib/utils/dateFormatUtils';
 
 Date.now = () => new Date().getTime(); // for å motvirke Date.now() mock i setupTests.ts
@@ -249,14 +248,14 @@ test('henter riktig fra og til-date fra filter ved valg av "siste 30 dager"', ()
     const fraDate: Date = getFraDateFromFilter(filter);
     const tilDate: Date = getTilDateFromFilter(filter);
 
-    expect(moment(fraDate).toString()).toEqual(
-        moment()
+    expect(dayjs(fraDate).toString()).toEqual(
+        dayjs()
             .subtract(30, 'day')
             .startOf('day')
             .toString()
     );
-    expect(moment(tilDate).toString()).toEqual(
-        moment()
+    expect(dayjs(tilDate).toString()).toEqual(
+        dayjs()
             .add(100, 'day')
             .endOf('day')
             .toString()
@@ -275,13 +274,13 @@ test('henter riktig fra og til-date fra filter ved valg av "inneværende år', (
     const fraDate: Date = getFraDateFromFilter(filter);
     const tilDate: Date = getTilDateFromFilter(filter);
 
-    expect(moment(fraDate).toString()).toEqual(
-        moment()
+    expect(dayjs(fraDate).toString()).toEqual(
+        dayjs()
             .startOf('year')
             .toString()
     );
-    expect(moment(tilDate).toString()).toEqual(
-        moment()
+    expect(dayjs(tilDate).toString()).toEqual(
+        dayjs()
             .add(100, 'day')
             .endOf('day')
             .toString()
@@ -300,14 +299,14 @@ test('henter riktig fra og til-date fra filter ved valg av "i fjor', () => {
     const fraDate: Date = getFraDateFromFilter(filter);
     const tilDate: Date = getTilDateFromFilter(filter);
 
-    expect(moment(fraDate).toString()).toEqual(
-        moment()
+    expect(dayjs(fraDate).toString()).toEqual(
+        dayjs()
             .subtract(1, 'year')
             .startOf('year')
             .toString()
     );
-    expect(moment(tilDate).toString()).toEqual(
-        moment()
+    expect(dayjs(tilDate).toString()).toEqual(
+        dayjs()
             .subtract(1, 'year')
             .endOf('year')
             .toString()

--- a/src/app/personside/infotabs/utbetalinger/utils/utbetalinger-utils.ts
+++ b/src/app/personside/infotabs/utbetalinger/utils/utbetalinger-utils.ts
@@ -1,11 +1,10 @@
 import { Skatt, Trekk, Utbetaling, Ytelse, Ytelseskomponent } from '../../../../../models/utbetalinger';
 import { formaterDato } from '../../../../../utils/string-utils';
 import { Periode } from '../../../../../models/tid';
-import moment from 'moment';
+import dayjs from 'dayjs';
 import { loggError } from '../../../../../utils/logger/frontendLogger';
 import { UtbetalingFilterState, PeriodeValg } from '../../../../../redux/utbetalinger/types';
 import { datoVerbose } from '../../../../../utils/date-utils';
-import dayjs from 'dayjs';
 import { ISO_DATE_STRING_FORMAT } from 'nav-datovelger/lib/utils/dateFormatUtils';
 
 export const utbetaltTilBruker = 'Bruker';
@@ -16,7 +15,7 @@ export function maanedOgAarForUtbetaling(utbetaling: Utbetaling) {
 }
 
 export function utbetalingDatoComparator(a: Utbetaling, b: Utbetaling) {
-    return moment(getGjeldendeDatoForUtbetaling(b)).unix() - moment(getGjeldendeDatoForUtbetaling(a)).unix();
+    return dayjs(getGjeldendeDatoForUtbetaling(b)).unix() - dayjs(getGjeldendeDatoForUtbetaling(a)).unix();
 }
 
 export function ytelseBelopDescComparator(a: Ytelseskomponent, b: Ytelseskomponent) {
@@ -33,11 +32,11 @@ export function trekkBelopAscComparator(a: Trekk, b: Trekk) {
 
 export function getUtbetalingerForSiste30DagerDatoer() {
     return {
-        fra: moment()
+        fra: dayjs()
             .subtract(30, 'day')
             .startOf('day')
             .toDate(),
-        til: moment()
+        til: dayjs()
             .add(100, 'day')
             .endOf('day')
             .toDate()
@@ -47,11 +46,11 @@ export function getUtbetalingerForSiste30DagerDatoer() {
 export function getFraDateFromFilter(filter: UtbetalingFilterState): Date {
     switch (filter.periode.radioValg) {
         case PeriodeValg.INNEVÆRENDE_ÅR:
-            return moment()
+            return dayjs()
                 .startOf('year')
                 .toDate();
         case PeriodeValg.I_FJOR:
-            return moment()
+            return dayjs()
                 .subtract(1, 'year')
                 .startOf('year')
                 .toDate();
@@ -66,7 +65,7 @@ export function getFraDateFromFilter(filter: UtbetalingFilterState): Date {
 export function getTilDateFromFilter(filter: UtbetalingFilterState): Date {
     switch (filter.periode.radioValg) {
         case PeriodeValg.I_FJOR:
-            return moment()
+            return dayjs()
                 .subtract(1, 'year')
                 .endOf('year')
                 .toDate();
@@ -154,20 +153,20 @@ export function flatMapYtelser(utbetalinger?: Utbetaling[]): Ytelse[] {
 }
 
 export function getPeriodeFromYtelser(ytelser: Ytelse[]): Periode {
-    console.log('debug', moment().format(), moment(0).format());
+    console.log('debug', dayjs().format(), dayjs(0).format());
     return ytelser.reduce(
         (acc: Periode, ytelse: Ytelse) => {
             if (!ytelse.periode) {
                 return acc;
             }
             return {
-                fra: moment(ytelse.periode.start).isBefore(moment(acc.fra)) ? ytelse.periode.start : acc.fra,
-                til: moment(ytelse.periode.slutt).isAfter(moment(acc.til)) ? ytelse.periode.slutt : acc.til
+                fra: dayjs(ytelse.periode.start).isBefore(dayjs(acc.fra)) ? ytelse.periode.start : acc.fra,
+                til: dayjs(ytelse.periode.slutt).isAfter(dayjs(acc.til)) ? ytelse.periode.slutt : acc.til
             };
         },
         {
-            fra: moment().format(),
-            til: moment(0).format()
+            fra: dayjs().format(),
+            til: dayjs(0).format()
         }
     );
 }

--- a/src/app/personside/infotabs/ytelser/sykepenger/utbetalingerpåvent/utledUtbetalingerPåVentÅrsak.ts
+++ b/src/app/personside/infotabs/ytelser/sykepenger/utbetalingerpåvent/utledUtbetalingerPåVentÅrsak.ts
@@ -1,6 +1,10 @@
 import { UtbetalingPåVent } from '../../../../../../models/ytelse/ytelse-utbetalinger';
-import moment from 'moment';
 import { Periode } from '../../../../../../models/tid';
+import dayjs from 'dayjs';
+import isSameOrBeforePlugin from 'dayjs/plugin/isSameOrBefore';
+import isSameOrAfterPlugin from 'dayjs/plugin/isSameOrAfter';
+dayjs.extend(isSameOrBeforePlugin);
+dayjs.extend(isSameOrAfterPlugin);
 
 export function utledUtbetalingPåVentÅrsak(utbetaling: UtbetalingPåVent): string {
     if (utbetaling.arbeidskategori === 'Inntektsopplysninger mangler') {
@@ -23,9 +27,9 @@ export function utledUtbetalingPåVentÅrsak(utbetaling: UtbetalingPåVent): str
 
 function utbetalingPåVentPgaSanksjon({ vedtak, sanksjon }: UtbetalingPåVent): boolean {
     if (sanksjon && vedtak && vedtak.til) {
-        const sanksjonInnenforVedtaksperiode = moment(sanksjon.fra).isSameOrBefore(moment(vedtak.til));
+        const sanksjonInnenforVedtaksperiode = dayjs(sanksjon.fra).isSameOrBefore(dayjs(vedtak.til));
         const sanksjonUtenSlutt = sanksjonInnenforVedtaksperiode && !sanksjon.til;
-        const sanksjonFremdelesGjeldende = !!sanksjon.til && moment(sanksjon.til).isSameOrAfter(moment(vedtak.til));
+        const sanksjonFremdelesGjeldende = !!sanksjon.til && dayjs(sanksjon.til).isSameOrAfter(dayjs(vedtak.til));
         return sanksjonUtenSlutt || sanksjonFremdelesGjeldende;
     }
     return false;
@@ -33,7 +37,7 @@ function utbetalingPåVentPgaSanksjon({ vedtak, sanksjon }: UtbetalingPåVent): 
 
 function erPåVentFordiSykemeldingMangler({ vedtak, sykmeldt }: UtbetalingPåVent): boolean {
     if (vedtak && sykmeldt && vedtak.til && sykmeldt.til) {
-        return moment(vedtak.til).isSameOrAfter(moment(sykmeldt.til));
+        return dayjs(vedtak.til).isSameOrAfter(dayjs(sykmeldt.til));
     }
     return false;
 }
@@ -46,5 +50,5 @@ function erPåVentGrunnetFerie({ vedtak, ferie1, ferie2 }: UtbetalingPåVent): b
 }
 
 function ferieEtterVedtakTom(ferie: Periode | null, vedtakTil: string): boolean {
-    return !!ferie && moment(vedtakTil).isSameOrBefore(moment(ferie.til));
+    return !!ferie && dayjs(vedtakTil).isSameOrBefore(dayjs(ferie.til));
 }

--- a/src/app/personside/kontrollsporsmal/SporsmalExtractors.tsx
+++ b/src/app/personside/kontrollsporsmal/SporsmalExtractors.tsx
@@ -12,7 +12,7 @@ import { KRRKontaktinformasjon } from '../../../models/kontaktinformasjon';
 import { formaterDato } from '../../../utils/string-utils';
 import { shuffle } from './list-utils';
 import { Svar } from '../../../redux/kontrollSporsmal/types';
-import moment from 'moment';
+import dayjs from 'dayjs';
 import { formatertKontonummerString } from '../../../utils/FormatertKontonummer';
 import { getFodselsdatoFraFnr } from '../../../utils/fnr-utils';
 
@@ -110,7 +110,7 @@ export function hentGiftedato(person: Person) {
 }
 
 function hentDato(person: Person): string {
-    const relasjonFraOgMed = moment(person.sivilstand.fraOgMed).format('DD.MM.YYYY');
+    const relasjonFraOgMed = dayjs(person.sivilstand.fraOgMed).format('DD.MM.YYYY');
     const nullDatoFraTPS = '01.01.9999';
 
     if (relasjonFraOgMed === nullDatoFraTPS) {

--- a/src/app/personside/kontrollsporsmal/cookie-utils.ts
+++ b/src/app/personside/kontrollsporsmal/cookie-utils.ts
@@ -1,10 +1,10 @@
-import moment from 'moment';
+import dayjs from 'dayjs';
 import * as Cookies from 'js-cookie';
 
 const kontrollSpmErLukketForBrukerCookieNavn = 'KontrollSpmErLukketForBruker';
 
 export function settSkjulKontrollspørsmålPåTversAvVinduerForBrukerCookie(fnr: string) {
-    const omEnTime = moment()
+    const omEnTime = dayjs()
         .add(1, 'hour')
         .toDate();
     Cookies.set(kontrollSpmErLukketForBrukerCookieNavn, fnr, { expires: omEnTime });

--- a/src/app/personside/visittkort/body/familie/Sivilstand.tsx
+++ b/src/app/personside/visittkort/body/familie/Sivilstand.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import moment from 'moment';
+import dayjs from 'dayjs';
 import { Normaltekst } from 'nav-frontend-typografi';
 import VisittkortElement from '../VisittkortElement';
 import {
@@ -27,7 +27,7 @@ function Sivilstand(props: { sivilstand: SivilstandInterface }) {
     if (props.sivilstand.kodeRef === SivilstandTyper.Ugift) {
         return <>{props.sivilstand.beskrivelse}</>;
     }
-    const relasjonFraOgMed = moment(props.sivilstand.fraOgMed).format('DD.MM.YYYY');
+    const relasjonFraOgMed = dayjs(props.sivilstand.fraOgMed).format('DD.MM.YYYY');
     const nullDatoFraTPS = '01.01.9999';
 
     if (relasjonFraOgMed !== nullDatoFraTPS) {

--- a/src/app/personsok/PersonsokDatovelger.tsx
+++ b/src/app/personsok/PersonsokDatovelger.tsx
@@ -9,7 +9,7 @@ import useBoundingRect from '../../utils/hooks/use-bounding-rect';
 import { PersonSokFormState } from './personsok-utils';
 import { FieldState, Mapped, Values } from '@nutgaard/use-formstate';
 import { SkjemaelementFeilmelding } from 'nav-frontend-skjema';
-import moment from 'moment';
+import dayjs from 'dayjs';
 
 const DatovelgerStyle = styled.div<{ top: number; left: number }>`
     margin-right: 0.5em;
@@ -90,8 +90,8 @@ function PersonsokDatovelger(props: { form: Mapped<Values<PersonSokFormState>, F
     const dropdownFraCoordinate = beregnDropdownCoordinate(datovelgerFraRect);
     const dropdownTilCoordinate = beregnDropdownCoordinate(datovelgerTilRect);
     const datoFeilmelding = getDatoFeilmelding(
-        moment(props.form.fodselsdatoFra.input.value).toDate(),
-        moment(props.form.fodselsdatoTil.input.value).toDate()
+        dayjs(props.form.fodselsdatoFra.input.value).toDate(),
+        dayjs(props.form.fodselsdatoTil.input.value).toDate()
     );
     const avgrensninger = { minDate: props.form.fodselsdatoFra.input.value };
     return (

--- a/src/app/personsok/PersonsokSkjema.tsx
+++ b/src/app/personsok/PersonsokSkjema.tsx
@@ -17,7 +17,7 @@ import styled from 'styled-components/macro';
 import theme from '../../styles/personOversiktTheme';
 import { erTall } from '../../utils/string-utils';
 import { validerKontonummer } from './kontonummer/kontonummerUtils';
-import moment from 'moment';
+import dayjs from 'dayjs';
 import { feilmelding } from '../personside/infotabs/meldinger/traadvisning/verktoylinje/oppgave/validering';
 import { useRef } from 'react';
 import { guid } from 'nav-frontend-js-utils';
@@ -107,8 +107,8 @@ export const validatorPersonsok: FunctionValidator<PersonSokFormState> = values 
 
     let fodselsdatoFra = undefined;
     let fodselsdatoTil = undefined;
-    const fra = moment(values.fodselsdatoFra).toDate();
-    const til = moment(values.fodselsdatoTil).toDate();
+    const fra = dayjs(values.fodselsdatoFra).toDate();
+    const til = dayjs(values.fodselsdatoTil).toDate();
     if (fra > til) {
         fodselsdatoFra = 'Fra-dato kan ikke være senere enn til-dato';
     }

--- a/src/components/standalone/Sykepenger/SykepengerLaster.tsx
+++ b/src/components/standalone/Sykepenger/SykepengerLaster.tsx
@@ -3,7 +3,7 @@ import { useEffect } from 'react';
 import { SykepengerResponse } from '../../../models/ytelse/sykepenger';
 import { loggError, loggEvent } from '../../../utils/logger/frontendLogger';
 import Sykepenger from '../../../app/personside/infotabs/ytelser/sykepenger/Sykepenger';
-import moment from 'moment';
+import dayjs from 'dayjs';
 import { AlertStripeAdvarsel, AlertStripeInfo } from 'nav-frontend-alertstriper';
 import RestResourceConsumer from '../../../rest/consumer/RestResourceConsumer';
 import { BigCenteredLazySpinner } from '../../BigCenteredLazySpinner';
@@ -26,7 +26,7 @@ function SykePengerLaster(props: Props) {
             return <AlertStripeInfo>Kunne ikke finne sykepengerettighet for bruker</AlertStripeInfo>;
         }
         const aktuellRettighet = data.sykepenger.find(rettighet =>
-            moment(rettighet.sykmeldtFom).isSame(moment(props.sykmeldtFraOgMed))
+            dayjs(rettighet.sykmeldtFom).isSame(dayjs(props.sykmeldtFraOgMed))
         );
         if (!aktuellRettighet) {
             loggError(new Error('Kunne ikke finne sykepengerettighet'), undefined, {

--- a/src/mock/meldinger/meldinger-mock.ts
+++ b/src/mock/meldinger/meldinger-mock.ts
@@ -1,7 +1,7 @@
 import { LestStatus, Melding, Saksbehandler, Traad, Meldingstype } from '../../models/meldinger/meldinger';
 import faker from 'faker/locale/nb_NO';
 import navfaker from 'nav-faker';
-import moment from 'moment';
+import dayjs from 'dayjs';
 import { fyllRandomListe } from '../utils/mock-utils';
 import {
     erMeldingstypeSamtalereferat,
@@ -80,18 +80,18 @@ function getMelding(temagruppe: Temagruppe): Melding {
         skrevetAvTekst: saksbehandlerTekst(getSaksbehandler()),
         journalfortAv: getSaksbehandler(),
         journalfortDato: navfaker.random.vektetSjanse(0.5)
-            ? moment(faker.date.recent(50)).format(backendDatoTidformat)
+            ? dayjs(faker.date.recent(50)).format(backendDatoTidformat)
             : undefined,
         journalfortSaksid: faker.random.alphaNumeric(5),
         journalfortTemanavn: navfaker.random.arrayElement(['Dagpenger', 'Arbeid', 'Pensjon', 'Bidrag']),
         fritekst: fritekst,
-        lestDato: moment(faker.date.recent(40)).format(backendDatoTidformat),
+        lestDato: dayjs(faker.date.recent(40)).format(backendDatoTidformat),
         status: navfaker.random.arrayElement([LestStatus.IkkeLest, LestStatus.Lest]),
-        opprettetDato: moment(faker.date.recent(40)).format(backendDatoTidformat),
-        ferdigstiltDato: moment(faker.date.recent(40)).format(backendDatoTidformat),
+        opprettetDato: dayjs(faker.date.recent(40)).format(backendDatoTidformat),
+        ferdigstiltDato: dayjs(faker.date.recent(40)).format(backendDatoTidformat),
         erFerdigstiltUtenSvar: ferdigstilUtenSvar,
         ferdigstiltUtenSvarDato: ferdigstilUtenSvar
-            ? moment(faker.date.recent(40)).format(backendDatoTidformat)
+            ? dayjs(faker.date.recent(40)).format(backendDatoTidformat)
             : undefined,
         ferdigstiltUtenSvarAv: ferdigstilUtenSvar ? getSaksbehandler() : undefined,
         kontorsperretAv: visKontrosperre ? getSaksbehandler() : undefined,

--- a/src/mock/mockBackend/meldingerBackendMock.ts
+++ b/src/mock/mockBackend/meldingerBackendMock.ts
@@ -12,7 +12,7 @@ import {
     Traad
 } from '../../models/meldinger/meldinger';
 import { guid } from 'nav-frontend-js-utils';
-import moment from 'moment';
+import dayjs from 'dayjs';
 import { getMockTraader } from '../meldinger/meldinger-mock';
 import { Temagruppe } from '../../models/temagrupper';
 import { OppgaverBackendMock } from './oppgaverBackendMock';
@@ -141,7 +141,7 @@ function getMockMelding(): Melding {
         skrevetAvTekst: 'Saksbehandler',
         fritekst: 'Dette er en mock-melding',
         status: LestStatus.IkkeLest,
-        opprettetDato: moment().format(backendDatoTidformat),
+        opprettetDato: dayjs().format(backendDatoTidformat),
         erFerdigstiltUtenSvar: false,
         erDokumentMelding: false
     };

--- a/src/mock/oppfolging-mock.ts
+++ b/src/mock/oppfolging-mock.ts
@@ -11,7 +11,7 @@ import {
 } from '../models/oppfolging';
 import { fyllRandomListe } from './utils/mock-utils';
 import navfaker from 'nav-faker';
-import moment from 'moment';
+import dayjs from 'dayjs';
 import { backendDatoformat } from '../utils/date-utils';
 
 export function getMockOppfølging(fødselsnummer: string): Oppfolging {
@@ -49,9 +49,9 @@ export function getMockYtelserOgKontrakter(fødselsnummer: string): DetaljertOpp
         meldeplikt: faker.random.boolean(),
         formidlingsgruppe: 'FMGRP' + faker.random.number(5),
         innsatsgruppe: 'INGRP' + faker.random.number(10),
-        sykemeldtFra: moment(faker.date.recent(10)).format(backendDatoformat),
+        sykemeldtFra: dayjs(faker.date.recent(10)).format(backendDatoformat),
         rettighetsgruppe: 'RGRP' + faker.random.number(10),
-        vedtaksdato: moment(faker.date.recent(10)).format(backendDatoformat),
+        vedtaksdato: dayjs(faker.date.recent(10)).format(backendDatoformat),
         sykefraværsoppfølging: fyllRandomListe(getSyfoPunkt, 5),
         ytelser: fyllRandomListe(() => navfaker.random.arrayElement([getYtelse(), getDagpenger()]), 4)
     };
@@ -59,7 +59,7 @@ export function getMockYtelserOgKontrakter(fødselsnummer: string): DetaljertOpp
 
 function getSyfoPunkt(): SyfoPunkt {
     return {
-        dato: moment(faker.date.recent(100)).format(backendDatoformat),
+        dato: dayjs(faker.date.recent(100)).format(backendDatoformat),
         fastOppfølgingspunkt: faker.random.boolean(),
         status: 'Ferdig behandlet',
         syfoHendelse: faker.lorem.words(6)
@@ -68,9 +68,9 @@ function getSyfoPunkt(): SyfoPunkt {
 
 function getYtelse(): OppfolgingsYtelse {
     return {
-        datoKravMottatt: moment(faker.date.recent(30)).format(backendDatoformat),
-        fom: moment(faker.date.recent(20)).format(backendDatoformat),
-        tom: moment(faker.date.recent(10)).format(backendDatoformat),
+        datoKravMottatt: dayjs(faker.date.recent(30)).format(backendDatoformat),
+        fom: dayjs(faker.date.recent(20)).format(backendDatoformat),
+        tom: dayjs(faker.date.recent(10)).format(backendDatoformat),
         status: navfaker.random.arrayElement(['Aktiv', 'Avsluttet']),
         type: navfaker.random.arrayElement(['Arbeidsavklaringspenger', 'Individstønad']),
         vedtak: Array(navfaker.random.integer(5, 1))
@@ -94,8 +94,8 @@ function getDagpenger(): Dagpenger {
 
 function getVedtak(): OppfolgingsVedtak {
     return {
-        aktivFra: moment(faker.date.recent(40)).format(backendDatoformat),
-        aktivTil: moment(faker.date.recent(20)).format(backendDatoformat),
+        aktivFra: dayjs(faker.date.recent(40)).format(backendDatoformat),
+        aktivTil: dayjs(faker.date.recent(20)).format(backendDatoformat),
         aktivitetsfase: 'Ikke spesif. aktivitetsfase',
         vedtakstatus: navfaker.random.arrayElement(['Iverksatt', 'Avsluttet']),
         vedtakstype: 'Ordinære dagpenger'

--- a/src/mock/person/familierelasjoner/familerelasjonerMock.ts
+++ b/src/mock/person/familierelasjoner/familerelasjonerMock.ts
@@ -1,7 +1,5 @@
-import moment from 'moment';
-
+import dayjs from 'dayjs';
 import navfaker from 'nav-faker';
-
 import { Familierelasjon, Relasjonstype, Sivilstand, SivilstandTyper } from '../../../models/person/person';
 import { lagForeldre } from './relasjoner/foreldre';
 import { mockBarn } from './relasjoner/barn';
@@ -10,14 +8,14 @@ import { getDiskresjonskode } from '../../utils/diskresjonskode-util';
 
 export function getFamilierelasjoner(forFødselsnummer: string, sivilstand: Sivilstand) {
     const fødselsdato = navfaker.personIdentifikator.getFødselsdato(forFødselsnummer);
-    const alder = moment().diff(fødselsdato, 'years');
+    const alder = dayjs().diff(fødselsdato, 'years');
 
     let relasjoner: Familierelasjon[] = [];
     if (alder >= 18) {
         relasjoner = relasjoner.concat(mockBarn(forFødselsnummer));
     }
 
-    relasjoner = relasjoner.concat(lagForeldre(moment(fødselsdato)));
+    relasjoner = relasjoner.concat(lagForeldre(dayjs(fødselsdato)));
 
     if (sivilstand.kodeRef === SivilstandTyper.Gift) {
         relasjoner.push(lagPartner(Relasjonstype.Ektefelle));

--- a/src/mock/person/familierelasjoner/relasjoner/barn.ts
+++ b/src/mock/person/familierelasjoner/relasjoner/barn.ts
@@ -1,7 +1,5 @@
-import moment from 'moment';
-
+import dayjs from 'dayjs';
 import navfaker from 'nav-faker';
-
 import { tilfeldigFodselsnummer } from '../../../utils/fnr-utils';
 import { getPersonstatus } from '../../personMock';
 import { lagNavn, getAlderFromFødselsnummer } from '../../../utils/person-utils';
@@ -10,7 +8,7 @@ import { Familierelasjon, Relasjonstype } from '../../../../models/person/person
 export function mockBarn(foreldresFødselsnummer: string) {
     navfaker.seed(foreldresFødselsnummer);
     const foreldresFødseldato = navfaker.personIdentifikator.getFødselsdato(foreldresFødselsnummer);
-    const alder = moment().diff(foreldresFødseldato, 'years');
+    const alder = dayjs().diff(foreldresFødseldato, 'years');
     const antallBarn = kalkulerAntallBarn(alder);
 
     let barn = [];

--- a/src/mock/person/familierelasjoner/relasjoner/foreldre.ts
+++ b/src/mock/person/familierelasjoner/relasjoner/foreldre.ts
@@ -1,14 +1,11 @@
-import moment from 'moment';
-import { Moment } from 'moment';
-
+import dayjs, { Dayjs } from 'dayjs';
 import navfaker from 'nav-faker';
-
 import { tilfeldigFodselsnummer } from '../../../utils/fnr-utils';
 import { getPersonstatus } from '../../personMock';
 import { lagNavn, getAlderFromFødselsnummer } from '../../../utils/person-utils';
 import { Familierelasjon, Kjonn, Relasjonstype } from '../../../../models/person/person';
 
-export function lagForeldre(barnetsAlder: Moment): Familierelasjon[] {
+export function lagForeldre(barnetsAlder: Dayjs): Familierelasjon[] {
     let foreldre = [];
     if (navfaker.random.vektetSjanse(0.9)) {
         foreldre.push(lagForelder(barnetsAlder, Relasjonstype.Mor));
@@ -19,7 +16,7 @@ export function lagForeldre(barnetsAlder: Moment): Familierelasjon[] {
     return foreldre;
 }
 
-function lagForelder(barnetsFødselsdato: Moment, relasjonstype: Relasjonstype) {
+function lagForelder(barnetsFødselsdato: Dayjs, relasjonstype: Relasjonstype) {
     const kjønn = relasjonstype === Relasjonstype.Mor ? Kjonn.Kvinne : Kjonn.Mann;
     const foreldersFødselsnummer = lagFødselsnummer(barnetsFødselsdato, kjønn);
     const alder = getAlderFromFødselsnummer(foreldersFødselsnummer);
@@ -36,9 +33,10 @@ function lagForelder(barnetsFødselsdato: Moment, relasjonstype: Relasjonstype) 
     };
 }
 
-function lagFødselsnummer(barnetsFødselsdato: moment.Moment, kjønn: Kjonn) {
+function lagFødselsnummer(barnetsFødselsdato: Dayjs, kjønn: Kjonn) {
     const minFødselsdato = barnetsFødselsdato.subtract(18, 'years');
-    const maxFødselsdato = moment.min(minFødselsdato, moment().subtract(100, 'years'));
+    const absoluteMinDato = dayjs().subtract(100, 'years');
+    const maxFødselsdato = absoluteMinDato.isBefore(minFødselsdato) ? absoluteMinDato : minFødselsdato;
     const fødselsdato = navfaker.dato.mellom(minFødselsdato.toDate(), maxFødselsdato.toDate());
     const foreldersFødselsnummer = tilfeldigFodselsnummer(fødselsdato, kjønn);
     return foreldersFødselsnummer;

--- a/src/mock/person/fullmakter-mock.ts
+++ b/src/mock/person/fullmakter-mock.ts
@@ -1,6 +1,5 @@
 import { Fullmakt } from '../../models/person/fullmakter';
-import moment from 'moment';
-
+import dayjs from 'dayjs';
 import { fyllRandomListe, vektetSjanse } from '../utils/mock-utils';
 import NavFaker from 'nav-faker/dist/navfaker';
 import { backendDatoformat } from '../../utils/date-utils';
@@ -18,8 +17,8 @@ function getMockFullmakt(faker: Faker.FakerStatic, navfaker: NavFaker): Fullmakt
         motpartsPersonident: navfaker.personIdentifikator.fødselsnummer(),
         motpartsPersonNavn: navfaker.navn.fornavn(),
         omraade: getOmraade(faker),
-        gyldigFraOgMed: moment(faker.date.past(1)).format(backendDatoformat),
-        gyldigTilOgMed: moment(faker.date.future(2)).format(backendDatoformat)
+        gyldigFraOgMed: dayjs(faker.date.past(1)).format(backendDatoformat),
+        gyldigTilOgMed: dayjs(faker.date.future(2)).format(backendDatoformat)
     };
 }
 

--- a/src/mock/person/periodeMock.ts
+++ b/src/mock/person/periodeMock.ts
@@ -1,6 +1,6 @@
 import { Periode } from '../../models/tid';
 import { getSistOppdatert } from '../utils/mock-utils';
-import moment from 'moment';
+import dayjs from 'dayjs';
 import { backendDatoformat } from '../../utils/date-utils';
 
 export function getPeriode(): Periode {
@@ -12,7 +12,7 @@ export function getPeriode(): Periode {
 
 export function getPeriodeRange(faker: Faker.FakerStatic, years: number): Periode {
     return {
-        fra: moment(faker.date.past(years)).format(backendDatoformat),
-        til: moment(faker.date.past(years)).format(backendDatoformat)
+        fra: dayjs(faker.date.past(years)).format(backendDatoformat),
+        til: dayjs(faker.date.past(years)).format(backendDatoformat)
     };
 }

--- a/src/mock/person/personMock.ts
+++ b/src/mock/person/personMock.ts
@@ -1,6 +1,5 @@
 import faker from 'faker/locale/nb_NO';
-import moment from 'moment';
-
+import dayjs from 'dayjs';
 import navfaker from 'nav-faker/dist/index';
 
 import { Bostatus, BostatusTyper, Navn, Person, PersonRespons } from '../../models/person/person';
@@ -37,8 +36,8 @@ export function getPerson(fødselsnummer: string): PersonRespons {
 
 function genererPerson(fødselsnummer: string): Person {
     const fødselsdato = navfaker.personIdentifikator.getFødselsdato(fødselsnummer);
-    const alder = moment().diff(fødselsdato, 'years');
-    const sivilstand = getSivilstand(moment(fødselsdato), faker);
+    const alder = dayjs().diff(fødselsdato, 'years');
+    const sivilstand = getSivilstand(dayjs(fødselsdato), faker);
     return {
         fødselsnummer,
         kjønn: utledKjønnFraFødselsnummer(fødselsnummer),
@@ -91,9 +90,7 @@ export function getBedriftsNavn(id: string): string {
 export function getPersonstatus(alder: number): Bostatus {
     const bostatus = getBostatus();
     const dødsdato =
-        bostatus && bostatus.kodeRef === BostatusTyper.Død
-            ? moment(faker.date.past(alder)).format(moment.ISO_8601.__momentBuiltinFormatBrand)
-            : undefined;
+        bostatus && bostatus.kodeRef === BostatusTyper.Død ? dayjs(faker.date.past(alder)).toISOString() : undefined;
     return {
         bostatus,
         dødsdato

--- a/src/mock/person/sivilstandMock.ts
+++ b/src/mock/person/sivilstandMock.ts
@@ -1,6 +1,4 @@
-import moment from 'moment';
-import { Moment } from 'moment';
-
+import dayjs, { Dayjs } from 'dayjs';
 import { vektetSjanse } from '../utils/mock-utils';
 import { Sivilstand, SivilstandTyper } from '../../models/person/person';
 
@@ -44,8 +42,8 @@ const enke = (fraOgMed: string) => {
     };
 };
 
-export function getSivilstand(fødselsdato: Moment, faker: Faker.FakerStatic): Sivilstand {
-    const alder = moment().diff(fødselsdato, 'years');
+export function getSivilstand(fødselsdato: Dayjs, faker: Faker.FakerStatic): Sivilstand {
+    const alder = dayjs().diff(fødselsdato, 'years');
     const fraOgMed = getSistOppdatert(alder, faker);
     if (alder < 18) {
         return ugift(fraOgMed);
@@ -69,5 +67,5 @@ function getTilfeldigSilvstand(fraOgMed: string, faker: Faker.FakerStatic) {
 
 function getSistOppdatert(alder: number, faker: Faker.FakerStatic) {
     const maxYearsAgo = alder - 18;
-    return moment(faker.date.past(maxYearsAgo)).format('YYYY-MM-DD');
+    return dayjs(faker.date.past(maxYearsAgo)).format('YYYY-MM-DD');
 }

--- a/src/mock/utbetalinger/utbetalinger-mock.ts
+++ b/src/mock/utbetalinger/utbetalinger-mock.ts
@@ -1,6 +1,5 @@
 import faker from 'faker/locale/nb_NO';
-import moment from 'moment';
-
+import dayjs from 'dayjs';
 import navfaker from 'nav-faker/dist/index';
 
 import {
@@ -46,7 +45,7 @@ function getUtbetalinger(fødselsnummer: string) {
 }
 
 function randomDato(seededFaker: Faker.FakerStatic) {
-    return moment(seededFaker.date.past(1.5))
+    return dayjs(seededFaker.date.past(1.5))
         .startOf('day')
         .format(backendDatoformat);
 }

--- a/src/mock/utils/mock-utils.ts
+++ b/src/mock/utils/mock-utils.ts
@@ -1,8 +1,8 @@
-import moment from 'moment';
+import dayjs from 'dayjs';
 import navfaker from 'nav-faker';
 
 export function getSistOppdatert() {
-    return moment(navfaker.dato.forÅrSiden(5)).toISOString();
+    return dayjs(navfaker.dato.forÅrSiden(5)).toISOString();
 }
 
 export function vektetSjanse(seededFaker: Faker.FakerStatic, vekt: Number) {

--- a/src/mock/utils/person-utils.ts
+++ b/src/mock/utils/person-utils.ts
@@ -1,6 +1,6 @@
 import faker from 'faker/locale/nb_NO';
 import navfaker from 'nav-faker';
-import moment from 'moment';
+import dayjs from 'dayjs';
 
 export function lagNavn(fødselsnummer: string) {
     faker.seed(Number(fødselsnummer));
@@ -18,5 +18,5 @@ export function lagNavn(fødselsnummer: string) {
 }
 
 export function getAlderFromFødselsnummer(fødselsnummer: string) {
-    return moment().diff(navfaker.personIdentifikator.getFødselsdato(fødselsnummer), 'years');
+    return dayjs().diff(navfaker.personIdentifikator.getFødselsdato(fødselsnummer), 'years');
 }

--- a/src/mock/varsler/varsel-mock.ts
+++ b/src/mock/varsler/varsel-mock.ts
@@ -2,7 +2,7 @@ import faker from 'faker/locale/nb_NO';
 import navfaker from 'nav-faker';
 import { DittNavEvent, Varsel, Varselmelding, Varseltype } from '../../models/varsel';
 import { fyllRandomListe } from '../utils/mock-utils';
-import moment from 'moment';
+import dayjs from 'dayjs';
 import { aremark } from '../person/aremark';
 import { statiskVarselMock } from './statiskVarselMock';
 import { backendDatoformat } from '../../utils/date-utils';
@@ -27,10 +27,10 @@ function genererDittNavEventVarsel(fnr: string): DittNavEvent {
         fodselsnummer: fnr,
         grupperingsId: faker.random.uuid(),
         eventId: faker.random.uuid(),
-        eventTidspunkt: moment(tidspunkt).format(backendDatoformat),
+        eventTidspunkt: dayjs(tidspunkt).format(backendDatoformat),
         produsent: faker.random.alphaNumeric(),
         sikkerhetsnivaa: navfaker.random.arrayElement([3, 4]),
-        sistOppdatert: moment(tidspunkt).format(backendDatoformat),
+        sistOppdatert: dayjs(tidspunkt).format(backendDatoformat),
         tekst: faker.lorem.sentence(5 + faker.random.number(5)),
         link: faker.lorem.sentence(5 + faker.random.number(5)),
         aktiv: faker.random.boolean()
@@ -40,7 +40,7 @@ function genererDittNavEventVarsel(fnr: string): DittNavEvent {
 function getVarsel(): Varsel {
     return {
         varselType: navfaker.random.arrayElement(Object.keys(Varseltype)),
-        mottattTidspunkt: moment(faker.date.recent(90)).format(backendDatoformat),
+        mottattTidspunkt: dayjs(faker.date.recent(90)).format(backendDatoformat),
         erRevarsling: faker.random.boolean(),
         meldingListe: fyllRandomListe(getVarselMelding, 5)
     };
@@ -53,7 +53,7 @@ function getVarselMelding(): Varselmelding {
         kanal: kanal,
         innhold: faker.lorem.sentence(faker.random.number(25)),
         mottakerInformasjon: motakerInfo,
-        utsendingsTidspunkt: moment(faker.date.recent(90)).format(backendDatoformat),
+        utsendingsTidspunkt: dayjs(faker.date.recent(90)).format(backendDatoformat),
         feilbeskrivelse: 'Feil',
         epostemne: 'Epostemne',
         url: 'http://test.com',

--- a/src/mock/ytelse/foreldrepenger-mock.ts
+++ b/src/mock/ytelse/foreldrepenger-mock.ts
@@ -1,8 +1,6 @@
 import faker from 'faker/locale/nb_NO';
-import moment from 'moment';
-
+import dayjs from 'dayjs';
 import navfaker from 'nav-faker/dist/index';
-
 import {
     Foreldrepengerperiode,
     ForeldrepengerResponse,
@@ -48,23 +46,23 @@ export function getForeldrepengerettighetMock(fødselsnummer: string, seed?: num
         forelder: fødselsnummer,
         andreForeldersFnr: navfaker.personIdentifikator.fødselsnummer(),
         antallBarn: navfaker.random.integer(5),
-        barnetsFødselsdato: moment(faker.date.recent()).format(backendDatoformat),
+        barnetsFødselsdato: dayjs(faker.date.recent()).format(backendDatoformat),
         dekningsgrad: navfaker.random.integer(95),
-        fedrekvoteTom: vektetSjanse(faker, 0.5) ? moment(faker.date.recent()).format(backendDatoformat) : null,
-        mødrekvoteTom: vektetSjanse(faker, 0.5) ? moment(faker.date.recent()).format(backendDatoformat) : null,
+        fedrekvoteTom: vektetSjanse(faker, 0.5) ? dayjs(faker.date.recent()).format(backendDatoformat) : null,
+        mødrekvoteTom: vektetSjanse(faker, 0.5) ? dayjs(faker.date.recent()).format(backendDatoformat) : null,
         foreldrepengetype: foreldrePengeType(),
         graderingsdager: navfaker.random.integer(100),
         restDager: navfaker.random.integer(50),
-        rettighetFom: vektetSjanse(faker, 0.5) ? moment(faker.date.past(2)).format(backendDatoformat) : null,
-        eldsteIdDato: vektetSjanse(faker, 0.5) ? moment(faker.date.past(2)).format(backendDatoformat) : null,
+        rettighetFom: vektetSjanse(faker, 0.5) ? dayjs(faker.date.past(2)).format(backendDatoformat) : null,
+        eldsteIdDato: vektetSjanse(faker, 0.5) ? dayjs(faker.date.past(2)).format(backendDatoformat) : null,
         foreldreAvSammeKjønn: vektetSjanse(faker, 0.5) ? 'Begge er pappaer' : null,
         periode: fyllRandomListe<Foreldrepengerperiode>(() => getForeldrepengerperiodeMock(fødselsnummer), 5),
-        slutt: vektetSjanse(faker, 0.5) ? moment(faker.date.recent()).format(backendDatoformat) : null,
+        slutt: vektetSjanse(faker, 0.5) ? dayjs(faker.date.recent()).format(backendDatoformat) : null,
         arbeidsforhold: fyllRandomListe<Arbeidsforhold>(() => getArbeidsforholdMock(fødselsnummer), 5),
         erArbeidsgiverperiode: vektetSjanse(faker, 0.5) ? faker.random.boolean() : null,
         arbeidskategori: vektetSjanse(faker, 0.5) ? 'Arbeidstaker' : null,
-        omsorgsovertakelse: !erFødsel ? moment(faker.date.past(2)).format(backendDatoformat) : undefined,
-        termin: erFødsel ? moment(faker.date.recent()).format(backendDatoformat) : undefined
+        omsorgsovertakelse: !erFødsel ? dayjs(faker.date.past(2)).format(backendDatoformat) : undefined,
+        termin: erFødsel ? dayjs(faker.date.recent()).format(backendDatoformat) : undefined
     } as Foreldrepengerettighet;
 }
 
@@ -83,8 +81,8 @@ export function getForeldrepengerperiodeMock(fødselsnummer: string): Foreldrepe
         forskyvelsesperiode1: vektetSjanse(faker, 0.5) ? getPeriode() : null,
         forskyvelsesårsak2: vektetSjanse(faker, 0.5) ? 'FÅRSAK2' : null,
         forskyvelsesperiode2: vektetSjanse(faker, 0.5) ? getPeriode() : null,
-        foreldrepengerFom: moment(faker.date.past(5)).format(backendDatoformat),
-        midlertidigStansDato: vektetSjanse(faker, 0.5) ? moment(faker.date.recent()).format(backendDatoformat) : null,
+        foreldrepengerFom: dayjs(faker.date.past(5)).format(backendDatoformat),
+        midlertidigStansDato: vektetSjanse(faker, 0.5) ? dayjs(faker.date.recent()).format(backendDatoformat) : null,
         morSituasjon: vektetSjanse(faker, 0.5) ? faker.lorem.words(5) : null,
         rettTilFedrekvote: vektetSjanse(faker, 0.5) ? 'Rett til fedrekvote' : 'Ingen rett til fedrekvote',
         rettTilMødrekvote: vektetSjanse(faker, 0.5) ? 'Rett til mødrekvote' : 'Ingen rett til mødrekvote',
@@ -99,8 +97,8 @@ function getArbeidsforholdMock(fødselsnummer: string): Arbeidsforhold {
         arbeidsgiverKontonr: Number(faker.finance.account(11)).toString(),
         inntektsperiode: vektetSjanse(faker, 0.5) ? 'Månedlig' : 'Årlig',
         inntektForPerioden: Math.round(Number(faker.finance.amount(5000, 50000))),
-        sykepengerFom: vektetSjanse(faker, 0.5) ? moment(faker.date.recent()).format(backendDatoformat) : null,
-        refusjonTom: vektetSjanse(faker, 0.5) ? moment(faker.date.recent()).format(backendDatoformat) : null,
+        sykepengerFom: vektetSjanse(faker, 0.5) ? dayjs(faker.date.recent()).format(backendDatoformat) : null,
+        refusjonTom: vektetSjanse(faker, 0.5) ? dayjs(faker.date.recent()).format(backendDatoformat) : null,
         refusjonstype: 'Ikke refusjon'
     };
 }

--- a/src/mock/ytelse/pleiepenger-mock.ts
+++ b/src/mock/ytelse/pleiepenger-mock.ts
@@ -1,5 +1,5 @@
 import faker from 'faker/locale/nb_NO';
-import moment from 'moment';
+import dayjs from 'dayjs';
 
 import navfaker from 'nav-faker/dist/index';
 import {
@@ -63,7 +63,7 @@ export function getMockPleiepengerettighet(fødselsnummer: string): Pleiepengere
 
 function getPleiepengeperiode(): Pleiepengeperiode {
     return {
-        fom: moment(faker.date.past(2)).format(backendDatoformat),
+        fom: dayjs(faker.date.past(2)).format(backendDatoformat),
         antallPleiepengedager: navfaker.random.integer(20),
         arbeidsforhold: fyllRandomListe<Arbeidsforhold>(() => getArbeidsforhold(), 2),
         vedtak: fyllRandomListe<Vedtak>(() => getVedtak(), 3)
@@ -76,7 +76,7 @@ function getArbeidsforhold(): Arbeidsforhold {
         arbeidsgiverKontonr: Number(faker.finance.account(11)).toString(),
         inntektsperiode: 'Månedssats',
         inntektForPerioden: Math.round(Number(faker.finance.amount(5000, 50000))),
-        refusjonTom: moment(faker.date.past(2)).format(backendDatoformat),
+        refusjonTom: dayjs(faker.date.past(2)).format(backendDatoformat),
         refusjonstype: 'Ikke refusjon',
         arbeidsgiverOrgnr: '1234567890',
         arbeidskategori: 'Arbeidstaker'
@@ -88,7 +88,7 @@ function getVedtak(): Vedtak {
         periode: getPeriode(),
         kompensasjonsgrad: navfaker.random.vektetSjanse(0.5) ? 100 : navfaker.random.integer(100),
         utbetalingsgrad: navfaker.random.vektetSjanse(0.5) ? 100 : navfaker.random.integer(100),
-        anvistUtbetaling: moment(faker.date.past(2)).format(backendDatoformat),
+        anvistUtbetaling: dayjs(faker.date.past(2)).format(backendDatoformat),
         bruttobeløp: Number(faker.commerce.price()),
         dagsats: navfaker.random.integer(70),
         pleiepengegrad: navfaker.random.integer(100)
@@ -96,8 +96,8 @@ function getVedtak(): Vedtak {
 }
 
 function getPeriode(): Periode {
-    const fom = moment(faker.date.past(2));
-    const tom = moment(fom).add(faker.random.number(40), 'days');
+    const fom = dayjs(faker.date.past(2));
+    const tom = dayjs(fom).add(faker.random.number(40), 'days');
     return {
         fom: fom.format(backendDatoformat),
         tom: tom.format(backendDatoformat)

--- a/src/mock/ytelse/sykepenger-mock.ts
+++ b/src/mock/ytelse/sykepenger-mock.ts
@@ -1,6 +1,5 @@
 import faker from 'faker/locale/nb_NO';
-import moment from 'moment';
-
+import dayjs from 'dayjs';
 import navfaker from 'nav-faker/dist/index';
 
 import {
@@ -44,7 +43,7 @@ export function getMockSykepengerRespons(fødselsnummer: string): SykepengerResp
 export function getMockSykmepenger(fødselsnummer: string): Sykepenger {
     return {
         fødselsnummer: fødselsnummer,
-        sykmeldtFom: moment(faker.date.past(1)).format(backendDatoformat),
+        sykmeldtFom: dayjs(faker.date.past(1)).format(backendDatoformat),
         forbrukteDager: navfaker.random.integer(100),
         ferie1: navfaker.random.vektetSjanse(0.3) ? getPeriode() : null,
         ferie2: navfaker.random.vektetSjanse(0.3) ? getPeriode() : null,
@@ -57,9 +56,9 @@ export function getMockSykmepenger(fødselsnummer: string): Sykepenger {
         utbetalingerPåVent: fyllRandomListe<UtbetalingPåVent>(() => getUtbetalingPåVent(faker), 2, true),
         bruker: fødselsnummer,
         midlertidigStanset: navfaker.random.vektetSjanse(0.3)
-            ? moment(faker.date.past(1)).format(backendDatoformat)
+            ? dayjs(faker.date.past(1)).format(backendDatoformat)
             : null,
-        slutt: navfaker.random.vektetSjanse(0.7) ? null : moment(faker.date.past(1)).format(backendDatoformat),
+        slutt: navfaker.random.vektetSjanse(0.7) ? null : dayjs(faker.date.past(1)).format(backendDatoformat),
         arbeidsforholdListe: fyllRandomListe(() => getArbeidsforhold(), 10, true),
         erArbeidsgiverperiode: navfaker.random.vektetSjanse(0.5),
         arbeidskategori: 'Ærlig arbeid'
@@ -78,7 +77,7 @@ function getForsikring(): Forsikring {
 export function getMockSykmelding(): Sykmelding {
     return {
         sykmelder: faker.name.firstName() + ' ' + faker.name.lastName(),
-        behandlet: moment(faker.date.past(1)).format(backendDatoformat),
+        behandlet: dayjs(faker.date.past(1)).format(backendDatoformat),
         sykmeldt: getPeriode(),
         sykmeldingsgrad: navfaker.random.integer(100),
         gjelderYrkesskade: navfaker.random.vektetSjanse(0.0) ? getYrkesskade() : null,
@@ -89,8 +88,8 @@ export function getMockSykmelding(): Sykmelding {
 function getYrkesskade(): Yrkesskade {
     return {
         yrkesskadeart: faker.lorem.words(3),
-        skadet: moment(faker.date.past(1)).format(backendDatoformat),
-        vedtatt: moment(faker.date.past(1)).format(backendDatoformat)
+        skadet: dayjs(faker.date.past(1)).format(backendDatoformat),
+        vedtatt: dayjs(faker.date.past(1)).format(backendDatoformat)
     };
 }
 
@@ -107,8 +106,8 @@ function getArbeidsforhold(): Arbeidsforhold {
         arbeidsgiverKontonr: Number(faker.finance.account(11)).toString(),
         inntektsperiode: 'Månedssats',
         inntektForPerioden: Math.round(Number(faker.finance.amount(5000, 50000))),
-        refusjonTom: moment(faker.date.past(2)).format(backendDatoformat),
+        refusjonTom: dayjs(faker.date.past(2)).format(backendDatoformat),
         refusjonstype: 'Ikke refusjon',
-        sykepengerFom: moment(faker.date.past(2)).format(backendDatoformat)
+        sykepengerFom: dayjs(faker.date.past(2)).format(backendDatoformat)
     };
 }

--- a/src/mock/ytelse/ytelse-utbetalinger-mock.ts
+++ b/src/mock/ytelse/ytelse-utbetalinger-mock.ts
@@ -1,5 +1,4 @@
-import moment from 'moment';
-
+import dayjs from 'dayjs';
 import { KommendeUtbetaling, UtbetalingPåVent } from '../../models/ytelse/ytelse-utbetalinger';
 import { getPeriodeRange } from '../person/periodeMock';
 import { backendDatoformat } from '../../utils/date-utils';
@@ -8,7 +7,7 @@ export function getKommendeUtbetaling(faker: Faker.FakerStatic): KommendeUtbetal
     return {
         vedtak: getPeriodeRange(faker, 2),
         utbetalingsgrad: faker.random.number(100),
-        utbetalingsdato: moment(faker.date.past(2)).format(backendDatoformat),
+        utbetalingsdato: dayjs(faker.date.past(2)).format(backendDatoformat),
         bruttobeløp: Number(faker.commerce.price()),
         arbeidsgiverNavn: faker.company.companyName(),
         arbeidsgiverOrgNr: '1234567890',

--- a/src/models/saksoversikt/fellesSak.ts
+++ b/src/models/saksoversikt/fellesSak.ts
@@ -1,4 +1,4 @@
-import moment from 'moment';
+import dayjs from 'dayjs';
 
 export enum Baksystem {
     Gsak = 'GSAK',
@@ -22,7 +22,7 @@ export interface Saksdato {
 }
 
 export function saksdatoSomDate(saksdato: Saksdato): Date {
-    return moment(`${saksdato.år}-${padZero(saksdato.måned)}-${padZero(saksdato.dag)}`).toDate();
+    return dayjs(`${saksdato.år}-${padZero(saksdato.måned)}-${padZero(saksdato.dag)}`).toDate();
 }
 
 function padZero(date: number): string {

--- a/src/models/ytelse/foreldrepenger.ts
+++ b/src/models/ytelse/foreldrepenger.ts
@@ -1,7 +1,7 @@
 import { Periode } from '../tid';
 import { KommendeUtbetaling } from './ytelse-utbetalinger';
 import { Arbeidsforhold } from './arbeidsforhold';
-import moment from 'moment';
+import dayjs from 'dayjs';
 import { backendDatoformat } from '../../utils/date-utils';
 
 export interface ForeldrepengerResponse {
@@ -69,7 +69,7 @@ export interface Foreldrepengerperiode {
 }
 
 export function getForeldepengerIdDato(foreldrepenger: Foreldrepengerettighet) {
-    return foreldrepenger.rettighetFom ? foreldrepenger.rettighetFom : moment().format(backendDatoformat);
+    return foreldrepenger.rettighetFom ? foreldrepenger.rettighetFom : dayjs().format(backendDatoformat);
 }
 
 export function getUnikForeldrepengerKey(foreldrepenger: Foreldrepengerettighet): string {

--- a/src/models/ytelse/pleiepenger.ts
+++ b/src/models/ytelse/pleiepenger.ts
@@ -1,5 +1,5 @@
 import { getSistePeriodeForPleiepengerettighet } from '../../app/personside/infotabs/ytelser/pleiepenger/pleiepengerUtils';
-import moment from 'moment';
+import dayjs from 'dayjs';
 import { backendDatoformat } from '../../utils/date-utils';
 
 export interface PleiepengerResponse {
@@ -54,7 +54,7 @@ export function getPleiepengerIdDato(pleiepengerettighet: Pleiepengerettighet) {
     const sistePeriodeForPleiepengerettighet = getSistePeriodeForPleiepengerettighet(pleiepengerettighet);
     return sistePeriodeForPleiepengerettighet
         ? sistePeriodeForPleiepengerettighet.fom
-        : moment().format(backendDatoformat);
+        : dayjs().format(backendDatoformat);
 }
 
 export function getUnikPleiepengerKey(pleiepengerettighet: Pleiepengerettighet): string {

--- a/src/redux/oppfolging/types.ts
+++ b/src/redux/oppfolging/types.ts
@@ -1,4 +1,4 @@
-import moment from 'moment';
+import dayjs from 'dayjs';
 
 export interface VisOppfolgingFraTilDato {
     fra: string;
@@ -13,10 +13,10 @@ export interface OppfolgingState {
 
 export const initialState: OppfolgingState = {
     valgtPeriode: {
-        fra: moment()
+        fra: dayjs()
             .subtract(2, 'month')
             .format('YYYY-MM-DD'),
-        til: moment()
+        til: dayjs()
             .add(1, 'month')
             .format('YYYY-MM-DD')
     },

--- a/src/redux/restReducers/utbetalinger.ts
+++ b/src/redux/restReducers/utbetalinger.ts
@@ -2,7 +2,7 @@ import { UtbetalingerResponse } from '../../models/utbetalinger';
 import { apiBaseUri } from '../../api/config';
 import { createRestResourceReducerAndActions } from '../../rest/utils/restResource';
 import { AppState } from '../reducers';
-import moment from 'moment';
+import dayjs from 'dayjs';
 import {
     getFraDateFromFilter,
     getTilDateFromFilter
@@ -14,8 +14,8 @@ function getUtbetalingerFetchUri(state: AppState) {
     const utbetalingerFilter = state.utbetalinger.filter;
     const startDato = getFraDateFromFilter(utbetalingerFilter);
     const sluttDato = getTilDateFromFilter(utbetalingerFilter);
-    const fra = moment(startDato).format('YYYY-MM-DD');
-    const til = moment(sluttDato).format('YYYY-MM-DD');
+    const fra = dayjs(startDato).format('YYYY-MM-DD');
+    const til = dayjs(sluttDato).format('YYYY-MM-DD');
 
     return `${apiBaseUri}/utbetaling/${fodselsnummer}?startDato=${fra}&sluttDato=${til}`;
 }

--- a/src/redux/restReducers/utbetalingerOversikt.ts
+++ b/src/redux/restReducers/utbetalingerOversikt.ts
@@ -3,15 +3,15 @@ import { apiBaseUri } from '../../api/config';
 import { createRestResourceReducerAndActions } from '../../rest/utils/restResource';
 import { AppState } from '../reducers';
 import { getUtbetalingerForSiste30DagerDatoer } from '../../app/personside/infotabs/utbetalinger/utils/utbetalinger-utils';
-import moment from 'moment';
+import dayjs from 'dayjs';
 import { backendDatoformat } from '../../utils/date-utils';
 
 function getUtbetalingerFetchUri(state: AppState) {
     const fodselsnummer = state.gjeldendeBruker.fødselsnummer;
 
     const datoer = getUtbetalingerForSiste30DagerDatoer();
-    const fra = moment(datoer.fra).format(backendDatoformat);
-    const til = moment(datoer.til).format(backendDatoformat);
+    const fra = dayjs(datoer.fra).format(backendDatoformat);
+    const til = dayjs(datoer.til).format(backendDatoformat);
 
     return `${apiBaseUri}/utbetaling/${fodselsnummer}?startDato=${fra}&sluttDato=${til}`;
 }

--- a/src/redux/session/plukkTemaCookie.ts
+++ b/src/redux/session/plukkTemaCookie.ts
@@ -1,5 +1,5 @@
 import * as Cookies from 'js-cookie';
-import moment from 'moment';
+import dayjs from 'dayjs';
 import { Temagruppe } from '../../models/temagrupper';
 
 const temaValgCookieNavn = 'plukk-tema';
@@ -9,7 +9,7 @@ export function getTemaFraCookie(): Temagruppe | undefined {
 }
 
 export function setTemaCookie(tema: Temagruppe) {
-    const omEnTime = moment()
+    const omEnTime = dayjs()
         .add(1, 'hour')
         .toDate();
     Cookies.set(temaValgCookieNavn, tema, { expires: omEnTime });

--- a/src/setupTests.ts
+++ b/src/setupTests.ts
@@ -3,6 +3,9 @@ import { configure } from 'enzyme';
 import EnzymeReactAdapter from 'enzyme-adapter-react-16';
 import * as EnzymeContainer from './test/enzyme-container';
 import MockDate from 'mockdate';
+import dayjs from 'dayjs';
+import 'dayjs/locale/nb';
+dayjs.locale('nb');
 import 'jest-enzyme';
 import 'jest-styled-components';
 

--- a/src/utils/date-utils.test.ts
+++ b/src/utils/date-utils.test.ts
@@ -10,7 +10,7 @@ import {
     erMaks10MinSiden,
     backendDatoformat
 } from './date-utils';
-import moment from 'moment';
+import dayjs from 'dayjs';
 
 Date.now = () => new Date().getTime(); // for å motvirke Date.now() mock i setupTests.ts
 
@@ -92,10 +92,10 @@ test('datoVerbose henter riktig dag, måned og år', () => {
 
 describe('getNewestDate', () => {
     it('git den nyeste datoen', () => {
-        const oldDate = moment()
+        const oldDate = dayjs()
             .subtract(1, 'year')
             .toDate();
-        const newDate = moment().toDate();
+        const newDate = dayjs().toDate();
 
         const result = getNewestDate(newDate, oldDate);
         const result2 = getNewestDate(oldDate, newDate);
@@ -105,10 +105,10 @@ describe('getNewestDate', () => {
     });
 
     it('aksepterer strings som argumenter', () => {
-        const oldDate = moment()
+        const oldDate = dayjs()
             .subtract(1, 'year')
             .format(backendDatoformat);
-        const newDate = moment().format(backendDatoformat);
+        const newDate = dayjs().format(backendDatoformat);
 
         const result = getNewestDate(newDate, oldDate);
 
@@ -118,10 +118,10 @@ describe('getNewestDate', () => {
 
 describe('getOldestDate', () => {
     it('git den eldste datoen', () => {
-        const oldDate = moment()
+        const oldDate = dayjs()
             .subtract(1, 'year')
             .toDate();
-        const newDate = moment().toDate();
+        const newDate = dayjs().toDate();
 
         const result = getOldestDate(newDate, oldDate);
         const result2 = getOldestDate(oldDate, newDate);
@@ -131,10 +131,10 @@ describe('getOldestDate', () => {
     });
 
     it('aksepterer strings og dates som argumenter', () => {
-        const oldDate = moment()
+        const oldDate = dayjs()
             .subtract(1, 'year')
             .format(backendDatoformat);
-        const newDate = moment().format(backendDatoformat);
+        const newDate = dayjs().format(backendDatoformat);
 
         const result = getOldestDate(newDate, oldDate);
 
@@ -144,10 +144,10 @@ describe('getOldestDate', () => {
 
 describe('erMaks10MinSiden', () => {
     it('sjekker om dato er mindre enn 10 min siden', () => {
-        const dateUnder10min = moment()
+        const dateUnder10min = dayjs()
             .subtract(5, 'minute')
             .toDate();
-        const dateOver10min = moment()
+        const dateOver10min = dayjs()
             .subtract(15, 'minute')
             .toDate();
 

--- a/src/utils/date-utils.ts
+++ b/src/utils/date-utils.ts
@@ -1,6 +1,10 @@
-import moment from 'moment';
-import 'moment/locale/nb';
+import dayjs from 'dayjs';
+import 'dayjs/locale/nb';
+import isSameOrBeforePlugin from 'dayjs/plugin/isSameOrBefore';
 import { loggError } from './logger/frontendLogger';
+
+dayjs.locale('nb');
+dayjs.extend(isSameOrBeforePlugin);
 
 export const backendDatoformat: string = 'YYYY-MM-DD';
 export const backendDatoTidformat: string = 'YYYY-MM-DD HH:mm';
@@ -11,23 +15,23 @@ const DATO_TID_FORMAT = 'DD.MM.YYYY HH:mm';
 const DATO_TID_MANEDSNANV_FORMAT = 'DD. MMM YYYY HH:mm';
 
 export function formatterDato(dato: string | Date) {
-    return moment(dato).format(DATO_FORMAT);
+    return dayjs(dato).format(DATO_FORMAT);
 }
 
 export function formatterDatoMedMaanedsnavn(dato: string | Date) {
-    return moment(dato).format(DATO_FORMAT_MANEDSNAVN);
+    return dayjs(dato).format(DATO_FORMAT_MANEDSNAVN);
 }
 
 export function formatterDatoTid(dato: string | Date) {
-    return moment(dato).format(DATO_TID_FORMAT);
+    return dayjs(dato).format(DATO_TID_FORMAT);
 }
 
 export function formatterDatoTidMedMaanedsnavn(dato?: string | Date) {
-    return moment(dato).format(DATO_TID_MANEDSNANV_FORMAT);
+    return dayjs(dato).format(DATO_TID_MANEDSNANV_FORMAT);
 }
 
 export function formatterDatoTidNaa() {
-    return moment().format(DATO_TID_FORMAT);
+    return dayjs().format(DATO_TID_FORMAT);
 }
 
 const månedTilNavnMapping = (månednr: number) => {
@@ -62,11 +66,11 @@ const månedTilNavnMapping = (månednr: number) => {
 };
 
 export function datoVerbose(dato?: string | Date) {
-    const datoMoment = dato ? moment(dato) : moment();
-    const måned = månedTilNavnMapping(datoMoment.month());
-    const år = datoMoment.year();
-    const dag = datoMoment.date();
-    const klokkeslett = datoMoment.format('HH:mm');
+    const parsedDato = dato ? dayjs(dato) : dayjs();
+    const måned = månedTilNavnMapping(parsedDato.month());
+    const år = parsedDato.year();
+    const dag = parsedDato.date();
+    const klokkeslett = parsedDato.format('HH:mm');
     return {
         dag: dag,
         måned: måned,
@@ -78,29 +82,29 @@ export function datoVerbose(dato?: string | Date) {
 }
 
 export function erImorgenEllerSenere(date: Date) {
-    return moment(date).isAfter(new Date(), 'day');
+    return dayjs(date).isAfter(new Date(), 'day');
 }
 
 export function erMaks10MinSiden(date: string | Date) {
-    return moment(date).isAfter(moment().subtract(10, 'minute'));
+    return dayjs(date).isAfter(dayjs().subtract(10, 'minute'));
 }
 
 export function erMaksEttÅrFramITid(date: Date) {
-    const ettÅrFramITid = moment().add(1, 'years');
-    return moment(date).isSameOrBefore(ettÅrFramITid);
+    const ettÅrFramITid = dayjs().add(1, 'years');
+    return dayjs(date).isSameOrBefore(ettÅrFramITid);
 }
 
 export function getOldestDate<T extends string | Date>(date1: T, date2: T): T {
-    return moment(date1).isBefore(date2) ? date1 : date2;
+    return dayjs(date1).isBefore(date2) ? date1 : date2;
 }
 
 export function getNewestDate<T extends string | Date>(date1: T, date2: T): T {
-    return moment(date1).isAfter(date2) ? date1 : date2;
+    return dayjs(date1).isAfter(date2) ? date1 : date2;
 }
 
 export function ascendingDateComparator(a: Date | string, b: Date | string) {
-    const dateA = moment(a);
-    const dateB = moment(b);
+    const dateA = dayjs(a);
+    const dateB = dayjs(b);
     if (!dateA.isValid() || !dateB.isValid()) {
         loggError(Error('Invalid date in date comparator'), undefined, { datoA: a, datoB: b });
     }

--- a/src/utils/string-utils.ts
+++ b/src/utils/string-utils.ts
@@ -1,5 +1,5 @@
 import { formaterNOK } from '../app/personside/infotabs/utbetalinger/utils/utbetalinger-utils';
-import moment from 'moment';
+import dayjs from 'dayjs';
 import { Periode } from '../models/tid';
 
 export const ENDASH = '\u2013';
@@ -69,7 +69,7 @@ export function formatNumber(format: string, streng: string) {
 }
 
 export function formaterDato(rawDate: string | Date): string {
-    return moment(rawDate).format('DD.MM.YYYY');
+    return dayjs(rawDate).format('DD.MM.YYYY');
 }
 
 export function datoEllerNull(dato: string | Date | null): string | null {
@@ -94,7 +94,7 @@ export function periodeEllerNull(periode: Periode | null): string | null {
 }
 
 export function formaterTilISO8601Date(date: Date) {
-    return moment(date).format('YYYY-MM-DD');
+    return dayjs(date).format('YYYY-MM-DD');
 }
 
 export function capitalizeName(name: string): string {


### PR DESCRIPTION
Kan tittes på etter https://github.com/navikt/modiapersonoversikt/pull/1491

moment er deprecated som bibliotek av flere grunner, og det er derfor greit å komme seg bort fra det.
En av grunnen er størrelsen på biblioteket, og denne endringen gir en besvarelse på 20KB gzipped, eller ca 60KB i raw js.
