### PR TITLE
[FAGSYSTEM-185782] forhindre submit ved velgsak

### DIFF
--- a/src/app/personside/dialogpanel/__snapshots__/DialogPanel.test.tsx.snap
+++ b/src/app/personside/dialogpanel/__snapshots__/DialogPanel.test.tsx.snap
@@ -665,7 +665,7 @@ exports[`viser dialogpanel 1`] = `
                 className="knapp knapp--hoved knapp--mini"
                 disabled={false}
                 onClick={[Function]}
-                type="submit"
+                type="button"
               >
                 Velg sak
               </button>

--- a/src/app/personside/dialogpanel/sendMelding/DialogpanelVelgSak.tsx
+++ b/src/app/personside/dialogpanel/sendMelding/DialogpanelVelgSak.tsx
@@ -74,7 +74,7 @@ function DialogpanelVelgSak(props: Props) {
     return (
         <>
             <StyledDiv>
-                <Hovedknapp mini onClick={() => settApen(true)}>
+                <Hovedknapp mini htmlType="button" onClick={() => settApen(true)}>
                     Velg sak
                 </Hovedknapp>
                 <Normaltekst>{tittelDialogpanel}</Normaltekst>

--- a/src/app/personside/dialogpanel/sendMelding/__snapshots__/SendNyMelding.test.tsx.snap
+++ b/src/app/personside/dialogpanel/sendMelding/__snapshots__/SendNyMelding.test.tsx.snap
@@ -654,7 +654,7 @@ exports[`viser send ny melding 1`] = `
               className="knapp knapp--hoved knapp--mini"
               disabled={false}
               onClick={[Function]}
-              type="submit"
+              type="button"
             >
               Velg sak
             </button>


### PR DESCRIPTION
buttons innenfor ett form vil automatisk fungere som en submit knapp om ikke annet er spesifisert. Ved å sette type="button" skrus denne funksjonaliteten av.