### PR TITLE
[OPP-1278] legger til modal for velg sak i infomelding for å unngå scrolling i dialogpanel

### DIFF
--- a/src/app/personside/dialogpanel/__snapshots__/DialogPanel.test.tsx.snap
+++ b/src/app/personside/dialogpanel/__snapshots__/DialogPanel.test.tsx.snap
@@ -662,7 +662,7 @@ exports[`viser dialogpanel 1`] = `
               className="c15"
             >
               <button
-                className="knapp knapp--hoved"
+                className="knapp knapp--hoved knapp--mini"
                 disabled={false}
                 onClick={[Function]}
                 type="submit"

--- a/src/app/personside/dialogpanel/__snapshots__/DialogPanel.test.tsx.snap
+++ b/src/app/personside/dialogpanel/__snapshots__/DialogPanel.test.tsx.snap
@@ -13,36 +13,18 @@ exports[`viser dialogpanel 1`] = `
 }
 
 .c15 {
-  background-color: white;
-  border-radius: .25rem;
-  border: 1px solid #78706a;
-  position: relative;
-}
-
-.c16 {
-  border: none;
-  cursor: pointer;
-  background-color: transparent;
-  padding: 0.5rem;
-  border-radius: .25rem;
-  width: 100%;
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
-  -webkit-box-pack: justify;
-  -webkit-justify-content: space-between;
-  -ms-flex-pack: justify;
-  justify-content: space-between;
   -webkit-align-items: center;
   -webkit-box-align: center;
   -ms-flex-align: center;
   align-items: center;
 }
 
