### PR TITLE
[OPP-1370] ikke lage dokumentlenke hvis journalpost id ellers dokumen…

### DIFF
--- a/src/app/personside/infotabs/saksoversikt/__snapshots__/SaksoversiktContainer.test.tsx.snap
+++ b/src/app/personside/infotabs/saksoversikt/__snapshots__/SaksoversiktContainer.test.tsx.snap
@@ -1755,13 +1755,33 @@ exports[`Viser saksoversiktcontainer med alt innhold 1`] = `
                         </p>
                         <ul>
                           <li>
-                            A-inntekt
-                             
-                            <p
-                              className="typo-undertekst"
+                            <a
+                              className="lenke typo-element"
+                              href="/dokument/10108000398?dokumenturl=/modiapersonoversikt-api/rest/saker/10108000398/dokument/null/k51y90us"
+                              onClick={[Function]}
+                              target="_blank"
                             >
-                              (Dokument er ikke tilgjengelig)
-                            </p>
+                              A-inntekt
+                            </a>
+                            <a
+                              className="c26 lenke typo-element"
+                              download={true}
+                              href="/modiapersonoversikt-api/rest/saker/10108000398/dokument/null/k51y90us"
+                              title="Last ned"
+                            >
+                              <svg
+                                aria-hidden={true}
+                                height={20}
+                                width={20}
+                              >
+                                download.svg
+                              </svg>
+                              <span
+                                className="sr-only"
+                              >
+                                Last ned pdf
+                              </span>
+                            </a>
                           </li>
                         </ul>
                       </div>

--- a/src/app/personside/infotabs/saksoversikt/__snapshots__/SaksoversiktContainer.test.tsx.snap
+++ b/src/app/personside/infotabs/saksoversikt/__snapshots__/SaksoversiktContainer.test.tsx.snap
@@ -1755,33 +1755,13 @@ exports[`Viser saksoversiktcontainer med alt innhold 1`] = `
                         </p>
                         <ul>
                           <li>
-                            <a
-                              className="lenke typo-element"
-                              href="/dokument/10108000398?dokumenturl=/modiapersonoversikt-api/rest/saker/10108000398/dokument/12345/k51y90us"
-                              onClick={[Function]}
-                              target="_blank"
+                            A-inntekt
+                             
+                            <p
+                              className="typo-undertekst"
                             >
-                              A-inntekt
-                            </a>
-                            <a
-                              className="c26 lenke typo-element"
-                              download={true}
-                              href="/modiapersonoversikt-api/rest/saker/10108000398/dokument/12345/k51y90us"
-                              title="Last ned"
-                            >
-                              <svg
-                                aria-hidden={true}
-                                height={20}
-                                width={20}
-                              >
-                                download.svg
-                              </svg>
-                              <span
-                                className="sr-only"
-                              >
-                                Last ned pdf
-                              </span>
-                            </a>
+                              (Dokument er ikke tilgjengelig)
+                            </p>
                           </li>
                         </ul>
                       </div>

--- a/src/app/personside/infotabs/saksoversikt/__snapshots__/SaksoversiktContainer.test.tsx.snap
+++ b/src/app/personside/infotabs/saksoversikt/__snapshots__/SaksoversiktContainer.test.tsx.snap
@@ -1757,7 +1757,7 @@ exports[`Viser saksoversiktcontainer med alt innhold 1`] = `
                           <li>
                             <a
                               className="lenke typo-element"
-                              href="/dokument/10108000398?dokumenturl=/modiapersonoversikt-api/rest/saker/10108000398/dokument/null/k51y90us"
+                              href="/dokument/10108000398?dokumenturl=/modiapersonoversikt-api/rest/saker/10108000398/dokument/12345/k51y90us"
                               onClick={[Function]}
                               target="_blank"
                             >
@@ -1766,7 +1766,7 @@ exports[`Viser saksoversiktcontainer med alt innhold 1`] = `
                             <a
                               className="c26 lenke typo-element"
                               download={true}
-                              href="/modiapersonoversikt-api/rest/saker/10108000398/dokument/null/k51y90us"
+                              href="/modiapersonoversikt-api/rest/saker/10108000398/dokument/12345/k51y90us"
                               title="Last ned"
                             >
                               <svg

--- a/src/app/personside/infotabs/saksoversikt/dokumentvisning/getSaksdokumentUrl.ts
+++ b/src/app/personside/infotabs/saksoversikt/dokumentvisning/getSaksdokumentUrl.ts
@@ -1,9 +1,5 @@
 import { apiBaseUri } from '../../../../../api/config';
 
