### PR TITLE
[OPP-874] Vaske tekstfelter

### DIFF
--- a/src/app/personside/dialogpanel/fortsettDialog/FortsettDialog.tsx
+++ b/src/app/personside/dialogpanel/fortsettDialog/FortsettDialog.tsx
@@ -75,7 +75,11 @@ function FortsettDialog(props: Props) {
                 tekst={state.tekst}
                 navn={navn}
                 tekstMaksLengde={tekstMaksLengde}
-                updateTekst={tekst => updateState({ tekst: tekst })}
+                updateTekst={tekst =>
+                    updateState({
+                        tekst: tekst.replace(/[^a-zA-Z0-9,àèéæøåÆØÅÀÈÉ!?.*<>":;/(){}|+#$¢@=&%£\-\][\s]/g, '')
+                    })
+                }
                 feilmelding={
                     !FortsettDialogValidator.tekst(state) && state.visFeilmeldinger
                         ? `Du må skrive en tekst på mellom 1 og ${tekstMaksLengde} tegn`

--- a/src/app/personside/dialogpanel/fortsettDialog/FortsettDialog.tsx
+++ b/src/app/personside/dialogpanel/fortsettDialog/FortsettDialog.tsx
@@ -77,7 +77,7 @@ function FortsettDialog(props: Props) {
                 tekstMaksLengde={tekstMaksLengde}
                 updateTekst={tekst =>
                     updateState({
-                        tekst: tekst.replace(/[^a-zA-Z0-9,àèéæøåÆØÅÀÈÉ!?.*<>":;/(){}|+#$¢@=&%£\-\][\s]/g, '')
+                        tekst: tekst.replace(/[^a-zA-Z0-9À-ž!?.*<>":;/(){}|+#$¢@=&%£\-\][\s]/g, '')
                     })
                 }
                 feilmelding={

--- a/src/app/personside/dialogpanel/sendMelding/SendNyMelding.tsx
+++ b/src/app/personside/dialogpanel/sendMelding/SendNyMelding.tsx
@@ -108,7 +108,11 @@ function SendNyMelding(props: Props) {
                         tekst={state.tekst}
                         navn={navn}
                         tekstMaksLengde={tekstMaksLengde}
-                        updateTekst={tekst => updateState({ tekst })}
+                        updateTekst={tekst =>
+                            updateState({
+                                tekst: tekst.replace(/[^a-zA-Z0-9,æøåÆØÅ!?.*<>":;/(){}|+#$¢=&%£\-\[\]\s]/g, '')
+                            })
+                        }
                         feilmelding={
                             !NyMeldingValidator.tekst(state) && state.visFeilmeldinger
                                 ? `Du må skrive en tekst på mellom 1 og ${tekstMaksLengde} tegn`

--- a/src/app/personside/dialogpanel/sendMelding/SendNyMelding.tsx
+++ b/src/app/personside/dialogpanel/sendMelding/SendNyMelding.tsx
@@ -110,7 +110,7 @@ function SendNyMelding(props: Props) {
                         tekstMaksLengde={tekstMaksLengde}
                         updateTekst={tekst =>
                             updateState({
-                                tekst: tekst.replace(/[^a-zA-Z0-9,æøåÆØÅ!?.*<>":;/(){}|+#$¢=&%£\-[]\s]/g, '')
+                                tekst: tekst.replace(/[^a-zA-Z0-9,àèéæøåÆØÅÀÈÉ!?.*<>":;/(){}|+#$¢@=&%£\-\][\s]/g, '')
                             })
                         }
                         feilmelding={

--- a/src/app/personside/dialogpanel/sendMelding/SendNyMelding.tsx
+++ b/src/app/personside/dialogpanel/sendMelding/SendNyMelding.tsx
@@ -110,7 +110,7 @@ function SendNyMelding(props: Props) {
                         tekstMaksLengde={tekstMaksLengde}
                         updateTekst={tekst =>
                             updateState({
-                                tekst: tekst.replace(/[^a-zA-Z0-9,æøåÆØÅ!?.*<>":;/(){}|+#$¢=&%£\-\[\]\s]/g, '')
+                                tekst: tekst.replace(/[^a-zA-Z0-9,æøåÆØÅ!?.*<>":;/(){}|+#$¢=&%£\-[]\s]/g, '')
                             })
                         }
                         feilmelding={

--- a/src/app/personside/dialogpanel/sendMelding/SendNyMelding.tsx
+++ b/src/app/personside/dialogpanel/sendMelding/SendNyMelding.tsx
@@ -110,7 +110,7 @@ function SendNyMelding(props: Props) {
                         tekstMaksLengde={tekstMaksLengde}
                         updateTekst={tekst =>
                             updateState({
-                                tekst: tekst.replace(/[^a-zA-Z0-9,àèéæøåÆØÅÀÈÉ!?.*<>":;/(){}|+#$¢@=&%£\-\][\s]/g, '')
+                                tekst: tekst.replace(/[^a-zA-Z0-9À-ž!?.*<>":;/(){}|+#$¢@=&%£\-\][\s]/g, '')
                             })
                         }
                         feilmelding={


### PR DESCRIPTION
Bruker en regex replace til å vaske vekk ugyldige tegn når man klipper og limer inn tekst fra et tekstbehandlingsprogram inn i `Send ny Melding`.

Sånn så det ut før
![image](https://user-images.githubusercontent.com/33753494/115861871-a7c62480-a433-11eb-8e36-ab66a5489fea.png)


Slik ser ut nå etter at vi la en regex replace på tekst
![image](https://user-images.githubusercontent.com/33753494/116073463-bb21fb80-a690-11eb-9d35-210e0133faae.png)