-.c16:focus {
-  outline: none;
-  box-shadow: 0 0 0 0.1875rem #254b6d;
+.c15 > *:not(:last-child) {
+  margin-right: 1rem;
 }
 
 .c7 {
@@ -176,7 +158,7 @@ exports[`viser dialogpanel 1`] = `
   padding: 1rem .5rem;
 }
 
-.c17 {
+.c16 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -186,7 +168,7 @@ exports[`viser dialogpanel 1`] = `
   flex-direction: column;
 }
 
-.c17 > * {
+.c16 > * {
   margin-bottom: 0.7rem;
 }
 
@@ -676,34 +658,23 @@ exports[`viser dialogpanel 1`] = `
                 Gir ikke varsel til bruker
               </div>
             </div>
-            <fieldset
-              aria-invalid={false}
-              className="skjemagruppe"
+            <div
+              className="c15"
             >
-              <div
-                className="c15"
+              <button
+                className="knapp knapp--hoved"
+                disabled={false}
+                onClick={[Function]}
+                type="submit"
               >
-                <button
-                  aria-expanded={false}
-                  className="c16"
-                  onClick={[Function]}
-                  type="button"
-                >
-                  <p
-                    className="typo-normal"
-                  >
-                    Velg sak
-                  </p>
-                  <span
-                    className="nav-frontend-chevron chevronboks chevron--ned"
-                  />
-                </button>
-              </div>
-              <div
-                aria-live="polite"
-                id="Helt tilfeldig ID"
-              />
-            </fieldset>
+                Velg sak
+              </button>
+              <p
+                className="typo-normal"
+              >
+                Ingen valgt sak
+              </p>
+            </div>
             <div
               className="alertstripe c14 alertstripe--info"
             >
@@ -746,7 +717,7 @@ exports[`viser dialogpanel 1`] = `
             </div>
           </div>
           <div
-            className="c17"
+            className="c16"
           >
             <button
               className="knapp knapp--hoved"

--- a/src/app/personside/dialogpanel/sendMelding/DialogpanelVelgSak.tsx
+++ b/src/app/personside/dialogpanel/sendMelding/DialogpanelVelgSak.tsx
@@ -3,7 +3,7 @@ import { createRef, useState } from 'react';
 import { JournalforingsSak } from '../../infotabs/meldinger/traadvisning/verktoylinje/journalforing/JournalforingPanel';
 import VelgSak from '../../infotabs/meldinger/traadvisning/verktoylinje/journalforing/VelgSak';
 import { formatterDatoMedMaanedsnavn } from '../../../../utils/date-utils';
-import { Normaltekst } from 'nav-frontend-typografi';
+import { Normaltekst, Systemtittel } from 'nav-frontend-typografi';
 import styled from 'styled-components/macro';
 import theme from '../../../../styles/personOversiktTheme';
 import { useFodselsnummer, useOnMount } from '../../../../utils/customHooks';
@@ -16,18 +16,6 @@ interface Props {
     setValgtSak: (sak: JournalforingsSak) => void;
     visFeilmelding: boolean;
 }
-
-const Dropdown = styled.div`
-    padding: ${theme.margin.layout};
-    position: absolute;
-    z-index: 1000;
-    background-color: white;
-    border: ${theme.border.skille};
-    border-radius: ${theme.borderRadius.layout};
-    width: 100%;
-    max-height: 50vh;
-    overflow: auto;
-`;
 
 function getTittel(sak: JournalforingsSak) {
     return [sak.opprettetDato && formatterDatoMedMaanedsnavn(sak.opprettetDato), sak.temaNavn, sak.saksIdVisning]
@@ -48,10 +36,15 @@ const StyledModalWrapper = styled(ModalWrapper)`
     }
 `;
 
-const StyledArticle = styled.article`
-    padding: ${theme.margin.layout};
-    min-width: 30rem;
-    min-height: 40rem;
+const Style = styled.section`
+    display: flex;
+    height: 100%;
+    width: 40rem;
+    min-height: 20rem;
+    max-height: 40rem;
+    flex-direction: column;
+    justify-content: space-between;
+    padding: 1rem;
 `;
 
 const StyledDiv = styled.div`
@@ -82,11 +75,11 @@ function DialogpanelVelgSak(props: Props) {
                 <Normaltekst>{tittelDialogpanel}</Normaltekst>
             </StyledDiv>
             <StyledModalWrapper contentLabel="Velg sak" onRequestClose={handleOnClose} isOpen={apen}>
-                <StyledArticle>
-                    <Dropdown>
-                        <VelgSak velgSak={handleVelgSak} valgtSak={props.valgtSak} />
-                    </Dropdown>
-                </StyledArticle>
+                <Systemtittel>Velg sak</Systemtittel>
+                <Style>
+                    <VelgSak velgSak={handleVelgSak} valgtSak={props.valgtSak} />
+                </Style>
+                <Hovedknapp onClick={() => settApen(false)}>Lukk</Hovedknapp>
             </StyledModalWrapper>
         </>
     );

--- a/src/app/personside/dialogpanel/sendMelding/DialogpanelVelgSak.tsx
+++ b/src/app/personside/dialogpanel/sendMelding/DialogpanelVelgSak.tsx
@@ -46,7 +46,7 @@ const Style = styled.section`
     justify-content: space-between;
     padding: 1rem;
     overflow-y: scroll;
-    margin-bottom: 1rem;
+    margin: 1rem;
 `;
 
 const StyledDiv = styled.div`
@@ -74,7 +74,9 @@ function DialogpanelVelgSak(props: Props) {
     return (
         <>
             <StyledDiv>
-                <Hovedknapp onClick={() => settApen(true)}>Velg sak</Hovedknapp>
+                <Hovedknapp mini onClick={() => settApen(true)}>
+                    Velg sak
+                </Hovedknapp>
                 <Normaltekst>{tittelDialogpanel}</Normaltekst>
             </StyledDiv>
             <StyledModalWrapper contentLabel="Velg sak" onRequestClose={handleOnClose} isOpen={apen}>

--- a/src/app/personside/dialogpanel/sendMelding/DialogpanelVelgSak.tsx
+++ b/src/app/personside/dialogpanel/sendMelding/DialogpanelVelgSak.tsx
@@ -45,6 +45,8 @@ const Style = styled.section`
     flex-direction: column;
     justify-content: space-between;
     padding: 1rem;
+    overflow-y: scroll;
+    margin-bottom: 1rem;
 `;
 
 const StyledDiv = styled.div`
@@ -57,14 +59,15 @@ const StyledDiv = styled.div`
 function DialogpanelVelgSak(props: Props) {
     const knappRef = createRef<HTMLButtonElement>();
     usePreFetchJournalforingsSaker();
+    const [apen, settApen] = useState(false);
 
     const handleVelgSak = (sak: JournalforingsSak) => {
+        settApen(false);
         props.setValgtSak(sak);
         knappRef.current && knappRef.current.focus();
     };
 
     const tittelDialogpanel = props.valgtSak ? getTittel(props.valgtSak) : 'Ingen valgt sak';
-    const [apen, settApen] = useState(false);
     const handleOnClose = () => {
         settApen(false);
     };

--- a/src/app/personside/dialogpanel/sendMelding/DialogpanelVelgSak.tsx
+++ b/src/app/personside/dialogpanel/sendMelding/DialogpanelVelgSak.tsx
@@ -3,37 +3,19 @@ import { createRef, useState } from 'react';
 import { JournalforingsSak } from '../../infotabs/meldinger/traadvisning/verktoylinje/journalforing/JournalforingPanel';
 import VelgSak from '../../infotabs/meldinger/traadvisning/verktoylinje/journalforing/VelgSak';
 import { formatterDatoMedMaanedsnavn } from '../../../../utils/date-utils';
-import { SkjemaGruppe } from 'nav-frontend-skjema';
 import { Normaltekst } from 'nav-frontend-typografi';
 import styled from 'styled-components/macro';
-import theme, { pxToRem } from '../../../../styles/personOversiktTheme';
-import { NedChevron, OppChevron } from 'nav-frontend-chevron';
+import theme from '../../../../styles/personOversiktTheme';
 import { useFodselsnummer, useOnMount } from '../../../../utils/customHooks';
-import SkjemaelementFeilmelding from 'nav-frontend-skjema/lib/skjemaelement-feilmelding';
 import * as JournalforingUtils from '../../journalforings-use-fetch-utils';
+import ModalWrapper from 'nav-frontend-modal';
+import { Hovedknapp } from 'nav-frontend-knapper';
 
 interface Props {
     valgtSak?: JournalforingsSak;
     setValgtSak: (sak: JournalforingsSak) => void;
     visFeilmelding: boolean;
 }
-
-const Style = styled.div`
-    background-color: white;
-    border-radius: ${theme.borderRadius.layout};
-    border: 1px solid #78706a;
-    position: relative;
-`;
-
-const Knapp = styled.button`
-    ${theme.resetButtonStyle};
-    padding: ${pxToRem(8)};
-    border-radius: ${theme.borderRadius.layout};
-    width: 100%;
-    display: flex;
-    justify-content: space-between;
-    align-items: center;
-`;
 
 const Dropdown = styled.div`
     padding: ${theme.margin.layout};
@@ -60,37 +42,53 @@ function usePreFetchJournalforingsSaker() {
     });
 }
 
+const StyledModalWrapper = styled(ModalWrapper)`
+    &.modal {
+        background-color: ${theme.color.navLysGra};
+    }
+`;
+
+const StyledArticle = styled.article`
+    padding: ${theme.margin.layout};
+    min-width: 30rem;
+    min-height: 40rem;
+`;
+
+const StyledDiv = styled.div`
+    display: flex;
+    align-items: center;
+    > *:not(:last-child) {
+        margin-right: 1rem;
+    }
+`;
 function DialogpanelVelgSak(props: Props) {
-    const [visSaker, setVisSaker] = useState(false);
     const knappRef = createRef<HTMLButtonElement>();
     usePreFetchJournalforingsSaker();
 
     const handleVelgSak = (sak: JournalforingsSak) => {
-        setVisSaker(false);
         props.setValgtSak(sak);
         knappRef.current && knappRef.current.focus();
     };
 
-    const tittel = props.valgtSak ? getTittel(props.valgtSak) : 'Velg sak';
-
+    const tittelDialogpanel = props.valgtSak ? getTittel(props.valgtSak) : 'Ingen valgt sak';
+    const [apen, settApen] = useState(false);
+    const handleOnClose = () => {
+        settApen(false);
+    };
     return (
-        <SkjemaGruppe
-            feil={
-                props.visFeilmelding ? <SkjemaelementFeilmelding>Du må velge sak </SkjemaelementFeilmelding> : undefined
-            }
-        >
-            <Style>
-                <Knapp ref={knappRef} type="button" onClick={() => setVisSaker(!visSaker)} aria-expanded={visSaker}>
-                    <Normaltekst>{tittel}</Normaltekst>
-                    {visSaker ? <OppChevron /> : <NedChevron />}
-                </Knapp>
-                {visSaker && (
+        <>
+            <StyledDiv>
+                <Hovedknapp onClick={() => settApen(true)}>Velg sak</Hovedknapp>
+                <Normaltekst>{tittelDialogpanel}</Normaltekst>
+            </StyledDiv>
+            <StyledModalWrapper contentLabel="Velg sak" onRequestClose={handleOnClose} isOpen={apen}>
+                <StyledArticle>
                     <Dropdown>
                         <VelgSak velgSak={handleVelgSak} valgtSak={props.valgtSak} />
                     </Dropdown>
-                )}
-            </Style>
-        </SkjemaGruppe>
+                </StyledArticle>
+            </StyledModalWrapper>
+        </>
     );
 }
 

--- a/src/app/personside/dialogpanel/sendMelding/__snapshots__/SendNyMelding.test.tsx.snap
+++ b/src/app/personside/dialogpanel/sendMelding/__snapshots__/SendNyMelding.test.tsx.snap
@@ -13,36 +13,18 @@ exports[`viser send ny melding 1`] = `
 }
 
 .c14 {
-  background-color: white;
-  border-radius: .25rem;
-  border: 1px solid #78706a;
-  position: relative;
-}
-
-.c15 {
-  border: none;
-  cursor: pointer;
-  background-color: transparent;
-  padding: 0.5rem;
-  border-radius: .25rem;
-  width: 100%;
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
-  -webkit-box-pack: justify;
-  -webkit-justify-content: space-between;
-  -ms-flex-pack: justify;
-  justify-content: space-between;
   -webkit-align-items: center;
   -webkit-box-align: center;
   -ms-flex-align: center;
   align-items: center;
 }
 
-.c15:focus {
-  outline: none;
-  box-shadow: 0 0 0 0.1875rem #254b6d;
+.c14 > *:not(:last-child) {
+  margin-right: 1rem;
 }
 
 .c6 {
@@ -176,7 +158,7 @@ exports[`viser send ny melding 1`] = `
   padding: 1rem .5rem;
 }
 
