### PR TITLE
[OPP-1370] ikke lage dokumentlenke om journalpost id dokumentid null

### DIFF
--- a/src/app/personside/infotabs/saksoversikt/__snapshots__/SaksoversiktContainer.test.tsx.snap
+++ b/src/app/personside/infotabs/saksoversikt/__snapshots__/SaksoversiktContainer.test.tsx.snap
@@ -842,7 +842,7 @@ exports[`Viser saksoversiktcontainer med alt innhold 1`] = `
                   className="typo-normal"
                 >
                   (
-                  14
+                  15
                    journalposter)
                 </p>
               </div>
@@ -1675,6 +1675,93 @@ exports[`Viser saksoversiktcontainer med alt innhold 1`] = `
                                 Last ned pdf
                               </span>
                             </a>
+                          </li>
+                        </ul>
+                      </div>
+                      <div
+                        className="c24"
+                      >
+                        <p
+                          className="typo-undertekst"
+                        >
+                          Alle tema
+                           / Saksid: 
+                          q8mlv7u2
+                        </p>
+                      </div>
+                    </div>
+                  </article>
+                </li>
+                <li>
+                  <article
+                    aria-labelledby="Helt tilfeldig ID"
+                    className="c20"
+                  >
+                    <div
+                      className="c21"
+                    >
+                      <svg
+                        aria-label="Du har ikke tilgang til dette dokumentet"
+                        viewBox="0 0 24 24"
+                        xmlns="http://www.w3.org/2000/svg"
+                      >
+                        <g
+                          fill="currentColor"
+                        >
+                          <path
+                            d="M17 10V5.5l-.1-.4-5-5-.4-.1H.5C.2 0 0 .2 0 .5v21c0 .3.2.5.5.5h11A7.5 7.5 0 0 1 17 10zM11.5.5l5 5h-5v-5z"
+                          />
+                          <path
+                            d="M17.5 11a6.5 6.5 0 0 0-5 10.7l9.2-9.1a6.5 6.5 0 0 0-4.2-1.6zM22.4 13.3l-9.1 9.1c1.1 1 2.6 1.6 4.2 1.6a6.5 6.5 0 0 0 5-10.7z"
+                          />
+                        </g>
+                      </svg>
+                    </div>
+                    <div
+                      className="c22"
+                    >
+                      <div
+                        className="c23"
+                        id="Helt tilfeldig ID"
+                      >
+                        <h4
+                          className="order-second"
+                        >
+                          <p
+                            className="typo-element"
+                          >
+                            Inntektsopplysninger
+                          </p>
+                        </h4>
+                        <div
+                          className="order-first"
+                        >
+                          <p
+                            className="typo-normal"
+                          >
+                            28.02.2017 / Fra AREMARK TESTFAMILIEN
+                          </p>
+                        </div>
+                      </div>
+                      <div
+                        className="c25"
+                      >
+                        <p
+                          className="typo-normal"
+                        >
+                          Dokumentet har 
+                          1
+                           vedlegg:
+                        </p>
+                        <ul>
+                          <li>
+                            A-inntekt
+                             
+                            <p
+                              className="typo-undertekst"
+                            >
+                              (Dokument er ikke tilgjengelig)
+                            </p>
                           </li>
                         </ul>
                       </div>

--- a/src/app/personside/infotabs/saksoversikt/saksdokumenter/DokumentLenke.tsx
+++ b/src/app/personside/infotabs/saksoversikt/saksdokumenter/DokumentLenke.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import styled from 'styled-components';
-import { Element } from 'nav-frontend-typografi';
+import { Element, Undertekst } from 'nav-frontend-typografi';
 import { Link, useLocation } from 'react-router-dom';
 import { Dokument, Journalpost } from '../../../../../models/saksoversikt/journalpost';
 import { Sakstema } from '../../../../../models/saksoversikt/sakstema';
@@ -54,11 +54,20 @@ function DokumentLenke(props: Props) {
     const apneDokumentINyttVindu = !erSakerFullscreen(pathname);
     const journalpostId = props.journalPost.journalpostId;
     const dokumentReferanse = props.dokument.dokumentreferanse;
+
+    if (journalpostId === 'null' || dokumentReferanse === 'null') {
+        return (
+            <>
+                {dokumentTekst(props.dokument)} <Undertekst>(Dokument er ikke tilgjengelig)</Undertekst>
+            </>
+        );
+    }
+
     const url = apneDokumentINyttVindu
         ? getUrlSaksdokumentEgetVindu(fødselsnummer, journalpostId, dokumentReferanse)
         : dyplenker.saker.link(props.valgtSakstema, props.dokument);
-    const saksdokumentUrl = getSaksdokumentUrl(fødselsnummer, journalpostId, dokumentReferanse);
 
+    const saksdokumentUrl = getSaksdokumentUrl(fødselsnummer, journalpostId, dokumentReferanse);
     return (
         <>
             <Link to={url} target={apneDokumentINyttVindu ? '_blank' : undefined} className="lenke typo-element">

--- a/src/mock/saksoversikt/aremark-saksoversikt-mock.ts
+++ b/src/mock/saksoversikt/aremark-saksoversikt-mock.ts
@@ -97,6 +97,39 @@ export function getAremarkSakstemaListe(): Sakstema[] {
                     feil: { inneholderFeil: true, feilmelding: Feilmelding.Sikkerhetsbegrensning }
                 },
                 {
+                    id: 'jg2nbv00_null',
+                    retning: Kommunikasjonsretning.Inn,
+                    dato: { år: 2017, måned: 2, dag: 28, time: 23, minutt: 50, sekund: 24 },
+                    navn: 'Benjamin',
+                    journalpostId: 'null',
+                    hoveddokument: {
+                        tittel: 'Inntektsopplysninger',
+                        dokumentreferanse: 'null',
+                        kanVises: true,
+                        logiskDokument: false,
+                        skjerming: null
+                    },
+                    vedlegg: [
+                        {
+                            tittel: 'A-inntekt',
+                            dokumentreferanse: 'k51y90us',
+                            kanVises: true,
+                            logiskDokument: false,
+                            skjerming: null
+                        }
+                    ],
+                    avsender: Entitet.Sluttbruker,
+                    mottaker: Entitet.EksternPart,
+                    tilhørendeSaksid: 't6s7hp8k',
+                    tilhørendeFagsaksid: 'q8mlv7u2',
+                    baksystem: [Baksystem.Gsak, Baksystem.Kodeverk],
+                    temakode: 'SYK',
+                    temakodeVisning: 'Sykepenger',
+                    ettersending: false,
+                    erJournalfort: false,
+                    feil: { inneholderFeil: true, feilmelding: Feilmelding.Sikkerhetsbegrensning }
+                },
+                {
                     id: 'odiio5ou',
                     retning: Kommunikasjonsretning.Intern,
                     dato: { år: 2018, måned: 12, dag: 5, time: 5, minutt: 29, sekund: 17 },


### PR DESCRIPTION
…t referans er null

veildere bruke unødvendig tid å åpne dokument som skulle åpnes siden journalpostid og dokumentreferanse er null. i det tilfelle skulle ikke sende forspørsel til backend for hente den dokument. Det er feil i backend hvor som fører til at dokumentreferase og journalpostid dukker opp som null. Det kommer til vi fikse i backend siden