### PR TITLE
[OPP-1359] ikke vise ytelser som er inaktiv i Oppfølgingslamell

### DIFF
--- a/src/app/personside/infotabs/oversikt/OppfolgingOversikt.tsx
+++ b/src/app/personside/infotabs/oversikt/OppfolgingOversikt.tsx
@@ -49,7 +49,7 @@ function YtelserForBruker({ detaljertOppfolging }: { detaljertOppfolging: Detalj
     const filtrerteYtelser = ytelser.filter((item, index) => ytelser.indexOf(item) === index).join(', ');
     return (
         <>
-            <Element>{filtrerteYtelser.length > 0 ? 'Ytelser:' : ''}</Element>
+            <Element>Ytelser:</Element>
             <Normaltekst>{filtrerteYtelser}</Normaltekst>
         </>
     );

--- a/src/app/personside/infotabs/oversikt/OppfolgingOversikt.tsx
+++ b/src/app/personside/infotabs/oversikt/OppfolgingOversikt.tsx
@@ -43,11 +43,13 @@ function YtelserForBruker({ detaljertOppfolging }: { detaljertOppfolging: Detalj
     if (detaljertOppfolging.ytelser.length === 0) {
         return null;
     }
-    const ytelser = detaljertOppfolging.ytelser.map(ytelse => ytelse.type);
+    const ytelser = detaljertOppfolging.ytelser
+        .filter(ytelse => ytelse.status !== 'Avsluttet')
+        .map(ytelse => ytelse.type + ' : ' + ytelse.status);
     const filtrerteYtelser = ytelser.filter((item, index) => ytelser.indexOf(item) === index).join(', ');
     return (
         <>
-            <Element>Ytelser:</Element>
+            <Element>{filtrerteYtelser.length > 0 ? 'Ytelser:' : ''}</Element>
             <Normaltekst>{filtrerteYtelser}</Normaltekst>
         </>
     );

--- a/src/mock/oppfolging-mock.ts
+++ b/src/mock/oppfolging-mock.ts
@@ -71,7 +71,7 @@ function getYtelse(): OppfolgingsYtelse {
         datoKravMottatt: dayjs(faker.date.recent(30)).format(backendDatoformat),
         fom: dayjs(faker.date.recent(20)).format(backendDatoformat),
         tom: dayjs(faker.date.recent(10)).format(backendDatoformat),
-        status: navfaker.random.arrayElement(['Aktiv', 'Avsluttet']),
+        status: navfaker.random.arrayElement(['Aktiv', 'Avsluttet', 'Inaktiv']),
         type: navfaker.random.arrayElement(['Arbeidsavklaringspenger', 'Individstønad']),
         vedtak: Array(navfaker.random.integer(5, 1))
             .fill(null)


### PR DESCRIPTION
Etter vi har hentet alle ytelser fra backend vi skal filtere borte ytelser som er Avsluttet