-.c16 {
+.c15 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -186,7 +168,7 @@ exports[`viser send ny melding 1`] = `
   flex-direction: column;
 }
 
-.c16 > * {
+.c15 > * {
   margin-bottom: 0.7rem;
 }
 
@@ -665,34 +647,23 @@ exports[`viser send ny melding 1`] = `
               Gir ikke varsel til bruker
             </div>
           </div>
-          <fieldset
-            aria-invalid={false}
-            className="skjemagruppe"
+          <div
+            className="c14"
           >
-            <div
-              className="c14"
+            <button
+              className="knapp knapp--hoved"
+              disabled={false}
+              onClick={[Function]}
+              type="submit"
             >
-              <button
-                aria-expanded={false}
-                className="c15"
-                onClick={[Function]}
-                type="button"
-              >
-                <p
-                  className="typo-normal"
-                >
-                  Velg sak
-                </p>
-                <span
-                  className="nav-frontend-chevron chevronboks chevron--ned"
-                />
-              </button>
-            </div>
-            <div
-              aria-live="polite"
-              id="Helt tilfeldig ID"
-            />
-          </fieldset>
+              Velg sak
+            </button>
+            <p
+              className="typo-normal"
+            >
+              Ingen valgt sak
+            </p>
+          </div>
           <div
             className="alertstripe c13 alertstripe--info"
           >
@@ -735,7 +706,7 @@ exports[`viser send ny melding 1`] = `
           </div>
         </div>
         <div
-          className="c16"
+          className="c15"
         >
           <button
             className="knapp knapp--hoved"

--- a/src/app/personside/dialogpanel/sendMelding/__snapshots__/SendNyMelding.test.tsx.snap
+++ b/src/app/personside/dialogpanel/sendMelding/__snapshots__/SendNyMelding.test.tsx.snap
@@ -651,7 +651,7 @@ exports[`viser send ny melding 1`] = `
             className="c14"
           >
             <button
-              className="knapp knapp--hoved"
+              className="knapp knapp--hoved knapp--mini"
               disabled={false}
               onClick={[Function]}
               type="submit"


### PR DESCRIPTION
![Skjermbilde 2021-08-27 kl  11 10 41](https://user-images.githubusercontent.com/11627538/131103310-76c4088b-1b45-4261-8c17-f5b0e324ec61.png)
![Skjermbilde 2021-08-27 kl  11 10 29](https://user-images.githubusercontent.com/11627538/131103311-5ff51aa7-b8d6-4f70-a6cc-502b9aafc24d.png)
![Skjermbilde 2021-08-27 kl  11 10 10](https://user-images.githubusercontent.com/11627538/131103313-bd561f8e-6040-40e6-b703-74fdd8e006d3.png)


For å unngå at dialogpanelet fikk dobbel scrolling og ble veldig mye på liten plass valgte jeg å trekke ut velg sak menyen i en modal. 