### PR TITLE
[PROD][FAGSYSTEM-178851] ta i bruk nullable oppfolging felt

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17749,9 +17749,9 @@
             "integrity": "sha512-4WK/bYZmj8xLr+HUCODHGF1ZFzsYffasLUgEiMBY4fgtltdO6B4WJtlSbPaDTLpYTcGVwM2qLnFTICEcNxs3kA=="
         },
         "tar": {
-            "version": "6.1.0",
-            "resolved": "https://registry.npmjs.org/tar/-/tar-6.1.0.tgz",
-            "integrity": "sha512-DUCttfhsnLCjwoDoFcI+B2iJgYa93vBnDUATYEeRx6sntCTdN01VnqsIuTlALXla/LWooNg0yEGeB+Y8WdFxGA==",
+            "version": "6.1.5",
+            "resolved": "https://registry.npmjs.org/tar/-/tar-6.1.5.tgz",
+            "integrity": "sha512-FiK6MQyyaqd5vHuUjbg/NpO8BuEGeSXcmlH7Pt/JkugWS8s0w8nKybWjHDJiwzCAIKZ66uof4ghm4tBADjcqRA==",
             "requires": {
                 "chownr": "^2.0.0",
                 "fs-minipass": "^2.0.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -10521,9 +10521,9 @@
                     }
                 },
                 "ws": {
-                    "version": "5.2.2",
-                    "resolved": "https://registry.npmjs.org/ws/-/ws-5.2.2.tgz",
-                    "integrity": "sha512-jaHFD6PFv6UgoIVda6qZllptQsMlDEJkTQcybzzXDYM1XO9Y8em691FGMPmM46WGyLU4z9KMgQN+qrux/nhlHA==",
+                    "version": "5.2.3",
+                    "resolved": "https://registry.npmjs.org/ws/-/ws-5.2.3.tgz",
+                    "integrity": "sha512-jZArVERrMsKUatIdnLzqvcfydI85dvd/Fp1u/VOpfdDWQ4c9qWXe+VIeAbQ5FrDwciAkr+lzofXLz3Kuf26AOA==",
                     "dev": true,
                     "requires": {
                         "async-limiter": "~1.0.0"
@@ -19523,9 +19523,9 @@
                     }
                 },
                 "ws": {
-                    "version": "6.2.1",
-                    "resolved": "https://registry.npmjs.org/ws/-/ws-6.2.1.tgz",
-                    "integrity": "sha512-GIyAXC2cB7LjvpgMt9EKS2ldqr0MTrORaleiOno6TweZ6r3TKtoFQWay/2PceJ3RuBasOHzXNn5Lrw1X0bEjqA==",
+                    "version": "6.2.2",
+                    "resolved": "https://registry.npmjs.org/ws/-/ws-6.2.2.tgz",
+                    "integrity": "sha512-zmhltoSR8u1cnDsD43TX59mzoMZsLKqUweyYBAIvTngR3shc0W6aOZylZmq/7hqyVxPdi+5Ud2QInblgyE72fw==",
                     "requires": {
                         "async-limiter": "~1.0.0"
                     }
@@ -19969,9 +19969,9 @@
             }
         },
         "ws": {
-            "version": "7.4.5",
-            "resolved": "https://registry.npmjs.org/ws/-/ws-7.4.5.tgz",
-            "integrity": "sha512-xzyu3hFvomRfXKH8vOFMU3OguG6oOvhXMo3xsGy3xWExqaM2dxBbVxuD99O7m3ZUFMvvscsZDqxfgMaRr/Nr1g=="
+            "version": "7.5.3",
+            "resolved": "https://registry.npmjs.org/ws/-/ws-7.5.3.tgz",
+            "integrity": "sha512-kQ/dHIzuLrS6Je9+uv81ueZomEwH0qVYstcAQ4/Z93K8zeko9gtAbttJWzoC5ukqXY1PpoouV3+VSOqEAFt5wg=="
         },
         "xml-name-validator": {
             "version": "3.0.0",

--- a/src/app/personside/infotabs/oppfolging/GetVeileder.test.ts
+++ b/src/app/personside/infotabs/oppfolging/GetVeileder.test.ts
@@ -1,4 +1,4 @@
-import { getVeileder } from './OppfolgingDetaljerKomponent';
+import { getVeileder } from './oppfolging-utils';
 
 test('Viser informasjon om veileder dersom veileder finnes med navn og ident', () => {
     const veilederMedTommeFelter = {
@@ -21,10 +21,10 @@ test('Viser ikke informasjon om veileder med et veilederobjekt med tomme feilter
         navn: '',
         ident: ''
     };
-    expect(getVeileder(veilederMedTommeFelter)).toBeNull();
+    expect(getVeileder(veilederMedTommeFelter)).toBe('\u2014');
 });
 
 test('Viser ikke informasjon om veileder med null-veilederobjekt', () => {
     const nullVeileder = null;
-    expect(getVeileder(nullVeileder)).toBeNull();
+    expect(getVeileder(nullVeileder)).toBe('\u2014');
 });

--- a/src/app/personside/infotabs/oppfolging/OppfolgingDetaljerKomponent.tsx
+++ b/src/app/personside/infotabs/oppfolging/OppfolgingDetaljerKomponent.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { DetaljertOppfolging, Saksbehandler } from '../../../../models/oppfolging';
+import { DetaljertOppfolging } from '../../../../models/oppfolging';
 import styled from 'styled-components/macro';
 import { pxToRem } from '../../../../styles/personOversiktTheme';
 import { Undertittel } from 'nav-frontend-typografi';
@@ -8,6 +8,8 @@ import { datoEllerNull } from '../../../../utils/string-utils';
 import { useRef } from 'react';
 import { guid } from 'nav-frontend-js-utils';
 import Panel from 'nav-frontend-paneler';
+import { getErUnderOppfolging, getOppfolgingEnhet, getVeileder } from './oppfolging-utils';
+import { AlertStripeAdvarsel } from 'nav-frontend-alertstriper';
 
 const StyledPanel = styled(Panel)`
     padding: ${pxToRem(15)};
@@ -17,24 +19,24 @@ const StyledPanel = styled(Panel)`
 `;
 
 interface Props {
-    detaljertOppfølging: DetaljertOppfolging;
+    detaljertOppfolging: DetaljertOppfolging;
 }
 
 function VisOppfolgingDetaljer(props: Props) {
-    const detaljer = props.detaljertOppfølging;
-    const arbeidsrettetOppfølging = detaljer.oppfølging.erUnderOppfølging ? 'Ja' : 'Nei';
-    const oppfølgingsenhet = detaljer.oppfølging.enhet
-        ? `${detaljer.oppfølging.enhet.id} ${detaljer.oppfølging.enhet.navn}`
-        : 'Ikke angitt';
-    const meldeplikt = detaljer.meldeplikt ? 'Ja' : detaljer.meldeplikt === false ? 'Nei' : 'Meldeplikt Ukjent';
     const headerId = useRef(guid());
+    const detaljer = props.detaljertOppfolging;
+    const meldeplikt = detaljer.meldeplikt ? 'Ja' : detaljer.meldeplikt === false ? 'Nei' : 'Meldeplikt Ukjent';
+    const ikkeFullstendigData =
+        detaljer.oppfolging === null ? (
+            <AlertStripeAdvarsel>Kunne ikke hente ut all oppfølgings-informasjon</AlertStripeAdvarsel>
+        ) : null;
 
     const descriptionListProps = {
-        'Er under oppfølging': arbeidsrettetOppfølging,
-        Oppfølgingsenhet: oppfølgingsenhet,
+        'Er under oppfølging': getErUnderOppfolging(detaljer.oppfolging),
+        Oppfølgingsenhet: getOppfolgingEnhet(detaljer.oppfolging),
         Rettighetsgruppe: detaljer.rettighetsgruppe,
         Innsatsgruppe: detaljer.innsatsgruppe,
-        Veileder: getVeileder(detaljer.oppfølging.veileder),
+        Veileder: getVeileder(detaljer.oppfolging?.veileder),
         Meldeplikt: meldeplikt,
         Formidlingsgruppe: detaljer.formidlingsgruppe,
         Oppfølgingsvedtak: datoEllerNull(detaljer.vedtaksdato)
@@ -44,14 +46,11 @@ function VisOppfolgingDetaljer(props: Props) {
         <StyledPanel aria-labelledby={headerId.current}>
             <article>
                 <Undertittel id={headerId.current}>Arbeidsoppfølging</Undertittel>
+                {ikkeFullstendigData}
                 <DescriptionList entries={descriptionListProps} />
             </article>
         </StyledPanel>
     );
-}
-
-export function getVeileder(veileder: Saksbehandler | null) {
-    return veileder && veileder.ident ? veileder.navn + ' (' + veileder.ident + ')' : null;
 }
 
 export default VisOppfolgingDetaljer;

--- a/src/app/personside/infotabs/oppfolging/OppfolgingVisningKomponent.tsx
+++ b/src/app/personside/infotabs/oppfolging/OppfolgingVisningKomponent.tsx
@@ -32,7 +32,7 @@ function OppfolgingVisning(props: VisningProps) {
         <OppfolgingStyle>
             <DetaljertInfoWrapper>
                 <OppfolgingDatoPanel />
-                <VisOppfolgingDetaljer detaljertOppfølging={props.detaljertOppfølging} />
+                <VisOppfolgingDetaljer detaljertOppfolging={props.detaljertOppfølging} />
             </DetaljertInfoWrapper>
             <SykefravarsoppfolgingEkspanderbartPanel syfoPunkter={props.detaljertOppfølging.sykefraværsoppfølging} />
             <OppfolgingYtelserEkspanderbartPanel ytelser={props.detaljertOppfølging.ytelser} />

--- a/src/app/personside/infotabs/oppfolging/oppfolging-utils.ts
+++ b/src/app/personside/infotabs/oppfolging/oppfolging-utils.ts
@@ -1,0 +1,22 @@
+import { Oppfolging, Saksbehandler } from '../../../../models/oppfolging';
+
+export function getErUnderOppfolging(oppfolging: Oppfolging | null): string {
+    if (oppfolging == null) {
+        return '\u2014';
+    }
+    return oppfolging.erUnderOppfolging ? 'Ja' : 'Nei';
+}
+
+export function getOppfolgingEnhet(oppfolging: Oppfolging | null): string {
+    if (oppfolging == null) {
+        return '\u2014';
+    }
+    return oppfolging.enhet ? `${oppfolging.enhet.id} ${oppfolging.enhet.navn}` : 'Ikke angitt';
+}
+
+export function getVeileder(veileder: Saksbehandler | null | undefined): string {
+    if (veileder === null || veileder === undefined || veileder.ident === '') {
+        return '\u2014';
+    }
+    return `${veileder.navn} (${veileder.ident})`;
+}

--- a/src/app/personside/infotabs/oversikt/OppfolgingOversikt.tsx
+++ b/src/app/personside/infotabs/oversikt/OppfolgingOversikt.tsx
@@ -8,9 +8,10 @@ import theme from '../../../../styles/personOversiktTheme';
 import { usePaths } from '../../../routes/routing';
 import { AlertStripeInfo } from 'nav-frontend-alertstriper';
 import CopyToClipboard from '../../visittkort/header/status/CopyToClipboard';
+import { getOppfolgingEnhet, getVeileder } from '../oppfolging/oppfolging-utils';
 
 interface Props {
-    detaljertOppfølging: DetaljertOppfolging;
+    detaljertOppfolging: DetaljertOppfolging;
 }
 
 const onPendingSpinner = <CenteredLazySpinner padding={theme.margin.layout} />;
@@ -20,7 +21,7 @@ function OppfolgingOversikt() {
             getResource={restResources => restResources.oppfolging}
             returnOnPending={onPendingSpinner}
         >
-            {data => <OppfolgingPanel detaljertOppfølging={data} />}
+            {data => <OppfolgingPanel detaljertOppfolging={data} />}
         </RestResourceConsumer>
     );
 }
@@ -28,13 +29,13 @@ function OppfolgingOversikt() {
 function OppfolgingPanel(props: Props) {
     const paths = usePaths();
 
-    if (!props.detaljertOppfølging.oppfølging.erUnderOppfølging) {
+    if (props.detaljertOppfolging.oppfolging !== null && !props.detaljertOppfolging.oppfolging.erUnderOppfolging) {
         return <AlertStripeInfo>Er ikke i arbeidsrettet oppfølging</AlertStripeInfo>;
     }
 
     return (
         <VisMerKnapp linkTo={paths.oppfolging} ariaDescription="Gå til oppfølging" valgt={false}>
-            <OppfolgingVisning detaljertOppfolging={props.detaljertOppfølging} />
+            <OppfolgingVisning detaljertOppfolging={props.detaljertOppfolging} />
         </VisMerKnapp>
     );
 }
@@ -57,46 +58,31 @@ function YtelserForBruker({ detaljertOppfolging }: { detaljertOppfolging: Detalj
 }
 
 function Veileder({ detaljertOppfolging }: { detaljertOppfolging: DetaljertOppfolging }) {
-    const veilederNavn = detaljertOppfolging.oppfølging.veileder ? (
-        <Normaltekst>{detaljertOppfolging.oppfølging.veileder.navn}</Normaltekst>
-    ) : (
-        <Normaltekst>Ikke angitt</Normaltekst>
-    );
-    const veilederIdent = detaljertOppfolging.oppfølging.veileder ? (
-        <Normaltekst>({detaljertOppfolging.oppfølging.veileder.ident})</Normaltekst>
-    ) : null;
     const clipboard =
-        detaljertOppfolging.oppfølging.veileder && detaljertOppfolging.oppfølging.veileder.ident ? (
+        detaljertOppfolging.oppfolging?.veileder && detaljertOppfolging.oppfolging.veileder.ident ? (
             <CopyToClipboard
                 ariaLabel="Kopier veileder"
-                stringToCopy={`${detaljertOppfolging.oppfølging.veileder.navn} (${detaljertOppfolging.oppfølging.veileder.ident})`}
+                stringToCopy={`${detaljertOppfolging.oppfolging.veileder.navn} (${detaljertOppfolging.oppfolging.veileder.ident})`}
             />
         ) : null;
 
     return (
         <>
             <Element>Veileder:</Element>
-            {veilederNavn}
-            {veilederIdent}
+            <Normaltekst>{getVeileder(detaljertOppfolging.oppfolging?.veileder)}</Normaltekst>
             {clipboard}
         </>
     );
 }
 
 function OppfolgingVisning({ detaljertOppfolging }: { detaljertOppfolging: DetaljertOppfolging }) {
-    const enhet = detaljertOppfolging.oppfølging.enhet ? (
-        <Normaltekst>{detaljertOppfolging.oppfølging.enhet.navn}</Normaltekst>
-    ) : (
-        <Normaltekst>Ikke angitt</Normaltekst>
-    );
-
     const innsatsgruppe = detaljertOppfolging.innsatsgruppe;
     const rettighetsgruppe = detaljertOppfolging.rettighetsgruppe;
 
     return (
         <>
             <Element>Oppfølgende enhet:</Element>
-            {enhet}
+            <Normaltekst>{getOppfolgingEnhet(detaljertOppfolging.oppfolging)}</Normaltekst>
             <Veileder detaljertOppfolging={detaljertOppfolging} />
             <Element>Innsatsgruppe / Rettighetsgruppe:</Element>
             <Normaltekst>

--- a/src/mock/oppfolging-mock.ts
+++ b/src/mock/oppfolging-mock.ts
@@ -19,7 +19,7 @@ export function getMockOppfølging(fødselsnummer: string): Oppfolging {
     const erUnderOppfolging = faker.random.boolean();
 
     return {
-        erUnderOppfølging: erUnderOppfolging,
+        erUnderOppfolging: erUnderOppfolging,
         veileder: erUnderOppfolging ? getSaksbehandler() : null,
         enhet: erUnderOppfolging ? getAnsattEnhet() : null
     };
@@ -45,7 +45,7 @@ export function getMockYtelserOgKontrakter(fødselsnummer: string): DetaljertOpp
     navfaker.seed(fødselsnummer + 'oppf');
 
     return {
-        oppfølging: getMockOppfølging(fødselsnummer),
+        oppfolging: getMockOppfølging(fødselsnummer),
         meldeplikt: faker.random.boolean(),
         formidlingsgruppe: 'FMGRP' + faker.random.number(5),
         innsatsgruppe: 'INGRP' + faker.random.number(10),

--- a/src/mock/statiskOppfolgingMock.ts
+++ b/src/mock/statiskOppfolgingMock.ts
@@ -1,8 +1,8 @@
 import { DetaljertOppfolging } from '../models/oppfolging';
 
 export const statiskOppfolgingMock: DetaljertOppfolging = {
-    oppfølging: {
-        erUnderOppfølging: false,
+    oppfolging: {
+        erUnderOppfolging: false,
         veileder: { ident: 'Z0000001', navn: 'Testident Testidentesen' },
         enhet: { id: 'E0001', navn: 'Tangen AS', status: 'ESTAT' }
     },

--- a/src/models/oppfolging.ts
+++ b/src/models/oppfolging.ts
@@ -1,5 +1,5 @@
 export interface Oppfolging {
-    erUnderOppfølging: boolean;
+    erUnderOppfolging: boolean;
     veileder: null | Saksbehandler;
     enhet: null | AnsattEnhet;
 }
@@ -16,7 +16,7 @@ export interface AnsattEnhet {
 }
 
 export interface DetaljertOppfolging {
-    oppfølging: Oppfolging;
+    oppfolging: Oppfolging | null;
     meldeplikt: boolean;
     formidlingsgruppe: string;
     innsatsgruppe: string;


### PR DESCRIPTION
Pga tilgangskontroll i veilarboppfolging så må vi gjøre visning av oppfølging mer robust. Dette gjøres ved å håndtere at `null` fra oppfølgingaApiet, spesialhåndtere dette for å gi feedback til saksbehandler.

Det nye nullable-feltet er en erstatting som også fjerner norske spesialtegn. På sikt blir `oppfølging` feltet fjernet

Avhengig av  https://github.com/navikt/modiapersonoversikt-api/pull/392