### PR TITLE
[KAIZEN-0] fix/safe deploy

### DIFF
--- a/.nais/prod.yaml
+++ b/.nais/prod.yaml
@@ -29,9 +29,6 @@ spec:
       memory: 1024Mi
   ingresses:
     - https://app.adeo.no/modiapersonoversikt
-  sessionAffinity:
-    ClientIP:
-      timeoutSeconds: 300
   replicas:
     min: 2
     max: 4

--- a/.nais/qa-template.yaml
+++ b/.nais/qa-template.yaml
@@ -29,9 +29,6 @@ spec:
       memory: 1024Mi
   ingresses:
     - https://app-{{ namespace }}.adeo.no/modiapersonoversikt
-  sessionAffinity:
-    ClientIP:
-      timeoutSeconds: 300
   replicas:
     min: 2
     max: 4

--- a/craco.config.js
+++ b/craco.config.js
@@ -1,5 +1,6 @@
 const { ESLINT_MODES } = require('@craco/craco');
 const CracoLessPlugin = require('craco-less');
+const { ChangeJsFilename, ChangeCssFilename } = require('@navikt/craco-plugins');
 
 const DisableAsciiOnly = {
     overrideWebpackConfig: ({ webpackConfig, context }) => {
@@ -14,6 +15,11 @@ module.exports = function({ env }) {
         eslint: {
             mode: ESLINT_MODES.file
         },
-        plugins: [{ plugin: DisableAsciiOnly }, { plugin: CracoLessPlugin }]
+        plugins: [
+            { plugin: DisableAsciiOnly },
+            { plugin: CracoLessPlugin },
+            { plugin: ChangeCssFilename },
+            { plugin: ChangeJsFilename }
+        ]
     };
 };

--- a/package-lock.json
+++ b/package-lock.json
@@ -1845,6 +1845,122 @@
                 }
             }
         },
