### PR TITLE
[KAIZEN-0] koble mvh-tekst til skrivestøtte

### DIFF
--- a/src/components/autocomplete-textarea/autocomplete-textarea.tsx
+++ b/src/components/autocomplete-textarea/autocomplete-textarea.tsx
@@ -296,16 +296,16 @@ const Style = styled.div`
     position: relative;
 `;
 
-function autoFullfør(autofullførData: AutofullforData, parsedText: string) {
+function autoFullfor(autofullforData: AutofullforData, parsedText: string) {
     const autofullforMap = byggAutofullforMap(
         Locale.nb_NO,
-        autofullførData.enhet,
-        autofullførData.person,
-        autofullførData.kontor,
-        autofullførData.saksbehandler
+        autofullforData.enhet,
+        autofullforData.person,
+        autofullforData.kontor,
+        autofullforData.saksbehandler
     );
-    const fullfortTekst = autofullfor(parsedText, autofullforMap);
-    return fullfortTekst;
+
+    return autofullfor(parsedText, autofullforMap);
 }
 
 const tellerTekstCls = (remaining: number) => classNames('teller-tekst', { 'teller-tekst--overflow': remaining < 0 });
@@ -329,7 +329,7 @@ function asChangeEvent<T>(event: React.KeyboardEvent<T>): React.ChangeEvent<T> {
 }
 
 function AutocompleteTextarea(props: TextareaProps) {
-    const autofullførData = useAutoFullforData();
+    const autofullforData = useAutoFullforData();
     const [feilmelding, settFeilmelding] = useState<string>();
     const standardtekster: FetchResult<StandardTeksterModels.Tekster> = useFetch<StandardTeksterModels.Tekster>(
         '/modiapersonoversikt-skrivestotte/skrivestotte'
@@ -383,7 +383,7 @@ function AutocompleteTextarea(props: TextareaProps) {
                         return acc;
                     }, word);
 
-                    const fullfortTekst = autofullførData ? autoFullfør(autofullførData, replacement) : replacement;
+                    const fullfortTekst = autofullforData ? autoFullfor(autofullforData, replacement) : replacement;
 
                     event.currentTarget.value = [value.substring(0, start), fullfortTekst, value.substring(end)].join(
                         ''
@@ -395,7 +395,7 @@ function AutocompleteTextarea(props: TextareaProps) {
                 }
             }
         },
-        [autofullførData, onChange, rules, standardtekster]
+        [autofullforData, onChange, rules, standardtekster]
     );
 
     return (

--- a/src/components/autocomplete-textarea/autocomplete-textarea.tsx
+++ b/src/components/autocomplete-textarea/autocomplete-textarea.tsx
@@ -20,9 +20,6 @@ import { loggEvent } from '../../utils/logger/frontendLogger';
 import { useErKontaktsenter } from '../../utils/enheter-utils';
 import useFetch, { FetchResult, hasData } from '@nutgaard/use-fetch';
 import { rapporterBruk } from '../../app/personside/dialogpanel/sendMelding/standardTekster/sokUtils';
-import { useAppState } from '../../utils/customHooks';
-import { selectValgtEnhet } from '../../redux/session/session';
-import { useRestResource } from '../../rest/consumer/useRestResource';
 
 interface InlineRegel {
     type: 'internal';
@@ -43,31 +40,20 @@ type Regler = Array<Regel>;
 
 function useRules(): Regler {
     const erKontaktsenter = useErKontaktsenter();
-    const veiledersEnheter = useRestResource(resources => resources.saksbehandlersEnheter);
-    const valgtEnhetId = useAppState(selectValgtEnhet);
-    const valgtEnhet = veiledersEnheter.data?.enhetliste?.find(enhet => enhet.enhetId === valgtEnhetId);
-    const saksbehanderEnhet = valgtEnhet?.navn ?? '';
+
+    const nksSignaturReferanse = 'fd71ff08-be9c-4e90-a6f8-bc17a798f244';
+    const navKontorSignaturReferanse = 'b4b67323-f57d-47a2-ac19-7ba4b62fe156';
+    const signaturReferanse = erKontaktsenter ? nksSignaturReferanse : navKontorSignaturReferanse;
     return [
         { type: 'internal', regex: /^hei,?$/i, replacement: () => 'Hei [bruker.fornavn],\n' },
-        {
-            type: 'internal',
-            regex: /^mvh$/i,
-            replacement: () => {
-                const mvh = 'Med vennlig hilsen';
-                if (erKontaktsenter) {
-                    return `${mvh}\n[saksbehandler.fornavn]\nNAV Kontaktsenter`;
-                }
-                return `${mvh}\n[saksbehandler.navn]\n${saksbehanderEnhet}`;
-            }
-        },
-        {
-            type: 'internal',
-            regex: /^mvhks$/i,
-            replacement: () => {
-                return `Med vennlig hilsen\n[saksbehandler.fornavn]\nNAV Kontaktsenter`;
-            }
-        },
+        { type: 'internal', regex: /^hi,?$/i, replacement: () => 'Hi [bruker.fornavn], ' },
         { type: 'internal', regex: /^foet$/i, replacement: () => '[bruker.navn] ' },
+
+        { type: 'external', regex: /^mvh$/i, externalId: signaturReferanse },
+        { type: 'external', regex: /^mvhen$/i, externalId: signaturReferanse, locale: Locale.en_US },
+        { type: 'external', regex: /^mvhnn$/i, externalId: signaturReferanse, locale: Locale.nn_NO },
+        { type: 'external', regex: /^mvhks$/i, externalId: nksSignaturReferanse },
+
         {
             type: 'external',
             regex: /^vint$/i,
@@ -78,59 +64,6 @@ function useRules(): Regler {
             regex: /^vinten$/i,
             externalId: 'f31f5d09-4873-4f84-912d-0ff3636db1cd',
             locale: Locale.en_US
-        },
-        {
-            type: 'internal',
-            regex: /^aap$/i,
-            replacement: () => 'arbeidsavklaringspenger '
-        },
-        {
-            type: 'internal',
-            regex: /^sbt$/i,
-            replacement: () => 'saksbehandlingstid '
-        },
-        {
-            type: 'internal',
-            regex: /^nay$/i,
-            replacement: () => 'NAV Arbeid og ytelser '
-        },
-        {
-            type: 'internal',
-            regex: /^nfp$/i,
-            replacement: () => 'NAV Familie- og pensjonsytelser '
-        },
-        {
-            type: 'internal',
-            regex: /^aapen$/i,
-            replacement: () => 'work assessment allowance '
-        },
-        { type: 'internal', regex: /^hi,?$/i, replacement: () => 'Hi [bruker.fornavn], ' },
-        {
-            type: 'internal',
-            regex: /^mvhen$/i,
-            replacement: () => {
-                const bestregards = `Best regards`;
-                if (erKontaktsenter) {
-                    return `${bestregards}\n[saksbehandler.fornavn]\nNAV Call and Service Centre`;
-                }
-                return `${bestregards}\n[saksbehandler.navn]\n${saksbehanderEnhet}`;
-            }
-        },
-        {
-            type: 'internal',
-            regex: /^mvhnn$/i,
-            replacement: () => {
-                const mvh = 'Med vennleg helsing';
-                if (erKontaktsenter) {
-                    return `${mvh}\n[saksbehandler.fornavn]\nNAV Kontaktsenter`;
-                }
-                return `${mvh}\n[saksbehandler.navn]\n${saksbehanderEnhet}`;
-            }
-        },
-        {
-            type: 'internal',
-            regex: /^aapnn$/i,
-            replacement: () => 'arbeidsavklaringspengar '
         },
         {
             type: 'external',
@@ -167,6 +100,36 @@ function useRules(): Regler {
             type: 'external',
             regex: /^forskuddsøk$/i,
             externalId: '6c6a3604-d47a-4cb3-bd7b-a354e98de48c'
+        },
+        {
+            type: 'internal',
+            regex: /^aap$/i,
+            replacement: () => 'arbeidsavklaringspenger '
+        },
+        {
+            type: 'internal',
+            regex: /^aapen$/i,
+            replacement: () => 'work assessment allowance '
+        },
+        {
+            type: 'internal',
+            regex: /^aapnn$/i,
+            replacement: () => 'arbeidsavklaringspengar '
+        },
+        {
+            type: 'internal',
+            regex: /^sbt$/i,
+            replacement: () => 'saksbehandlingstid '
+        },
+        {
+            type: 'internal',
+            regex: /^nay$/i,
+            replacement: () => 'NAV Arbeid og ytelser '
+        },
+        {
+            type: 'internal',
+            regex: /^nfp$/i,
+            replacement: () => 'NAV Familie- og pensjonsytelser '
         },
         {
             type: 'internal',

--- a/src/mock/context-mock.ts
+++ b/src/mock/context-mock.ts
@@ -20,8 +20,9 @@ class VoidWebSocket {
 
 export function setupWsControlAndMock(mock: FetchMock) {
     (window as any).WebSocket = VoidWebSocket;
+    const baseUrl = `https://${window.location.host}`;
 
-    mock.post('/modiacontextholder/api/context', ({ body }, res, ctx) => {
+    mock.post(baseUrl + '/modiacontextholder/api/context', ({ body }, res, ctx) => {
         if (body.eventType === 'NY_AKTIV_ENHET') {
             context.aktivEnhet = body.verdi;
             return res(ctx.status(200));
@@ -33,13 +34,13 @@ export function setupWsControlAndMock(mock: FetchMock) {
         }
     });
 
-    mock.delete('/modiacontextholder/api/context', (req, res, ctx) => {
+    mock.delete(baseUrl + '/modiacontextholder/api/context', (req, res, ctx) => {
         context.aktivBruker = null;
         context.aktivEnhet = null;
         return res(ctx.status(200));
     });
 
-    mock.get('/modiacontextholder/api/context/aktivenhet', (req, res, ctx) =>
+    mock.get(baseUrl + '/modiacontextholder/api/context/aktivenhet', (req, res, ctx) =>
         res(
             ctx.json({
                 aktivEnhet: context.aktivEnhet,
@@ -48,12 +49,12 @@ export function setupWsControlAndMock(mock: FetchMock) {
         )
     );
 
-    mock.delete('/modiacontextholder/api/context/aktivbruker', (req, res, ctx) => {
+    mock.delete(baseUrl + '/modiacontextholder/api/context/aktivbruker', (req, res, ctx) => {
         context.aktivBruker = null;
         return res(ctx.status(200));
     });
 
-    mock.get('/modiacontextholder/api/context/aktivbruker', (req, res, ctx) =>
+    mock.get(baseUrl + '/modiacontextholder/api/context/aktivbruker', (req, res, ctx) =>
         res(
             ctx.json({
                 aktivEnhet: null,
@@ -62,7 +63,7 @@ export function setupWsControlAndMock(mock: FetchMock) {
         )
     );
 
-    mock.get('/modiacontextholder/api/context', (req, res, ctx) =>
+    mock.get(baseUrl + '/modiacontextholder/api/context', (req, res, ctx) =>
         res(
             ctx.json({
                 aktivEnhet: context.aktivEnhet,
@@ -71,7 +72,7 @@ export function setupWsControlAndMock(mock: FetchMock) {
         )
     );
 
-    mock.get('/modiacontextholder/api/decorator/aktor/:fnr', (req, res, ctx) =>
+    mock.get(baseUrl + '/modiacontextholder/api/decorator/aktor/:fnr', (req, res, ctx) =>
         res(ctx.json({ fnr: req.pathParams.fnr, aktorId: `0000${req.pathParams.fnr}0000` }))
     );
 
@@ -83,7 +84,7 @@ export function setupWsControlAndMock(mock: FetchMock) {
         enheter: enheter
     };
 
-    mock.get('/modiacontextholder/api/decorator', (req, res, ctx) => res(ctx.json(me)));
+    mock.get(baseUrl + '/modiacontextholder/api/decorator', (req, res, ctx) => res(ctx.json(me)));
 
     mock.get('https://app-q0.adeo.no/aktoerregister/api/v1/identer', (req, res, ctx) => {
         const fnr = (req.init!.headers! as Record<string, string>)['Nav-Personidenter'];

--- a/src/mock/index.ts
+++ b/src/mock/index.ts
@@ -378,7 +378,7 @@ function setupSendDelsvarMock(mock: FetchMock) {
 
 function setupTildelteOppgaverMock(mock: FetchMock) {
     mock.get(
-        apiBaseUri + '/oppgaver/tildelt',
+        apiBaseUri + '/oppgaver/tildelt/:fnr',
         withDelayedResponse(randomDelay(), STATUS_OK, () => oppgaveBackendMock.getTildelteOppgaver())
     );
 }

--- a/src/mock/standardTeksterMock.js
+++ b/src/mock/standardTeksterMock.js
@@ -9,6 +9,44 @@ const standardTeksterMock = {
                 'Hei [bruker.fornavn]\r\nVi ber om at du sender skriftlig kontoendring til NAV Økonomi Pensjon, postboks 6600 Etterstad, 0607 Oslo, sammen med en kopi av skifteattesten.\r\nDersom det finnes flere arvinger i skifteattesten, må du legge ved fullmakt fra disse.\r\n'
         }
     },
+    'f31f5d09-4873-4f84-912d-0ff3636db1cd': {
+        id: 'f31f5d09-4873-4f84-912d-0ff3636db1cd',
+        overskrift: 'Generell - Videreformidle - Internt (STO)',
+        tags: ['ks', 'sto', 'videresende', 'videreformidle', 'forwarded', 'office', ''],
+        innhold: {
+            nb_NO:
+                'Hei, [bruker.fornavn]\n\nJeg har videreformidlet henvendelsen til ENHET som skal kontakte deg senest innen utgangen av DAG+DATO. \n\nMed vennlig hilsen\n[saksbehandler.fornavn]\nNAV Kontaktsenter',
+            nn_NO:
+                'Hei, [bruker.fornavn]\n\nEg har sendt spørsmålet til EINING ditt som skal kontakte deg seinast innan utgongen av DAG+DATO\n\nMed venleg helsing\n[saksbehandler.fornavn]\nNAV Kontaktsenter',
+            en_US:
+                'Hello, [bruker.fornavn]\n\nI have forwarded your enquiry to OFFICE who will reply within the end of DAY+DATE\n\nKind regards,\n[saksbehandler.fornavn]\nNAV Kontaktsenter'
+        },
+        vekttall: 1604
+    },
+    'b4b67323-f57d-47a2-ac19-7ba4b62fe156': {
+        id: 'b4b67323-f57d-47a2-ac19-7ba4b62fe156',
+        overskrift: 'Signatur',
+        tags: ['signatur', ''],
+        innhold: {
+            nb_NO: 'Med vennlig hilsen\r\n[saksbehandler.navn]\r\n[saksbehandler.enhet]\r\n',
+            nn_NO: 'Med venleg helsing\r\n[saksbehandler.navn]\r\n[saksbehandler.enhet]\r\n',
+            en_US: 'Sincerely,\r\n[saksbehandler.navn]\r\n[saksbehandler.enhet]\r\n'
+        },
+        vekttall: 70
+    },
+    'fd71ff08-be9c-4e90-a6f8-bc17a798f244': {
+        id: 'fd71ff08-be9c-4e90-a6f8-bc17a798f244',
+        overskrift: 'Generell - Signatur.fornavn (STO) ',
+        tags: ['ks', 'sto', 'signatur'],
+        innhold: {
+            nb_NO:
+                'Vi ønsker å forbedre oss. Hvis du har ett minutt til overs vil vi gjerne at du svarer på disse spørsmålene https://url.til.nettside.com/tilbakmeldinger/submit.aspx?id=langrandomidheresombareerherforslikatlenkenercalikelangsomtidligere\n\nMed vennlig hilsen\n[saksbehandler.fornavn]\nNAV Kontaktsenter',
+            nn_NO:
+                'Vi ønsker å forbedre oss. Hvis du har ett minutt til overs vil vi gjerne at du svarer på disse spørsmålene https://url.til.nettside.com/tilbakmeldinger/submit.aspx?id=langrandomidheresombareerherforslikatlenkenercalikelangsomtidligere\n\nMed venleg helsing\n[saksbehandler.fornavn]\nNAV Kontaktsenter',
+            en_US: 'Kind regards,\n[saksbehandler.fornavn]\nNAV Kontaktsenter'
+        },
+        vekttall: 241
+    },
 
     'b2e93ec9-feba-41e9-a7c7-d54193191430': {
         id: 'b2e93ec9-feba-41e9-a7c7-d54193191430',


### PR DESCRIPTION
* [KAIZEN-0] fikse urlene satt av mocken 95f27fa
  vært noen mindre endringer på urler i det siste, så mocken må oppdateres
* [KAIZEN-0] endret ø til o for en funksjon 0235e87
* [KAIZEN-0] legge til noen eksteren skrivestøttetekster med reelle ider 5af3bf2
  gjør at vi kan teste ut mvh/hei lokalt og i heroku selvom de egentlig er avhengige av skrivestøtte-backend
* [KAIZEN-0] koblet flere tekster mot ekstern kilde 8f3d5c8
  Følgende er nå koblet mot ekstern definisjon: mvh, mvhen, mvhnn og mvhks

Hovedmotivasjonen bak endringer er endringene i 8f3d5c8, og at nks skal selv få mulighet til å styre sin signatur (nå uten lenke til tiny.cc)