### PR TITLE
[FAGSYSTEM-168518] legge til visning av ekstra info fra ditt-nav varsler

### DIFF
--- a/src/app/personside/infotabs/varsel/Varsel.tsx
+++ b/src/app/personside/infotabs/varsel/Varsel.tsx
@@ -67,6 +67,21 @@ const Kommaliste = styled.ul`
     }
 `;
 
+const GraattDefinisjonsListe = styled.dl`
+    ${theme.graattPanel}
+    dt {
+        float: left;
+        clear: left;
+        font-weight: bold;
+        margin-bottom: 0.5rem;
+        width: 7rem;
+    }
+    dd {
+        margin-bottom: 0.5rem;
+        margin-left: 7.125rem;
+    }
+`;
+
 function getVarselTekst(varsel: VarselModell) {
     const varselTekst = Varseltype[varsel.varselType];
 
@@ -80,13 +95,18 @@ function getVarselTekst(varsel: VarselModell) {
 }
 
 function DittNavEventVarsel({ varsel }: { varsel: DittNavEvent }) {
+    const open = useAppState(state => state.varsler.aapneVarsler).includes(varsel);
+    const dispatch = useDispatch();
+    const setOpen = (open: boolean) => dispatch(toggleVisVarsel(varsel, open));
+    const toggleOpen = () => setOpen(!open);
+
     const tittelId = useRef(guid());
     const aktiv = varsel.aktiv ? '' : '(Inaktiv)';
     return (
         <li>
             <StyledPanel>
                 <article aria-labelledby={tittelId.current}>
-                    <HeaderStyle>
+                    <HeaderStyle onClick={toggleOpen}>
                         <Normaltekst>{formaterDato(varsel.sistOppdatert)}</Normaltekst>
                         <Element id={tittelId.current} tag="h4">
                             {varsel.tekst}
@@ -94,7 +114,25 @@ function DittNavEventVarsel({ varsel }: { varsel: DittNavEvent }) {
                         <Kommaliste aria-label="Kommunikasjonskanaler">
                             <Normaltekst tag="li">NOTIFIKASJON {aktiv}</Normaltekst>
                         </Kommaliste>
+                        <VisMerChevron
+                            focusOnRelativeParent={true}
+                            onClick={toggleOpen}
+                            open={open}
+                            title={(open ? 'Skjul' : 'Vis') + ' mer informasjon om notifikasjon'}
+                        />
                     </HeaderStyle>
+                    <UnmountClosed isOpened={open}>
+                        <GraattDefinisjonsListe>
+                            <dt>Produsert av:</dt>
+                            <dd>{varsel.produsent}</dd>
+
+                            <dt>Tekst:</dt>
+                            <dd>{varsel.tekst}</dd>
+
+                            <dt>Link:</dt>
+                            <dd>{varsel.link}</dd>
+                        </GraattDefinisjonsListe>
+                    </UnmountClosed>
                 </article>
             </StyledPanel>
         </li>

--- a/src/app/personside/infotabs/varsel/__snapshots__/VarselContainer.test.tsx.snap
+++ b/src/app/personside/infotabs/varsel/__snapshots__/VarselContainer.test.tsx.snap
@@ -110,6 +110,26 @@ exports[`Viser varselcontainer med alt innhold 1`] = `
   margin-right: 0.5em;
 }
 
+.c9 {
+  border-radius: 0.5rem;
+  background-color: #f1f0f0;
+  box-shadow: inset 0 0 0 0.3rem white,inset 0 0 0 0.37rem rgba(0,0,0,0.15);
+  padding: 1.25rem;
+}
+
+.c9 dt {
+  float: left;
+  clear: left;
+  font-weight: bold;
+  margin-bottom: 0.5rem;
+  width: 7rem;
+}
+
+.c9 dd {
+  margin-bottom: 0.5rem;
+  margin-left: 7.125rem;
+}
+
 .c1 {
   display: -ms-grid;
   display: grid;
@@ -386,6 +406,7 @@ exports[`Viser varselcontainer med alt innhold 1`] = `
         >
           <div
             className="c4"
+            onClick={[Function]}
           >
             <p
               className="typo-normal"
@@ -409,7 +430,40 @@ exports[`Viser varselcontainer med alt innhold 1`] = `
                 
               </li>
             </ul>
+            <button
+              aria-expanded={false}
+              aria-label="Vis mer informasjon om notifikasjon"
+              className="c6"
+              onClick={[Function]}
+              title="Vis mer informasjon om notifikasjon"
+            >
+              <span
+                className="nav-frontend-chevron chevronboks chevron--ned"
+              />
+            </button>
           </div>
+          <dl
+            className="c9"
+          >
+            <dt>
+              Produsert av:
+            </dt>
+            <dd>
+              
+            </dd>
+            <dt>
+              Tekst:
+            </dt>
+            <dd>
+              Tekst her
+            </dd>
+            <dt>
+              Link:
+            </dt>
+            <dd>
+              
+            </dd>
+          </dl>
         </article>
       </div>
     </li>
@@ -422,6 +476,7 @@ exports[`Viser varselcontainer med alt innhold 1`] = `
         >
           <div
             className="c4"
+            onClick={[Function]}
           >
             <p
               className="typo-normal"
@@ -445,7 +500,40 @@ exports[`Viser varselcontainer med alt innhold 1`] = `
                 
               </li>
             </ul>
+            <button
+              aria-expanded={false}
+              aria-label="Vis mer informasjon om notifikasjon"
+              className="c6"
+              onClick={[Function]}
+              title="Vis mer informasjon om notifikasjon"
+            >
+              <span
+                className="nav-frontend-chevron chevronboks chevron--ned"
+              />
+            </button>
           </div>
+          <dl
+            className="c9"
+          >
+            <dt>
+              Produsert av:
+            </dt>
+            <dd>
+              
+            </dd>
+            <dt>
+              Tekst:
+            </dt>
+            <dd>
+              Tekst her
+            </dd>
+            <dt>
+              Link:
+            </dt>
+            <dd>
+              
+            </dd>
+          </dl>
         </article>
       </div>
     </li>

--- a/src/mock/varsler/varsel-mock.ts
+++ b/src/mock/varsler/varsel-mock.ts
@@ -28,7 +28,7 @@ function genererDittNavEventVarsel(fnr: string): DittNavEvent {
         grupperingsId: faker.random.uuid(),
         eventId: faker.random.uuid(),
         eventTidspunkt: dayjs(tidspunkt).format(backendDatoformat),
-        produsent: faker.random.alphaNumeric(),
+        produsent: faker.random.alphaNumeric(10),
         sikkerhetsnivaa: navfaker.random.arrayElement([3, 4]),
         sistOppdatert: dayjs(tidspunkt).format(backendDatoformat),
         tekst: faker.lorem.sentence(5 + faker.random.number(5)),

--- a/src/redux/varsler/varslerReducer.ts
+++ b/src/redux/varsler/varslerReducer.ts
@@ -1,8 +1,8 @@
 import { Action } from 'redux';
-import { Varsel } from '../../models/varsel';
+import { UnifiedVarsel } from '../../models/varsel';
 
 export interface VarslerState {
-    aapneVarsler: Varsel[];
+    aapneVarsler: UnifiedVarsel[];
 }
 
 const initialState: VarslerState = {
@@ -15,11 +15,11 @@ enum actionKeys {
 
 interface ToggleVisAction extends Action {
     type: actionKeys.TOGGLE_VIS_VARSEL;
-    varsel: Varsel;
+    varsel: UnifiedVarsel;
     vis: boolean;
 }
 
-export function toggleVisVarsel(varsel: Varsel, vis: boolean): ToggleVisAction {
+export function toggleVisVarsel(varsel: UnifiedVarsel, vis: boolean): ToggleVisAction {
     return {
         type: actionKeys.TOGGLE_VIS_VARSEL,
         varsel: varsel,


### PR DESCRIPTION
Viser mer informasjon fra dittnav-varslene, deriblant hvem som er satt som produsent.

Eksempel fra mock-visning:
![image](https://user-images.githubusercontent.com/1413417/119831478-9aea9400-befd-11eb-90d6-0ddf93f35bf3.png)