+        "@navikt/craco-plugins": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/@navikt/craco-plugins/-/craco-plugins-2.0.0.tgz",
+            "integrity": "sha512-8kzpA6HYa1j0G44IkdAv+nnSP29FjxOpdGmK/8pFkNJ1T76ql2Oj28+Q9ueO1vMkOkQWNS9zmpZYsfzbIi47Kg==",
+            "dev": true,
+            "requires": {
+                "yargs": "^13.2.0"
+            },
+            "dependencies": {
+                "ansi-regex": {
+                    "version": "4.1.0",
+                    "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.0.tgz",
+                    "integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg==",
+                    "dev": true
+                },
+                "camelcase": {
+                    "version": "5.3.1",
+                    "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.3.1.tgz",
+                    "integrity": "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg==",
+                    "dev": true
+                },
+                "cliui": {
+                    "version": "5.0.0",
+                    "resolved": "https://registry.npmjs.org/cliui/-/cliui-5.0.0.tgz",
+                    "integrity": "sha512-PYeGSEmmHM6zvoef2w8TPzlrnNpXIjTipYK780YswmIP9vjxmd6Y2a3CB2Ks6/AU8NHjZugXvo8w3oWM2qnwXA==",
+                    "dev": true,
+                    "requires": {
+                        "string-width": "^3.1.0",
+                        "strip-ansi": "^5.2.0",
+                        "wrap-ansi": "^5.1.0"
+                    }
+                },
+                "find-up": {
+                    "version": "3.0.0",
+                    "resolved": "https://registry.npmjs.org/find-up/-/find-up-3.0.0.tgz",
+                    "integrity": "sha512-1yD6RmLI1XBfxugvORwlck6f75tYL+iR0jqwsOrOxMZyGYqUuDhJ0l4AXdO1iX/FTs9cBAMEk1gWSEx1kSbylg==",
+                    "dev": true,
+                    "requires": {
+                        "locate-path": "^3.0.0"
+                    }
+                },
+                "locate-path": {
+                    "version": "3.0.0",
+                    "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-3.0.0.tgz",
+                    "integrity": "sha512-7AO748wWnIhNqAuaty2ZWHkQHRSNfPVIsPIfwEOWO22AmaoVrWavlOcMR5nzTLNYvp36X220/maaRsrec1G65A==",
+                    "dev": true,
+                    "requires": {
+                        "p-locate": "^3.0.0",
+                        "path-exists": "^3.0.0"
+                    }
+                },
+                "p-locate": {
+                    "version": "3.0.0",
+                    "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-3.0.0.tgz",
+                    "integrity": "sha512-x+12w/To+4GFfgJhBEpiDcLozRJGegY+Ei7/z0tSLkMmxGZNybVMSfWj9aJn8Z5Fc7dBUNJOOVgPv2H7IwulSQ==",
+                    "dev": true,
+                    "requires": {
+                        "p-limit": "^2.0.0"
+                    }
+                },
+                "path-exists": {
+                    "version": "3.0.0",
+                    "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-3.0.0.tgz",
+                    "integrity": "sha1-zg6+ql94yxiSXqfYENe1mwEP1RU=",
+                    "dev": true
+                },
+                "strip-ansi": {
+                    "version": "5.2.0",
+                    "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
+                    "integrity": "sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==",
+                    "dev": true,
+                    "requires": {
+                        "ansi-regex": "^4.1.0"
+                    }
+                },
+                "wrap-ansi": {
+                    "version": "5.1.0",
+                    "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-5.1.0.tgz",
+                    "integrity": "sha512-QC1/iN/2/RPVJ5jYK8BGttj5z83LmSKmvbvrXPNCLZSEb32KKVDJDl/MOt2N01qU2H/FkzEa9PKto1BqDjtd7Q==",
+                    "dev": true,
+                    "requires": {
+                        "ansi-styles": "^3.2.0",
+                        "string-width": "^3.0.0",
+                        "strip-ansi": "^5.0.0"
+                    }
+                },
+                "yargs": {
+                    "version": "13.3.2",
+                    "resolved": "https://registry.npmjs.org/yargs/-/yargs-13.3.2.tgz",
+                    "integrity": "sha512-AX3Zw5iPruN5ie6xGRIDgqkT+ZhnRlZMLMHAs8tg7nRruy2Nb+i5o9bwghAogtM08q1dpr2LVoS8KSTMYpWXUw==",
+                    "dev": true,
+                    "requires": {
+                        "cliui": "^5.0.0",
+                        "find-up": "^3.0.0",
+                        "get-caller-file": "^2.0.1",
+                        "require-directory": "^2.1.1",
+                        "require-main-filename": "^2.0.0",
+                        "set-blocking": "^2.0.0",
+                        "string-width": "^3.0.0",
+                        "which-module": "^2.0.0",
+                        "y18n": "^4.0.0",
+                        "yargs-parser": "^13.1.2"
+                    }
+                },
+                "yargs-parser": {
+                    "version": "13.1.2",
+                    "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-13.1.2.tgz",
+                    "integrity": "sha512-3lbsNRf/j+A4QuSZfDRA7HRSfWrzO0YjqTJd5kjAq37Zep1CEgaYmrH9Q3GwPiB9cHyd1Y1UwggGhJGoxipbzg==",
+                    "dev": true,
+                    "requires": {
+                        "camelcase": "^5.0.0",
+                        "decamelize": "^1.2.0"
+                    }
+                }
+            }
+        },
         "@navikt/fnrvalidator": {
             "version": "1.1.3",
             "resolved": "https://registry.npmjs.org/@navikt/fnrvalidator/-/fnrvalidator-1.1.3.tgz",
@@ -3716,9 +3832,9 @@
             },
             "dependencies": {
                 "core-js": {
-                    "version": "3.5.0",
-                    "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.5.0.tgz",
-                    "integrity": "sha512-Ifh3kj78gzQ7NAoJXeTu+XwzDld0QRIwjBLRqAMhuLhP3d2Av5wmgE9ycfnvK6NAEjTkQ1sDPeoEZAWO3Hx1Uw=="
+                    "version": "2.6.12",
+                    "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.6.12.tgz",
+                    "integrity": "sha512-Kb2wC0fvsWfQrgk8HU5lW6U/Lcs8+9aaYcy4ZFc6DDlo4nZ7n70dEgE5rtR0oG6ufKDUnrwfWL1mXR5ljDatrQ=="
                 },
                 "regenerator-runtime": {
                     "version": "0.11.1",
@@ -15089,9 +15205,9 @@
             },
             "dependencies": {
                 "core-js": {
-                    "version": "3.5.0",
-                    "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.5.0.tgz",
-                    "integrity": "sha512-Ifh3kj78gzQ7NAoJXeTu+XwzDld0QRIwjBLRqAMhuLhP3d2Av5wmgE9ycfnvK6NAEjTkQ1sDPeoEZAWO3Hx1Uw=="
+                    "version": "3.10.0",
+                    "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.10.0.tgz",
+                    "integrity": "sha512-MQx/7TLgmmDVamSyfE+O+5BHvG1aUGj/gHhLn1wVtm2B5u1eVIPvh7vkfjwWKNCjrTJB8+He99IntSQ1qP+vYQ=="
                 }
             }
         },

