### PR TITLE
update/opp 1378

### DIFF
--- a/src/app/personside/dialogpanel/fortsettDialog/BrukerKanSvare.tsx
+++ b/src/app/personside/dialogpanel/fortsettDialog/BrukerKanSvare.tsx
@@ -3,8 +3,8 @@ import Oppgaveliste from '../sendMelding/Oppgaveliste';
 import DialogpanelVelgSak from '../sendMelding/DialogpanelVelgSak';
 import styled from 'styled-components/macro';
 import { FortsettDialogValidator } from './validatorer';
-import { AlertStripeInfo } from 'nav-frontend-alertstriper';
 import { FortsettDialogState } from './FortsettDialogTypes';
+import { SkjemaelementFeilmelding } from 'nav-frontend-skjema';
 
 interface Props {
     formState: FortsettDialogState;
@@ -19,6 +19,7 @@ const Style = styled.div`
 `;
 
 function BrukerKanSvare(props: Props) {
+    const visFeilmelding = !FortsettDialogValidator.sak(props.formState) && props.formState.visFeilmeldinger;
     return (
         <Style>
             <AlertStripeInfo>Gir varsel, bruker kan svare</AlertStripeInfo>
@@ -27,11 +28,14 @@ function BrukerKanSvare(props: Props) {
                 setOppgaveliste={oppgaveliste => props.updateFormState({ oppgaveListe: oppgaveliste })}
             />
             {props.visVelgSak && (
-                <DialogpanelVelgSak
-                    setValgtSak={sak => props.updateFormState({ sak: sak })}
-                    valgtSak={props.formState.sak}
-                    visFeilmelding={!FortsettDialogValidator.sak(props.formState) && props.formState.visFeilmeldinger}
-                />
+                <>
+                    <DialogpanelVelgSak
+                        setValgtSak={sak => props.updateFormState({ sak: sak })}
+                        valgtSak={props.formState.sak}
+                        visFeilmelding={visFeilmelding}
+                    />
+                    {visFeilmelding ? <SkjemaelementFeilmelding>Du må velge sak </SkjemaelementFeilmelding> : null}
+                </>
             )}
         </Style>
     );

--- a/src/app/personside/dialogpanel/fortsettDialog/BrukerKanSvare.tsx
+++ b/src/app/personside/dialogpanel/fortsettDialog/BrukerKanSvare.tsx
@@ -22,7 +22,6 @@ function BrukerKanSvare(props: Props) {
     const visFeilmelding = !FortsettDialogValidator.sak(props.formState) && props.formState.visFeilmeldinger;
     return (
         <Style>
-            <AlertStripeInfo>Gir varsel, bruker kan svare</AlertStripeInfo>
             <Oppgaveliste
                 oppgaveliste={props.formState.oppgaveListe}
                 setOppgaveliste={oppgaveliste => props.updateFormState({ oppgaveListe: oppgaveliste })}

--- a/src/app/personside/dialogpanel/fortsettDialog/FortsettDialog.tsx
+++ b/src/app/personside/dialogpanel/fortsettDialog/FortsettDialog.tsx
@@ -107,6 +107,7 @@ function FortsettDialog(props: Props) {
                     <AlertStripeInfo>Gir ikke varsel</AlertStripeInfo>
                 </UnmountClosed>
                 <UnmountClosed isOpened={brukerKanSvareValg}>
+                    <AlertStripeInfo>Gir varsel, bruker kan svare</AlertStripeInfo>
                     <BrukerKanSvare
                         formState={state}
                         updateFormState={updateState}

--- a/src/app/personside/dialogpanel/fortsettDialog/FortsettDialog.tsx
+++ b/src/app/personside/dialogpanel/fortsettDialog/FortsettDialog.tsx
@@ -24,6 +24,8 @@ import {
 } from '../../infotabs/meldinger/utils/meldingerUtils';
 import { temagruppeTekst, TemaPlukkbare } from '../../../../models/temagrupper';
 import { useRestResource } from '../../../../rest/consumer/useRestResource';
+import useFeatureToggle from '../../../../components/featureToggle/useFeatureToggle';
+import { FeatureToggles } from '../../../../components/featureToggle/toggleIDs';
 
 const SubmitKnapp = styled(Hovedknapp)`
     white-space: normal;
@@ -61,6 +63,7 @@ export const tekstMaksLengde = 5000;
 function FortsettDialog(props: Props) {
     const { state, updateState, handleAvbryt, handleSubmit } = props;
     const personinformasjon = useRestResource(resources => resources.personinformasjon).resource;
+    const usingSFBackend: boolean = useFeatureToggle(FeatureToggles.BrukSalesforceDialoger).isOn ?? false;
     const temagrupperITraad = props.traad.meldinger.map(it => it.temagruppe);
 
     const navn = isLoadedPerson(personinformasjon)
@@ -100,18 +103,30 @@ function FortsettDialog(props: Props) {
                 erSamtalereferat={erSamtalereferat}
             />
             <Margin>
-                <UnmountClosed isOpened={girVarselKanIkkeSvare}>
+                <UnmountClosed isOpened={!usingSFBackend && girVarselKanIkkeSvare}>
                     <AlertStripeInfo>Gir varsel, bruker kan ikke svare</AlertStripeInfo>
                 </UnmountClosed>
-                <UnmountClosed isOpened={girIkkeVarsel}>
+                <UnmountClosed isOpened={!usingSFBackend && girIkkeVarsel}>
                     <AlertStripeInfo>Gir ikke varsel</AlertStripeInfo>
                 </UnmountClosed>
-                <UnmountClosed isOpened={brukerKanSvareValg}>
+                <UnmountClosed isOpened={!usingSFBackend && brukerKanSvareValg}>
                     <AlertStripeInfo>Gir varsel, bruker kan svare</AlertStripeInfo>
                     <BrukerKanSvare
                         formState={state}
                         updateFormState={updateState}
                         visVelgSak={!erEldsteMeldingJournalfort(props.traad) && !erOksosTraad}
+                    />
+                </UnmountClosed>
+                <UnmountClosed isOpened={usingSFBackend && !erSamtalereferat}>
+                    <AlertStripeInfo>Gir varsel, bruker kan svare.</AlertStripeInfo>
+                    <BrukerKanSvare
+                        formState={state}
+                        updateFormState={updateState}
+                        visVelgSak={
+                            !erEldsteMeldingJournalfort(props.traad) &&
+                            !erOksosTraad &&
+                            state.dialogType === Meldingstype.SPORSMAL_MODIA_UTGAAENDE
+                        }
                     />
                 </UnmountClosed>
                 <UnmountClosed isOpened={erDelsvar}>

--- a/src/app/personside/dialogpanel/fortsettDialog/VelgDialogType.tsx
+++ b/src/app/personside/dialogpanel/fortsettDialog/VelgDialogType.tsx
@@ -4,7 +4,7 @@ import { FortsettDialogType } from './FortsettDialogContainer';
 import { Radio } from 'nav-frontend-skjema';
 import { VelgDialogtypeStyle } from '../fellesStyling';
 import { FortsettDialogState } from './FortsettDialogTypes';
-import { useAppState } from '../../../../utils/customHooks';
+import { useAppState, useJustOnceEffect } from '../../../../utils/customHooks';
 import useFeatureToggle from '../../../../components/featureToggle/useFeatureToggle';
 import { FeatureToggles } from '../../../../components/featureToggle/toggleIDs';
 
@@ -21,6 +21,16 @@ interface Props {
 function VelgDialogType(props: Props) {
     const jobberMedSTO = useAppState(state => state.session.jobberMedSTO);
     const usingSFBackend = useFeatureToggle(FeatureToggles.BrukSalesforceDialoger).isOn ?? false;
+    useJustOnceEffect(
+        done => {
+            if (usingSFBackend) {
+                const type = props.erSamtalereferat ? Meldingstype.SAMTALEREFERAT_TELEFON : Meldingstype.SVAR_SKRIFTLIG;
+                props.updateDialogType(type);
+                done();
+            }
+        },
+        [usingSFBackend, props.erSamtalereferat]
+    );
 
     function lagRadio(label: string, type: FortsettDialogType) {
         return (
@@ -40,6 +50,24 @@ function VelgDialogType(props: Props) {
     const svarOppmote = lagRadio('Svar oppmøte', Meldingstype.SVAR_OPPMOTE);
     const referatTelefon = lagRadio('Referat telefon', Meldingstype.SAMTALEREFERAT_TELEFON);
     const referatOppmote = lagRadio('Referat oppmøte', Meldingstype.SAMTALEREFERAT_OPPMOTE);
+
+    if (usingSFBackend) {
+        if (props.erSamtalereferat) {
+            return (
+                <VelgDialogtypeStyle>
+                    {referatTelefon}
+                    {referatOppmote}
+                </VelgDialogtypeStyle>
+            );
+        } else {
+            return (
+                <VelgDialogtypeStyle>
+                    {svar}
+                    {spørsmål}
+                </VelgDialogtypeStyle>
+            );
+        }
+    }
 
     if (props.erDelvisBesvart) {
         return (

--- a/src/app/personside/infotabs/meldinger/traadvisning/verktoylinje/journalforing/SaksTabell.tsx
+++ b/src/app/personside/infotabs/meldinger/traadvisning/verktoylinje/journalforing/SaksTabell.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { MouseEventHandler } from 'react';
 import { JournalforingsSak } from './JournalforingPanel';
 import { ClickableTable } from '../../../../../../../utils/table/ClickableTable';
 
@@ -10,7 +10,12 @@ interface Props {
 function SaksTabell(props: Props) {
     const tittelRekke = ['Saks id', 'Opprettet dato', 'Fagsystem'];
     const rows = props.saker.map(sak => [sak.saksIdVisning, sak.opprettetDatoFormatert, sak.fagsystemNavn]);
-    const handlers = props.saker.map(sak => () => props.velgSak(sak));
+    const handlers: Array<MouseEventHandler> = props.saker.map(sak => {
+        return e => {
+            e.preventDefault();
+            props.velgSak(sak);
+        };
+    });
 
     return <ClickableTable rows={rows} tittelRekke={tittelRekke} rowsOnClickHandlers={handlers} />;
 }

--- a/src/app/personside/infotabs/meldinger/utils/meldingerUtils.ts
+++ b/src/app/personside/infotabs/meldinger/utils/meldingerUtils.ts
@@ -28,14 +28,15 @@ export function kanBesvares(usingSFBackend: boolean, traad?: Traad): boolean {
     const melding = eldsteMelding(traad);
 
     if (usingSFBackend) {
-        const type = [
-            Meldingstype.SPORSMAL_SKRIFTLIG,
-            Meldingstype.SVAR_SBL_INNGAAENDE,
-            Meldingstype.SPORSMAL_MODIA_UTGAAENDE,
-            Meldingstype.SVAR_SKRIFTLIG
-        ].includes(melding.meldingstype);
-        // avsluttetDato betyr at ting er journalført, og kan ikke besvares videre.
-        return !melding.avsluttetDato && type;
+        if (erMeldingstypeSamtalereferat(melding.meldingstype)) {
+            return true;
+        } else {
+            /**
+             * For meldingskjeder i salesforce er det kun mulig å sende oppfølgingsmeldinger
+             * før tråden blir avsluttet. På dette tidspunktet vil tråden bli journalført og låst.
+             */
+            return !melding.avsluttetDato;
+        }
     }
     return KanBesvaresMeldingstyper.includes(melding.meldingstype);
 }

--- a/src/utils/table/Table.tsx
+++ b/src/utils/table/Table.tsx
@@ -1,6 +1,6 @@
 /* eslint-disable jsx-a11y/no-redundant-roles */ // Bruker flex til å style tabell. Da trenger den eksplisitte roller for å funke med skjermleser
 import * as React from 'react';
-import { ReactNode } from 'react';
+import { MouseEventHandler, ReactNode } from 'react';
 import { loggError } from '../logger/frontendLogger';
 
 export type TitleCell = string | ReactNode;
@@ -9,7 +9,7 @@ export type TableCell = string | number | undefined | ReactNode;
 export type TableRow = Array<TableCell>;
 export type TableRows = TableRow[];
 
-export type TableProps = { tittelRekke: TitleRow; rows: TableRows; rowsOnClickHandlers?: Array<() => void> };
+export type TableProps = { tittelRekke: TitleRow; rows: TableRows; rowsOnClickHandlers?: Array<MouseEventHandler> };
 
 export function Table({ tittelRekke, rows, rowsOnClickHandlers }: TableProps) {
     rows.forEach((row: TableRow) => {


### PR DESCRIPTION
- [KAIZEN-0] fikse bug ved velg-sak modalen.
  valg av sak kunne førte til redirect til fremsiden på github-pages versjonen
- [KAIZEN-0] fikset bug ved feilmelding
  ved flytting av "velg sak" inn til modalen ble ikke feilmeldinger korrekt flyttet ut.
  Dette ble fanget opp når man lager en ny tråd, men feilen var fortsatt tilstede ved fortsettelse av tråden.
- [KAIZEN-0] flyttet alertstripe ut slik at de ligger samlet
- [OPP-1378] disabler valg av oppgavebenk ved utsending
  Alle oppgaver blir lagt til enhetens benk av salesforce.
  Vi setter derfor automatisk dette valgt om salesforce FT er aktivert, samt at vi disabler valget om personlig benk.
- [OPP-1378] tilrette for oppfølgsingsreferat
  Oppdatert reglene for nå det vil være mulig å sende en ny melding på en tråd.
  For samtalereferat vil dette alltid være mulig, siden disse journalføres enkeltvis og fortløpende.
  For meldingskjeder vil det kun være mulig frem til tråden blir lukket, e.g avsluttetDato blir da satt
- [OPP-1378] tilpasse informasjon gitt til veileder
  modia og salesforce har litt andre regler mtp utsending av varsel og hvorvidt bruker kan svare på en melding.
  For samtalereferat har bruker ingen mulighet til å svare, men for meldingskjeder er det helt åpent frem til veileder lukker tråden.
- [OPP-1378] tilpasse dialogvalg for salesforce
  Referat kan kun knyttet til eksisterende referat, og spørsmål/svar kan kunn knyttes til meldingskjeder.