### PR TITLE
[OPP-648] fjerner info om bor med bruker dersom person er død

### DIFF
--- a/src/app/personside/kontrollsporsmal/SporsmalExtractors.tsx
+++ b/src/app/personside/kontrollsporsmal/SporsmalExtractors.tsx
@@ -1,5 +1,5 @@
 import {
-    erDød,
+    erDod,
     Familierelasjon,
     getBarnUnder21,
     getNavn,
@@ -62,7 +62,7 @@ export function hentFødselsdatoBarn(person: Person): Svar {
     const gyldigeBarn = getBarnUnder21(person.familierelasjoner)
         .filter(barn => barn.harSammeBosted)
         .filter(barn => !barn.tilPerson.diskresjonskode)
-        .filter(barn => !erDød(barn.tilPerson.personstatus))
+        .filter(barn => !erDod(barn.tilPerson.personstatus))
         .filter(barn => !harDødsDato(barn));
 
     if (gyldigeBarn.length === 0) {

--- a/src/app/personside/visittkort/body/__snapshots__/VisittkortBody.test.tsx.snap
+++ b/src/app/personside/visittkort/body/__snapshots__/VisittkortBody.test.tsx.snap
@@ -879,9 +879,7 @@ exports[`viser info om bruker i visittkortbody 1`] = `
         </p>
         <p
           className="typo-normal"
-        >
-          Bor med bruker
-        </p>
+        />
       </div>
       <div
         className="c4"
@@ -940,9 +938,7 @@ exports[`viser info om bruker i visittkortbody 1`] = `
         </p>
         <p
           className="typo-normal"
-        >
-          Bor ikke med bruker
-        </p>
+        />
       </div>
     </section>
     <section>

--- a/src/app/personside/visittkort/body/__snapshots__/VisittkortBody.test.tsx.snap
+++ b/src/app/personside/visittkort/body/__snapshots__/VisittkortBody.test.tsx.snap
@@ -879,7 +879,9 @@ exports[`viser info om bruker i visittkortbody 1`] = `
         </p>
         <p
           className="typo-normal"
-        />
+        >
+          Bor med bruker
+        </p>
       </div>
       <div
         className="c4"
@@ -938,7 +940,9 @@ exports[`viser info om bruker i visittkortbody 1`] = `
         </p>
         <p
           className="typo-normal"
-        />
+        >
+          Bor ikke med bruker
+        </p>
       </div>
     </section>
     <section>

--- a/src/app/personside/visittkort/body/familie/Foreldre.tsx
+++ b/src/app/personside/visittkort/body/familie/Foreldre.tsx
@@ -3,7 +3,7 @@ import { Normaltekst } from 'nav-frontend-typografi';
 
 import VisittkortElement from '../VisittkortElement';
 
-import { Familierelasjon, getMorOgFar, Relasjonstype } from '../../../../../models/person/person';
+import { erDød, Familierelasjon, getMorOgFar, Relasjonstype } from '../../../../../models/person/person';
 import BorMedBruker from '../../../../../components/person/HarSammeBosted';
 import NavnOgAlder from '../../../../../components/person/NavnOgAlder';
 
@@ -21,6 +21,7 @@ interface ForelderProps {
 function Forelder({ relasjon }: ForelderProps) {
     const beskrivelse = relasjon.rolle === Relasjonstype.Mor ? 'Mor' : 'Far';
     const ikon = getKjønnIkon(relasjon.tilPerson.fødselsnummer);
+    const erDod = erDød(relasjon.tilPerson.personstatus);
     return (
         <VisittkortElement beskrivelse={beskrivelse} ikon={ikon}>
             <Diskresjonskode diskresjonskode={relasjon.tilPerson.diskresjonskode} />
@@ -29,7 +30,7 @@ function Forelder({ relasjon }: ForelderProps) {
             </Normaltekst>
             <Normaltekst>{relasjon.tilPerson.fødselsnummer || ''}</Normaltekst>
             <Normaltekst>
-                <BorMedBruker harSammeBosted={relasjon.harSammeBosted} />
+                <BorMedBruker harSammeBosted={relasjon.harSammeBosted} erDod={erDod} />
             </Normaltekst>
         </VisittkortElement>
     );

--- a/src/app/personside/visittkort/body/familie/Foreldre.tsx
+++ b/src/app/personside/visittkort/body/familie/Foreldre.tsx
@@ -3,7 +3,7 @@ import { Normaltekst } from 'nav-frontend-typografi';
 
 import VisittkortElement from '../VisittkortElement';
 
-import { erDød, Familierelasjon, getMorOgFar, Relasjonstype } from '../../../../../models/person/person';
+import { Familierelasjon, getMorOgFar, Relasjonstype } from '../../../../../models/person/person';
 import BorMedBruker from '../../../../../components/person/HarSammeBosted';
 import NavnOgAlder from '../../../../../components/person/NavnOgAlder';
 
@@ -21,7 +21,6 @@ interface ForelderProps {
 function Forelder({ relasjon }: ForelderProps) {
     const beskrivelse = relasjon.rolle === Relasjonstype.Mor ? 'Mor' : 'Far';
     const ikon = getKjønnIkon(relasjon.tilPerson.fødselsnummer);
-    const erDod = erDød(relasjon.tilPerson.personstatus);
     return (
         <VisittkortElement beskrivelse={beskrivelse} ikon={ikon}>
             <Diskresjonskode diskresjonskode={relasjon.tilPerson.diskresjonskode} />
@@ -30,7 +29,7 @@ function Forelder({ relasjon }: ForelderProps) {
             </Normaltekst>
             <Normaltekst>{relasjon.tilPerson.fødselsnummer || ''}</Normaltekst>
             <Normaltekst>
-                <BorMedBruker harSammeBosted={relasjon.harSammeBosted} erDod={erDod} />
+                <BorMedBruker relasjon={relasjon} />
             </Normaltekst>
         </VisittkortElement>
     );

--- a/src/app/personside/visittkort/body/familie/ListeAvBarn.tsx
+++ b/src/app/personside/visittkort/body/familie/ListeAvBarn.tsx
@@ -2,7 +2,7 @@ import * as React from 'react';
 
 import VisittkortElement from '../VisittkortElement';
 import { Normaltekst } from 'nav-frontend-typografi';
-import { erDød, Familierelasjon, getBarnUnder21 } from '../../../../../models/person/person';
+import { Familierelasjon, getBarnUnder21 } from '../../../../../models/person/person';
 import NavnOgAlder from '../../../../../components/person/NavnOgAlder';
 import BorMedBruker from '../../../../../components/person/HarSammeBosted';
 import { Diskresjonskode } from './common/Diskresjonskode';
@@ -19,7 +19,6 @@ interface BarnProps {
 function Barn({ barn }: BarnProps) {
     const ikon = getKjønnBarnIkon(barn.tilPerson.fødselsnummer);
     const beskrivelse = getKjønnBeskrivelseForBarn(barn.tilPerson.fødselsnummer);
-    const erDod = erDød(barn.tilPerson.personstatus);
     return (
         <VisittkortElement beskrivelse={beskrivelse} ikon={ikon}>
             <Diskresjonskode diskresjonskode={barn.tilPerson.diskresjonskode} />
@@ -28,7 +27,7 @@ function Barn({ barn }: BarnProps) {
             </Normaltekst>
             <Normaltekst>{barn.tilPerson.fødselsnummer || ''}</Normaltekst>
             <Normaltekst>
-                <BorMedBruker harSammeBosted={barn.harSammeBosted} erDod={erDod} />
+                <BorMedBruker relasjon={barn} />
             </Normaltekst>
         </VisittkortElement>
     );

--- a/src/app/personside/visittkort/body/familie/ListeAvBarn.tsx
+++ b/src/app/personside/visittkort/body/familie/ListeAvBarn.tsx
@@ -2,7 +2,7 @@ import * as React from 'react';
 
 import VisittkortElement from '../VisittkortElement';
 import { Normaltekst } from 'nav-frontend-typografi';
-import { Familierelasjon, getBarnUnder21 } from '../../../../../models/person/person';
+import { erDød, Familierelasjon, getBarnUnder21 } from '../../../../../models/person/person';
 import NavnOgAlder from '../../../../../components/person/NavnOgAlder';
 import BorMedBruker from '../../../../../components/person/HarSammeBosted';
 import { Diskresjonskode } from './common/Diskresjonskode';
@@ -19,6 +19,7 @@ interface BarnProps {
 function Barn({ barn }: BarnProps) {
     const ikon = getKjønnBarnIkon(barn.tilPerson.fødselsnummer);
     const beskrivelse = getKjønnBeskrivelseForBarn(barn.tilPerson.fødselsnummer);
+    const erDod = erDød(barn.tilPerson.personstatus);
     return (
         <VisittkortElement beskrivelse={beskrivelse} ikon={ikon}>
             <Diskresjonskode diskresjonskode={barn.tilPerson.diskresjonskode} />
@@ -27,7 +28,7 @@ function Barn({ barn }: BarnProps) {
             </Normaltekst>
             <Normaltekst>{barn.tilPerson.fødselsnummer || ''}</Normaltekst>
             <Normaltekst>
-                <BorMedBruker harSammeBosted={barn.harSammeBosted} />
+                <BorMedBruker harSammeBosted={barn.harSammeBosted} erDod={erDod} />
             </Normaltekst>
         </VisittkortElement>
     );

--- a/src/app/personside/visittkort/body/familie/Sivilstand.tsx
+++ b/src/app/personside/visittkort/body/familie/Sivilstand.tsx
@@ -3,7 +3,6 @@ import dayjs from 'dayjs';
 import { Normaltekst } from 'nav-frontend-typografi';
 import VisittkortElement from '../VisittkortElement';
 import {
-    erDød,
     Familierelasjon,
     getPartner,
     Person,
@@ -43,7 +42,6 @@ function Sivilstand(props: { sivilstand: SivilstandInterface }) {
 }
 
 function Partner({ relasjon, sivilstand }: PartnerProps) {
-    const erDod = erDød(relasjon.tilPerson.personstatus);
     return (
         <>
             <Normaltekst>
@@ -55,7 +53,7 @@ function Partner({ relasjon, sivilstand }: PartnerProps) {
             </Normaltekst>
             <Normaltekst>{relasjon.tilPerson.fødselsnummer || ''}</Normaltekst>
             <Normaltekst>
-                <BorMedBruker harSammeBosted={relasjon.harSammeBosted} skalVise={!erDod} />
+                <BorMedBruker relasjon={relasjon} />
             </Normaltekst>
         </>
     );

--- a/src/app/personside/visittkort/body/familie/Sivilstand.tsx
+++ b/src/app/personside/visittkort/body/familie/Sivilstand.tsx
@@ -3,6 +3,7 @@ import dayjs from 'dayjs';
 import { Normaltekst } from 'nav-frontend-typografi';
 import VisittkortElement from '../VisittkortElement';
 import {
+    erDød,
     Familierelasjon,
     getPartner,
     Person,
@@ -42,6 +43,7 @@ function Sivilstand(props: { sivilstand: SivilstandInterface }) {
 }
 
 function Partner({ relasjon, sivilstand }: PartnerProps) {
+    const erDod = erDød(relasjon.tilPerson.personstatus);
     return (
         <>
             <Normaltekst>
@@ -53,7 +55,7 @@ function Partner({ relasjon, sivilstand }: PartnerProps) {
             </Normaltekst>
             <Normaltekst>{relasjon.tilPerson.fødselsnummer || ''}</Normaltekst>
             <Normaltekst>
-                <BorMedBruker harSammeBosted={relasjon.harSammeBosted} />
+                <BorMedBruker harSammeBosted={relasjon.harSammeBosted} skalVise={!erDod} />
             </Normaltekst>
         </>
     );

--- a/src/app/personside/visittkort/header/VisittkortHeader.tsx
+++ b/src/app/personside/visittkort/header/VisittkortHeader.tsx
@@ -3,7 +3,7 @@ import { useRef } from 'react';
 import styled from 'styled-components/macro';
 import { Undertittel } from 'nav-frontend-typografi';
 import NavKontorContainer from './navkontor/NavKontorContainer';
-import { erDød, erMann, Person } from '../../../../models/person/person';
+import { erDod, erMann, Person } from '../../../../models/person/person';
 import PersonStatus from './status/PersonStatus';
 import Mann from '../../../../svg/Mann.js';
 import Kvinne from '../../../../svg/Kvinne.js';
@@ -105,7 +105,7 @@ function VisittkortHeader(props: Props) {
         ikon: erMann(props.person) ? <Mann /> : <Kvinne />
     };
 
-    const alder = erDød(props.person.personstatus) ? 'Død' : props.person.alder;
+    const alder = erDod(props.person.personstatus) ? 'Død' : props.person.alder;
     const kjønn = props.person.kjønn === 'M' ? 'Mann' : 'Kvinne';
     return (
         <VisittkortHeaderDiv role="region" aria-label="Visittkort-hode" onClick={toggleVisittkort}>

--- a/src/components/person/HarSammeBosted.tsx
+++ b/src/components/person/HarSammeBosted.tsx
@@ -2,10 +2,11 @@ import * as React from 'react';
 
 interface Props {
     harSammeBosted?: boolean;
+    skalVise?: boolean | string;
 }
 
-function BorMedBruker({ harSammeBosted }: Props) {
-    if (harSammeBosted === undefined) {
+function BorMedBruker({ harSammeBosted, skalVise }: Props) {
+    if (harSammeBosted === undefined || !skalVise) {
         return null;
     } else if (harSammeBosted) {
         return <>Bor med bruker</>;

--- a/src/components/person/HarSammeBosted.tsx
+++ b/src/components/person/HarSammeBosted.tsx
@@ -1,14 +1,15 @@
 import * as React from 'react';
+import { erDod, Familierelasjon } from '../../models/person/person';
 
 interface Props {
-    harSammeBosted?: boolean;
-    skalVise?: boolean | string;
+    relasjon?: Familierelasjon;
 }
 
-function BorMedBruker({ harSammeBosted, skalVise }: Props) {
-    if (harSammeBosted === undefined || !skalVise) {
+function BorMedBruker({ relasjon }: Props) {
+    const personErDod = relasjon && erDod(relasjon.tilPerson.personstatus);
+    if (relasjon?.harSammeBosted === undefined || personErDod) {
         return null;
-    } else if (harSammeBosted) {
+    } else if (relasjon.harSammeBosted) {
         return <>Bor med bruker</>;
     } else {
         return <>Bor ikke med bruker</>;

--- a/src/components/person/NavnOgAlder.tsx
+++ b/src/components/person/NavnOgAlder.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { erDød, Familierelasjon, getNavn } from '../../models/person/person';
+import { erDod, Familierelasjon, getNavn } from '../../models/person/person';
 
 interface Props {
     relasjon: Familierelasjon;
@@ -16,7 +16,7 @@ function getAlder(relasjon: Familierelasjon) {
 }
 
 function getAlderTekst(relasjon: Familierelasjon) {
-    if (erDød(relasjon.tilPerson.personstatus)) {
+    if (erDod(relasjon.tilPerson.personstatus)) {
         return '(Død)';
     }
 

--- a/src/mock/person/personMock.ts
+++ b/src/mock/person/personMock.ts
@@ -92,7 +92,7 @@ export function getBedriftsNavn(id: string): string {
 export function getPersonstatus(alder: number): Bostatus {
     const bostatus = getBostatus();
     const dødsdato =
-        bostatus && bostatus.kodeRef === BostatusTyper.Død ? dayjs(faker.date.past(alder)).toISOString() : undefined;
+        bostatus && bostatus.kodeRef === BostatusTyper.Dod ? dayjs(faker.date.past(alder)).toISOString() : undefined;
     return {
         bostatus,
         dødsdato
@@ -101,7 +101,7 @@ export function getPersonstatus(alder: number): Bostatus {
 
 function getBostatus() {
     if (vektetSjanse(faker, 0.1)) {
-        return { kodeRef: BostatusTyper.Død, beskrivelse: 'Død' };
+        return { kodeRef: BostatusTyper.Dod, beskrivelse: 'Død' };
     } else if (vektetSjanse(faker, 0.1)) {
         return { kodeRef: BostatusTyper.Utvandret, beskrivelse: 'Utvandret' };
     } else {

--- a/src/models/person/person.ts
+++ b/src/models/person/person.ts
@@ -81,7 +81,7 @@ export interface Bostatus {
 }
 
 export enum BostatusTyper {
-    Død = 'DØD',
+    Dod = 'DØD',
     Utvandret = 'UTVA'
 }
 
@@ -148,8 +148,8 @@ export function getNavn({ fornavn, mellomnavn, etternavn, sammensatt }: Navn) {
     return navn.join(' ');
 }
 
-export function erDød(personstatus: Bostatus) {
-    return personstatus.dødsdato || (personstatus.bostatus && personstatus.bostatus.kodeRef === BostatusTyper.Død);
+export function erDod(personstatus: Bostatus) {
+    return personstatus.dødsdato || (personstatus.bostatus && personstatus.bostatus.kodeRef === BostatusTyper.Dod);
 }
 
 export function getBarn(familierelasjoner: Familierelasjon[]) {


### PR DESCRIPTION
TPS sender med informasjon om avdød familiemedlem bor/ ikke bor med bruker. Dette er informasjon vi ikke trenger i Modia og bør filtreres bort,  slik at veileder ikke kommer i skade for å nevne dette for bruker.