--- a/package.json
+++ b/package.json
@@ -104,6 +104,7 @@
     },
     "devDependencies": {
         "@craco/craco": "^5.6.4",
+        "@navikt/craco-plugins": "^2.0.0",
         "@testing-library/react-hooks": "^2.0.1",
         "@types/classnames": "^2.2.10",
         "@types/detect-browser": "^2.0.1",

--- a/src/app/Routing.tsx
+++ b/src/app/Routing.tsx
@@ -8,7 +8,9 @@ import Startbilde from './startbilde/Startbilde';
 import { useFodselsnummer, useTriggerHotjarForLokalKontor } from '../utils/customHooks';
 import { CenteredLazySpinner } from '../components/LazySpinner';
 
-const StandAloneKomponenter = lazy(() => import('../components/standalone/StandAloneKomponenter'));
+const StandAloneKomponenter = lazy(() =>
+    import(/* webpackChunkName: "standalonekomponenter" */ '../components/standalone/StandAloneKomponenter')
+);
 
 function Routing() {
     const fnr = useFodselsnummer();


### PR DESCRIPTION
* [KAIZEN-0] fjerne sessionAffinity c1ea182
  sessionAffinitiy så ikke ut til å være nok for å unngå at brukere ble sendt til feil pods under deploy.

  Vi så derfor fortsatt en del tilfeller av at folk fikk index.html som fallback når man ikke fant ulike javascript-filer.
  Siden html ikke er gyldig JS, så feiler parsing av dette og saksbehandler får en blank side.

  Dette har sannsynligvisvis vært ett problem i lengre tid, men vært skjult siden pus-fss-frontend gjør samme fallback men med en 404-status.
  Når dette skjer så blir ikke JS-filen forsøkt parset, og feilrapporteringen slår ikke inn. Men bruker får fortsatt en blank side.

* [KAIZEN-0] endre navn på filene som blir bygd av CRA 2b0cb17
tar ibruk @navikt/craco-plugins som har plugins for å skru av chunking i CRA.

  Før endringen laget vi følgende filer, hvor filnavnet endres basert på innholdet (hashcode);
  ```
  186.79 KB  build/static/js/2.624c2684.chunk.js
  145.17 KB  build/static/js/4.9687c729.chunk.js
  140.33 KB  build/static/js/main.892067c6.chunk.js
  87.81 KB   build/static/css/2.c1f5d3da.chunk.css
  72.63 KB   build/static/js/3.b0183e60.chunk.js
  6.71 KB    build/static/css/main.2254d707.chunk.css
  1.19 KB    build/static/js/runtime-main.05ae1c60.js
  ```

  Etter endringen vil følgende filer lages;
  ```
  333.54 KB  build/static/js/main.js
  217.54 KB  build/static/js/standalonekomponenter.chunk.js
  89.05 KB   build/static/css/main.css
  ```

  Dette sikrer at vi alltid får samme filnavn, så under deploy vil alle poddene ha de samme filene.
  Caching etter deploy er derimot ett mulig problemstilling, og må nå kontrolleres vha http-cache-headere.