### PR TITLE
[OPP-1103] oppdatere visuelt uttrykk for popup-boksene

### DIFF
--- a/src/api/api.ts
+++ b/src/api/api.ts
@@ -23,7 +23,7 @@ export async function postWithConflictVerification(
     let response = await fetch(uri, config);
     if (response.status === CONFLICT) {
         const message = await readConflictMessage(response, conflictMessage);
-        if (await confirm(message)) {
+        if (await confirm({ icon: 'warning', header: 'Oppgave tilordning', message })) {
             config.headers['Ignore-Conflict'] = 'true';
             response = await fetch(uri, config);
         } else {


### PR DESCRIPTION
følger oppsett fra "LoggetUtModal" slik at vi ivaretar helhetlig look-n-feel.

Lagt opp til 5 ikon-valg som kan styres vha `icon` property, i tillegg har man mulighet til å velge å ikke bruke ett ikon.
`header` og `message` har blitt gjort obligatoriske slik at vi alltid kan være sikre på at ting ser nogenlunde bra ut.

Fra tidligere ble det eksponert fire popup-funksjoner; `alert`, `confirm`, `prompt` og `promptSecret`, og dette styrer hvilke valgmuligheter og input-felter som blir synlig for bruker.

`await alert({ icon: 'error', header: '...', message: '...' })`
![alert-error](https://user-images.githubusercontent.com/1413417/120452899-da4c3100-c392-11eb-8f16-4e99eee04196.png)

`await alert({ icon: 'info', header: '...', message: '...' })`
![alert-info](https://user-images.githubusercontent.com/1413417/120452906-dc15f480-c392-11eb-96fd-e241beac3cd7.png)

`await alert({ icon: 'none', header: '...', message: '...' })`
![alert-none](https://user-images.githubusercontent.com/1413417/120452914-dddfb800-c392-11eb-9036-99072fd2ab39.png)

`await alert({ icon: 'ok', header: '...', message: '...' })`
![alert-ok](https://user-images.githubusercontent.com/1413417/120452919-df10e500-c392-11eb-8e68-88bd78334635.png)

`const result: boolean = await confirm({ icon: 'warning', header: '...', message: '...' })`
![confirm-advarsel](https://user-images.githubusercontent.com/1413417/120452930-e0421200-c392-11eb-97e3-05d94fd40ad5.png)

`const result: string | null = await prompt({ icon: 'help', header: '...', message: '...' })`
![prompt-help](https://user-images.githubusercontent.com/1413417/120452940-e20bd580-c392-11eb-8729-6c9ddf16ad74.png)
