### PR TITLE
[KAIZEN-0] bump formstate bibliotek

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2036,12 +2036,12 @@
             }
         },
         "@nutgaard/use-formstate": {
-            "version": "2.6.0",
-            "resolved": "https://registry.npmjs.org/@nutgaard/use-formstate/-/use-formstate-2.6.0.tgz",
-            "integrity": "sha512-+ssy/GOjmenbSgcLSipIo+5XKqrq8i/reM5vdXrOfpOKUp3iKewfUGNMcLuTdAdRzPeb0LbI4t+4WQglCQxypQ==",
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/@nutgaard/use-formstate/-/use-formstate-3.0.0.tgz",
+            "integrity": "sha512-ZrR3DiejF9rlWHNpqZ1yC/otZBF7Ft+B+4lAUiEqWZJKPTC9cecBxjxZpRnrF2B3SEGqz0YtGNgPcqceVb6Ksg==",
             "requires": {
-                "immer": "^3.1.3",
-                "use-immer": "^0.3.3"
+                "immer": "^9.0.1",
+                "use-immer": "^0.5.1"
             }
         },
         "@pmmmwh/react-refresh-webpack-plugin": {
@@ -8548,9 +8548,9 @@
             "optional": true
         },
         "immer": {
-            "version": "3.3.0",
-            "resolved": "https://registry.npmjs.org/immer/-/immer-3.3.0.tgz",
-            "integrity": "sha512-vlWRjnZqoTHuEjadquVHK3GxsXe1gNoATffLEA8Qbrdd++Xb+wHEFiWtwAKTscMBoi1AsvEMXhYRzAXA8Ex9FQ=="
+            "version": "9.0.1",
+            "resolved": "https://registry.npmjs.org/immer/-/immer-9.0.1.tgz",
+            "integrity": "sha512-7CCw1DSgr8kKYXTYOI1qMM/f5qxT5vIVMeGLDCDX8CSxsggr1Sjdoha4OhsP0AZ1UvWbyZlILHvLjaynuu02Mg=="
         },
         "import-cwd": {
             "version": "2.1.0",
@@ -18112,9 +18112,9 @@
             "integrity": "sha512-cwESVXlO3url9YWlFW/TA9cshCEhtu7IKJ/p5soJ/gGpj7vbvFrAY/eIioQ6Dw23KjZhYgiIo8HOs1nQ2vr/oQ=="
         },
         "use-immer": {
-            "version": "0.3.5",
-            "resolved": "https://registry.npmjs.org/use-immer/-/use-immer-0.3.5.tgz",
-            "integrity": "sha512-0CNaJ/CtnF8/OmM4NBG7R0rhWMMQtgXPmWbakv8CK5z8dXeMaBYValFDXpkjBnToknjKJZuEPcoUZYd0rnQL2Q=="
+            "version": "0.5.1",
+            "resolved": "https://registry.npmjs.org/use-immer/-/use-immer-0.5.1.tgz",
+            "integrity": "sha512-Orb7PokM+jiLQfA1oJ3B3P7Guq0c2IxUHHmBpLeEMnJiz4ZOMlj9mkqq6D7iXJsnurRX0EOB134annf3RjEWHw=="
         },
         "util": {
             "version": "0.11.1",

--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
         "@navikt/navspa": "^1.1.1",
         "@navikt/tag-input": "^1.1.0",
         "@nutgaard/use-fetch": "^2.3.1",
-        "@nutgaard/use-formstate": "^2.6.0",
+        "@nutgaard/use-formstate": "^3.0.0",
         "core-js": "3.5.0",
         "craco-less": "^1.17.0",
         "detect-browser": "^3.0.1",


### PR DESCRIPTION
biblioteket brukte veldig gammel versjon av `immer` biblioteket,
dette er nå oppdatert og fjerner med det sikkerhetsfeilen; https://github.com/advisories/GHSA-9qmh-276g-x5pj