-export function getSaksdokumentUrl(
-    fnr: string,
-    journalpostId?: string | null | undefined,
-    dokumentreferanse?: string | null | undefined
-) {
+export function getSaksdokumentUrl(fnr: string, journalpostId: string | null, dokumentreferanse: string | null) {
     return apiBaseUri + '/saker/' + fnr + '/dokument/' + journalpostId + '/' + dokumentreferanse;
 }

--- a/src/app/personside/infotabs/saksoversikt/dokumentvisning/getSaksdokumentUrl.ts
+++ b/src/app/personside/infotabs/saksoversikt/dokumentvisning/getSaksdokumentUrl.ts
@@ -1,5 +1,9 @@
 import { apiBaseUri } from '../../../../../api/config';
 
-export function getSaksdokumentUrl(fnr: string, journalpostId: string, dokumentreferanse: string) {
+export function getSaksdokumentUrl(
+    fnr: string,
+    journalpostId?: string | null | undefined,
+    dokumentreferanse?: string | null | undefined
+) {
     return apiBaseUri + '/saker/' + fnr + '/dokument/' + journalpostId + '/' + dokumentreferanse;
 }

--- a/src/app/personside/infotabs/saksoversikt/saksdokumenter/DokumentLenke.tsx
+++ b/src/app/personside/infotabs/saksoversikt/saksdokumenter/DokumentLenke.tsx
@@ -36,7 +36,11 @@ const dokumentTekst = (dokument: Dokument) => {
     return dokument.tittel + (dokument.skjerming ? ' (Skjermet)' : '');
 };
 
-function getUrlSaksdokumentEgetVindu(fødselsnummer: string, journalpostId: string, dokumentReferanse: string) {
+function getUrlSaksdokumentEgetVindu(
+    fødselsnummer: string,
+    journalpostId?: string | null,
+    dokumentReferanse?: string | null
+) {
     const saksdokumentUrl = getSaksdokumentUrl(fødselsnummer, journalpostId, dokumentReferanse);
 
     return `${paths.saksdokumentEgetVindu}/${fødselsnummer}?dokumenturl=${saksdokumentUrl}`;

--- a/src/app/personside/infotabs/saksoversikt/saksdokumenter/DokumentLenke.tsx
+++ b/src/app/personside/infotabs/saksoversikt/saksdokumenter/DokumentLenke.tsx
@@ -55,7 +55,7 @@ function DokumentLenke(props: Props) {
     const journalpostId = props.journalPost.journalpostId;
     const dokumentReferanse = props.dokument.dokumentreferanse;
 
-    if (journalpostId === 'null' || dokumentReferanse === 'null') {
+    if (journalpostId === null || dokumentReferanse === null) {
         return (
             <>
                 {dokumentTekst(props.dokument)} <Undertekst>(Dokument er ikke tilgjengelig)</Undertekst>

--- a/src/app/personside/infotabs/saksoversikt/saksdokumenter/DokumentLenke.tsx
+++ b/src/app/personside/infotabs/saksoversikt/saksdokumenter/DokumentLenke.tsx
@@ -38,8 +38,8 @@ const dokumentTekst = (dokument: Dokument) => {
 
 function getUrlSaksdokumentEgetVindu(
     fødselsnummer: string,
-    journalpostId?: string | null,
-    dokumentReferanse?: string | null
+    journalpostId: string | null,
+    dokumentReferanse: string | null
 ) {
     const saksdokumentUrl = getSaksdokumentUrl(fødselsnummer, journalpostId, dokumentReferanse);
 

--- a/src/app/personside/infotabs/saksoversikt/saksdokumenter/JournalpostLiseElement.tsx
+++ b/src/app/personside/infotabs/saksoversikt/saksdokumenter/JournalpostLiseElement.tsx
@@ -147,7 +147,7 @@ function JournalpostLiseElement(props: Props) {
             <Normaltekst>Dokumentet har {journalpost.vedlegg.length} vedlegg:</Normaltekst>
             <ul ref={vedleggLinkRef}>
                 {journalpost.vedlegg.map(vedlegg => (
-                    <li key={vedlegg.dokumentreferanse + journalpost.journalpostId}>
+                    <li key={vedlegg.dokumentreferanse + journalpost.journalpostId!}>
                         <DokumentLenke
                             dokument={vedlegg}
                             valgtSakstema={props.valgtSakstema}
@@ -175,7 +175,7 @@ function JournalpostLiseElement(props: Props) {
                     <UUcustomOrder id={tittelId.current}>
                         <h4 ref={hoveddokumentLinkRef} className="order-second">
                             <DokumentLenke
-                                key={hovedDokument.dokumentreferanse + journalpost.journalpostId}
+                                key={hovedDokument.dokumentreferanse?.concat(journalpost.journalpostId!)}
                                 dokument={hovedDokument}
                                 valgtSakstema={props.valgtSakstema}
                                 kanVises={tilgangTilHoveddokument && dokumentKanVises(hovedDokument, journalpost)}

--- a/src/app/personside/infotabs/saksoversikt/saksdokumenter/JournalpostLiseElement.tsx
+++ b/src/app/personside/infotabs/saksoversikt/saksdokumenter/JournalpostLiseElement.tsx
@@ -146,8 +146,8 @@ function JournalpostLiseElement(props: Props) {
         <VedleggStyle>
             <Normaltekst>Dokumentet har {journalpost.vedlegg.length} vedlegg:</Normaltekst>
             <ul ref={vedleggLinkRef}>
-                {journalpost.vedlegg.map(vedlegg => (
-                    <li key={vedlegg.dokumentreferanse + journalpost.journalpostId!}>
+                {journalpost.vedlegg.map((vedlegg, index) => (
+                    <li key={index}>
                         <DokumentLenke
                             dokument={vedlegg}
                             valgtSakstema={props.valgtSakstema}
@@ -175,7 +175,6 @@ function JournalpostLiseElement(props: Props) {
                     <UUcustomOrder id={tittelId.current}>
                         <h4 ref={hoveddokumentLinkRef} className="order-second">
                             <DokumentLenke
-                                key={hovedDokument.dokumentreferanse?.concat(journalpost.journalpostId!)}
                                 dokument={hovedDokument}
                                 valgtSakstema={props.valgtSakstema}
                                 kanVises={tilgangTilHoveddokument && dokumentKanVises(hovedDokument, journalpost)}

--- a/src/mock/saksoversikt/aremark-saksoversikt-mock.ts
+++ b/src/mock/saksoversikt/aremark-saksoversikt-mock.ts
@@ -101,10 +101,10 @@ export function getAremarkSakstemaListe(): Sakstema[] {
                     retning: Kommunikasjonsretning.Inn,
                     dato: { år: 2017, måned: 2, dag: 28, time: 23, minutt: 50, sekund: 24 },
                     navn: 'Benjamin',
-                    journalpostId: '12345',
+                    journalpostId: null,
                     hoveddokument: {
                         tittel: 'Inntektsopplysninger',
-                        dokumentreferanse: 'null',
+                        dokumentreferanse: null,
                         kanVises: true,
                         logiskDokument: false,
                         skjerming: null
@@ -112,7 +112,7 @@ export function getAremarkSakstemaListe(): Sakstema[] {
                     vedlegg: [
                         {
                             tittel: 'A-inntekt',
-                            dokumentreferanse: 'k51y90us',
+                            dokumentreferanse: null,
                             kanVises: true,
                             logiskDokument: false,
                             skjerming: null

--- a/src/mock/saksoversikt/aremark-saksoversikt-mock.ts
+++ b/src/mock/saksoversikt/aremark-saksoversikt-mock.ts
@@ -101,7 +101,7 @@ export function getAremarkSakstemaListe(): Sakstema[] {
                     retning: Kommunikasjonsretning.Inn,
                     dato: { år: 2017, måned: 2, dag: 28, time: 23, minutt: 50, sekund: 24 },
                     navn: 'Benjamin',
-                    journalpostId: 'null',
+                    journalpostId: '12345',
                     hoveddokument: {
                         tittel: 'Inntektsopplysninger',
                         dokumentreferanse: 'null',

--- a/src/models/saksoversikt/journalpost.ts
+++ b/src/models/saksoversikt/journalpost.ts
@@ -5,7 +5,7 @@ export interface Journalpost {
     retning: Kommunikasjonsretning;
     dato: Saksdato;
     navn: string;
-    journalpostId?: string | null;
+    journalpostId: string | null;
     hoveddokument: Dokument;
     vedlegg: Dokument[];
     avsender: Entitet;
@@ -55,7 +55,7 @@ export interface FeilWrapper {
 
 export interface Dokument {
     tittel: string;
-    dokumentreferanse?: string | null;
+    dokumentreferanse: string | null;
     kanVises: boolean;
     logiskDokument: boolean;
     skjerming: string | null;

--- a/src/models/saksoversikt/journalpost.ts
+++ b/src/models/saksoversikt/journalpost.ts
@@ -5,7 +5,7 @@ export interface Journalpost {
     retning: Kommunikasjonsretning;
     dato: Saksdato;
     navn: string;
-    journalpostId: string | null;
+    journalpostId?: string | null;
     hoveddokument: Dokument;
     vedlegg: Dokument[];
     avsender: Entitet;
@@ -55,7 +55,7 @@ export interface FeilWrapper {
 
 export interface Dokument {
     tittel: string;
-    dokumentreferanse: string | null;
+    dokumentreferanse?: string | null;
     kanVises: boolean;
     logiskDokument: boolean;
     skjerming: string | null;

--- a/src/models/saksoversikt/journalpost.ts
+++ b/src/models/saksoversikt/journalpost.ts
@@ -5,7 +5,7 @@ export interface Journalpost {
     retning: Kommunikasjonsretning;
     dato: Saksdato;
     navn: string;
-    journalpostId: string;
+    journalpostId: string | null;
     hoveddokument: Dokument;
     vedlegg: Dokument[];
     avsender: Entitet;
@@ -55,7 +55,7 @@ export interface FeilWrapper {
 
 export interface Dokument {
     tittel: string;
-    dokumentreferanse: string;
+    dokumentreferanse: string | null;
     kanVises: boolean;
     logiskDokument: boolean;
     skjerming: string | null;


### PR DESCRIPTION
…t referans er null

veildere bruke unødvendig tid å åpne dokument som skulle åpnes siden journalpostid og dokumentreferanse er null. i det tilfelle skulle ikke sende forspørsel til backend for hente den dokument. Det er feil i backend hvor som fører til at dokumentreferase og journalpostid dukker opp som null. Det kommer til vi fikse i backend siden