### PR TITLE
[KAIZEN-0] skru på sessionAffinity

### DIFF
--- a/.nais/prod.yaml
+++ b/.nais/prod.yaml
@@ -29,6 +29,9 @@ spec:
       memory: 1024Mi
   ingresses:
     - https://app.adeo.no/modiapersonoversikt
+  sessionAffinity:
+    ClientIP:
+      timeoutSeconds: 300
   replicas:
     min: 2
     max: 4

--- a/.nais/qa-template.yaml
+++ b/.nais/qa-template.yaml
@@ -29,6 +29,9 @@ spec:
       memory: 1024Mi
   ingresses:
     - https://app-{{ namespace }}.adeo.no/modiapersonoversikt
+  sessionAffinity:
+    ClientIP:
+      timeoutSeconds: 300
   replicas:
     min: 2
     max: 4


### PR DESCRIPTION
gjør at brukere blir sendt til samme pod innenfor en periode (300s).

dette gjøres for å fikse en feil som er synlig ved deploy av appen når man har flere podder.

Eksempelvis:
* I prod: index.html peker mot main.abba1234.js
* Ny versjon: index.html peker mot main.acdc9876.js

Ved deploy først en pod bli erstattet, og man havner i en situasjon hvor
man har to forskjellige index.html filer i spill, og disse peker til forskjellige filer.

Ved deploy er det derfor viktig at index.html og påfølgende henting av js-filer går til samme pod.
Om pod 1 gir index.html og kallet for å hente ut js går til pod 2, så vil man få en 404 siden den nye js-filen ikke finnes på den gamle podden.

**Alternativ løsning**:
Dette har tidligere vært løst ved å sette faste navn på javascript/css filene vha https://github.com/navikt/craco-plugins
Men om dette fungerer greit så lar det oss beholde en enklere cache-busting strategy (endre filnavn), og vil derfor teste ut dette.