### PR TITLE
[OPP-1390] Endrer fullmakter til å ta inn kodebeskrivelse på område

### DIFF
--- a/src/app/personside/visittkort-v2/PersondataDomain.ts
+++ b/src/app/personside/visittkort-v2/PersondataDomain.ts
@@ -153,7 +153,7 @@ export interface Fullmakt {
     motpartsPersonident: string;
     motpartsPersonNavn: Navn;
     motpartsRolle: FullmaktsRolle;
-    omrade: Array<string>;
+    omrade: Array<KodeBeskrivelse<string>>;
     gyldigFraOgMed: LocalDate;
     gyldigTilOgMed: LocalDate;
 }

--- a/src/app/personside/visittkort-v2/body/fullmakt/Fullmakt.tsx
+++ b/src/app/personside/visittkort-v2/body/fullmakt/Fullmakt.tsx
@@ -4,18 +4,18 @@ import { Normaltekst } from 'nav-frontend-typografi';
 import { VisittkortGruppe } from '../VisittkortStyles';
 import Fullmaktlogo from '../../../../../svg/Utropstegn';
 import { formaterDato } from '../../../../../utils/string-utils';
-import { Fullmakt as FullmaktInterface } from '../../PersondataDomain';
+import { Fullmakt as FullmaktInterface, KodeBeskrivelse } from '../../PersondataDomain';
 import { hentNavn } from '../../visittkort-utils';
 
 interface Props {
     fullmakter: FullmaktInterface[];
 }
 
-function getOmrade(omrader: string[]): string {
-    if (omrader.includes('*')) {
+function getOmrade(omrader: KodeBeskrivelse<string>[]): string {
+    if (omrader.map((omrade) => omrade.kode).includes('*')) {
         return 'alle ytelser';
     }
-    return omrader.join(', ');
+    return omrader.map((omrade) => omrade.beskrivelse).join(', ');
 }
 
 function Fullmakt(props: { fullmakt: FullmaktInterface }) {

--- a/src/mock/persondata/aremark.ts
+++ b/src/mock/persondata/aremark.ts
@@ -269,7 +269,12 @@ export const aremark: Person = {
                 etternavn: 'Navnesen'
             },
             motpartsRolle: FullmaktsRolle.FULLMEKTIG,
-            omrade: ['*'],
+            omrade: [
+                {
+                    kode: '*',
+                    beskrivelse: ''
+                }
+            ],
             gyldigFraOgMed: '2015-01-01' as LocalDate,
             gyldigTilOgMed: '2017-12-12' as LocalDate
         }

--- a/src/mock/persondata/personEgenAnsatt.ts
+++ b/src/mock/persondata/personEgenAnsatt.ts
@@ -114,7 +114,12 @@ export const personEgenAnsatt: Person = {
                 etternavn: 'SNERK'
             },
             motpartsRolle: FullmaktsRolle.FULLMEKTIG,
-            omrade: ['Barnetrygd'],
+            omrade: [
+                {
+                    kode: 'BAR',
+                    beskrivelse: 'Barnetrygd'
+                }
+            ],
             gyldigFraOgMed: '2020-03-02' as LocalDate,
             gyldigTilOgMed: '2025-11-13' as LocalDate
         }
@@ -128,8 +133,7 @@ export const personEgenAnsatt: Person = {
                 etternavn: 'LAPP'
             },
             vergesakstype: 'Voksen',
-            omfang:
-                'Ivareta personens interesser innenfor det personlige og økonomiske området herunder utlendingssaken (kun for EMA)',
+            omfang: 'Ivareta personens interesser innenfor det personlige og økonomiske området herunder utlendingssaken (kun for EMA)',
             embete: 'Fylkesmannen i Møre og Romsdal',
             gyldighetstidspunkt: '2021-11-02' as LocalDate,
             opphorstidspunkt: null

--- a/src/mock/persondata/personKode6.ts
+++ b/src/mock/persondata/personKode6.ts
@@ -139,7 +139,12 @@ export const personKode6: Person = {
                 etternavn: 'SNERK'
             },
             motpartsRolle: FullmaktsRolle.FULLMEKTIG,
-            omrade: ['Barnetrygd'],
+            omrade: [
+                {
+                    kode: 'BAR',
+                    beskrivelse: 'Barnetrygd'
+                }
+            ],
             gyldigFraOgMed: '2020-03-02' as LocalDate,
             gyldigTilOgMed: '2025-11-13' as LocalDate
         }
@@ -153,8 +158,7 @@ export const personKode6: Person = {
                 etternavn: 'LAPP'
             },
             vergesakstype: 'Voksen',
-            omfang:
-                'Ivareta personens interesser innenfor det personlige og økonomiske området herunder utlendingssaken (kun for EMA)',
+            omfang: 'Ivareta personens interesser innenfor det personlige og økonomiske området herunder utlendingssaken (kun for EMA)',
             embete: 'Fylkesmannen i Møre og Romsdal',
             gyldighetstidspunkt: '2021-11-02' as LocalDate,
             opphorstidspunkt: null

--- a/src/mock/persondata/personKode6Utland.ts
+++ b/src/mock/persondata/personKode6Utland.ts
@@ -132,7 +132,12 @@ export const personKode6Utland: Person = {
                 etternavn: 'KNOTT'
             },
             motpartsRolle: FullmaktsRolle.FULLMEKTIG,
-            omrade: ['AAP'],
+            omrade: [
+                {
+                    kode: 'AAP',
+                    beskrivelse: 'Arbeidsavklaringspenger'
+                }
+            ],
             gyldigFraOgMed: '2021-10-28' as LocalDate,
             gyldigTilOgMed: '2021-12-28' as LocalDate
         }

--- a/src/mock/persondata/persondata.ts
+++ b/src/mock/persondata/persondata.ts
@@ -274,7 +274,12 @@ function lagPerson(fnr: string): Person {
                           etternavn: 'Navnesen'
                       },
                       motpartsRolle: FullmaktsRolle.FULLMEKTIG,
-                      omrade: ['*'],
+                      omrade: [
+                          {
+                              kode: '*',
+                              beskrivelse: ''
+                          }
+                      ],
                       gyldigFraOgMed: '2015-01-01' as LocalDate,
                       gyldigTilOgMed: '2017-12-12' as LocalDate
                   }


### PR DESCRIPTION
Gjør dette slik at vi kan hente beskrivelsen fra kodeverk i stedet for å kun vise koden i frontend