### PR TITLE
[OPP-1390] nye felter på foreldreansvar

### DIFF
--- a/src/app/personside/visittkort-v2/PersondataDomain.ts
+++ b/src/app/personside/visittkort-v2/PersondataDomain.ts
@@ -177,8 +177,13 @@ export interface Verge {
 
 export interface Foreldreansvar {
     ansvar: string;
-    ansvarlig: Navn | null;
-    ansvarsubject: Navn | null;
+    ansvarlig: NavnOgIdent | null;
+    ansvarsubject: NavnOgIdent | null;
+}
+
+export interface NavnOgIdent {
+    navn: Navn | null;
+    ident: string | null;
 }
 
 export interface DeltBosted {

--- a/src/app/personside/visittkort-v2/body/__snapshots__/VisittkortBody.test.tsx.snap
+++ b/src/app/personside/visittkort-v2/body/__snapshots__/VisittkortBody.test.tsx.snap
@@ -1008,15 +1008,35 @@ exports[`viser info om bruker i visittkortbody 1`] = `
         <p
           className="typo-normal"
         >
-          Test Testesen
-          (
+          Ansvar: 
           felles
-          )
         </p>
         <p
           className="typo-normal"
         >
-          Gjelder for: Barn Barnesen
+          Gjelder for: 
+          BARN1 BARNESEN (12345678910)
+        </p>
+      </div>
+      <div
+        className="c4"
+      >
+        <div
+          className="c2"
+        >
+          
+        </div>
+        <p
+          className="typo-normal"
+        >
+          Ansvar: 
+          felles
+        </p>
+        <p
+          className="typo-normal"
+        >
+          Gjelder for: 
+          BARN1 BARNESEN (12345678911)
         </p>
       </div>
     </section>

--- a/src/app/personside/visittkort-v2/body/foreldreansvar/Foreldreansvar.tsx
+++ b/src/app/personside/visittkort-v2/body/foreldreansvar/Foreldreansvar.tsx
@@ -3,24 +3,31 @@ import { VisittkortGruppe } from '../VisittkortStyles';
 import VisittkortElement from '../VisittkortElement';
 import { Normaltekst } from 'nav-frontend-typografi';
 import Infotegn from '../../../../../svg/Info';
-import { Foreldreansvar } from '../../PersondataDomain';
+import { Foreldreansvar, NavnOgIdent } from '../../PersondataDomain';
 import { hentNavn } from '../../visittkort-utils';
 
 interface Props {
     foreldreansvar: Foreldreansvar[];
 }
 
+function kombinerNavnOgIdent(personInfo: NavnOgIdent | null): string | null {
+    if (!personInfo) {
+        return null;
+    }
+    const navn = hentNavn(personInfo.navn);
+    return personInfo.navn ? `${navn} (${personInfo.ident})` : navn;
+}
+
 function ForeldreansvarElement(props: { foreldreansvar: Foreldreansvar }) {
-    const ansvarlig = hentNavn(props.foreldreansvar.ansvarlig);
-    const ansvar = props.foreldreansvar.ansvar;
-    const gjelder =
-        props.foreldreansvar.ansvarsubject && `Gjelder for: ${hentNavn(props.foreldreansvar.ansvarsubject)}`;
+    const { foreldreansvar } = props;
+    const ansvarlig = kombinerNavnOgIdent(foreldreansvar.ansvarlig);
+    const ansvarsubject = kombinerNavnOgIdent(foreldreansvar.ansvarsubject);
+
     return (
         <VisittkortElement>
-            <Normaltekst>
-                {ansvarlig}({ansvar})
-            </Normaltekst>
-            <Normaltekst>{gjelder}</Normaltekst>
+            <Normaltekst>Ansvar: {foreldreansvar.ansvar}</Normaltekst>
+            {ansvarlig && <Normaltekst>Ansvarlig: {ansvarlig}</Normaltekst>}
+            {ansvarsubject && <Normaltekst>Gjelder for: {ansvarsubject}</Normaltekst>}
         </VisittkortElement>
     );
 }

--- a/src/app/personside/visittkort-v2/body/foreldreansvar/__snapshots__/Foreldreansvar.test.tsx.snap
+++ b/src/app/personside/visittkort-v2/body/foreldreansvar/__snapshots__/Foreldreansvar.test.tsx.snap
@@ -86,15 +86,35 @@ exports[`viser foreldreansvar 1`] = `
     <p
       className="typo-normal"
     >
-      Test Testesen
-      (
+      Ansvar: 
       felles
-      )
     </p>
     <p
       className="typo-normal"
     >
-      Gjelder for: Barn Barnesen
+      Gjelder for: 
+      BARN1 BARNESEN (12345678910)
+    </p>
+  </div>
+  <div
+    className="c3"
+  >
+    <div
+      className="c0"
+    >
+      
+    </div>
+    <p
+      className="typo-normal"
+    >
+      Ansvar: 
+      felles
+    </p>
+    <p
+      className="typo-normal"
+    >
+      Gjelder for: 
+      BARN1 BARNESEN (12345678911)
     </p>
   </div>
 </section>

--- a/src/app/personside/visittkort-v2/visittkort-utils.ts
+++ b/src/app/personside/visittkort-v2/visittkort-utils.ts
@@ -17,7 +17,7 @@ function erDod(person: Person) {
 }
 
 export function hentBarnUnder22(forelderBarnRelasjon: ForelderBarnRelasjon[]) {
-    return forelderBarnRelasjon.filter(barn => hentAlderOrDefault(barn) <= 21);
+    return hentBarn(forelderBarnRelasjon).filter(barn => hentAlderOrDefault(barn) <= 21);
 }
 
 export function hentBarn(forelderBarnRelasjon: ForelderBarnRelasjon[]) {

--- a/src/mock/persondata/aremark.ts
+++ b/src/mock/persondata/aremark.ts
@@ -203,21 +203,14 @@ export const aremark: Person = {
             }
         }
     ],
-    foreldreansvar: [
-        {
-            ansvar: 'felles',
-            ansvarlig: {
-                fornavn: 'Test',
-                etternavn: 'Testesen',
-                mellomnavn: null
-            },
-            ansvarsubject: {
-                fornavn: 'Barn',
-                etternavn: 'Barnesen',
-                mellomnavn: null
-            }
+    foreldreansvar: barnAremark.map(barn => ({
+        ansvar: 'felles',
+        ansvarlig: null,
+        ansvarsubject: {
+            navn: barn.navn.firstOrNull(),
+            ident: barn.ident
         }
-    ],
+    })),
     deltBosted: [
         {
             startdatoForKontrakt: '2000-10-10' as LocalDate,

--- a/src/mock/persondata/personDeltBosted.ts
+++ b/src/mock/persondata/personDeltBosted.ts
@@ -1,5 +1,6 @@
 import {
     EgenAnsatt,
+    ForelderBarnRelasjon,
     ForelderBarnRelasjonRolle,
     Kjonn,
     LocalDate,
@@ -8,6 +9,63 @@ import {
     PersonStatus,
     SivilstandType
 } from '../../app/personside/visittkort-v2/PersondataDomain';
+
+const forelderBarnRelasjonMock: ForelderBarnRelasjon[] = [
+    {
+        ident: '24835498561',
+        rolle: ForelderBarnRelasjonRolle.FAR,
+        navn: [
+            {
+                fornavn: 'ALFABETISK',
+                mellomnavn: null,
+                etternavn: 'KLASSE'
+            }
+        ],
+        fodselsdato: ['1954-03-24' as LocalDate],
+        kjonn: [
+            {
+                kode: Kjonn.M,
+                beskrivelse: 'Mann'
+            }
+        ],
+        alder: 67,
+        adressebeskyttelse: [],
+        harSammeAdresse: true,
+        personstatus: [
+            {
+                kode: PersonStatus.BOSATT,
+                beskrivelse: 'Bosatt'
+            }
+        ]
+    },
+    {
+        ident: '09884397631',
+        rolle: ForelderBarnRelasjonRolle.MOR,
+        navn: [
+            {
+                fornavn: 'LATTERMILD',
+                mellomnavn: null,
+                etternavn: 'HAKKE'
+            }
+        ],
+        fodselsdato: ['1943-08-09' as LocalDate],
+        kjonn: [
+            {
+                kode: Kjonn.K,
+                beskrivelse: 'Kvinne'
+            }
+        ],
+        alder: 78,
+        adressebeskyttelse: [],
+        harSammeAdresse: false,
+        personstatus: [
+            {
+                kode: PersonStatus.BOSATT,
+                beskrivelse: 'Bosatt'
+            }
+        ]
+    }
+];
 
 export const personDeltBosted: Person = {
     fnr: '01021865210',
@@ -120,18 +178,16 @@ export const personDeltBosted: Person = {
             sivilstandRelasjon: null
         }
     ],
-    foreldreansvar: [
-        {
+    foreldreansvar: forelderBarnRelasjonMock
+        .filter(relasjon => relasjon.rolle !== ForelderBarnRelasjonRolle.BARN)
+        .map(forelder => ({
             ansvar: 'felles',
-            ansvarlig: null,
+            ansvarlig: {
+                navn: forelder.navn.firstOrNull(),
+                ident: forelder.ident
+            },
             ansvarsubject: null
-        },
-        {
-            ansvar: 'felles',
-            ansvarlig: null,
-            ansvarsubject: null
-        }
-    ],
+        })),
     deltBosted: [
         {
             startdatoForKontrakt: '2021-02-10' as LocalDate,
@@ -188,60 +244,5 @@ export const personDeltBosted: Person = {
             beskrivelse: 'Norske kroner'
         }
     },
-    forelderBarnRelasjon: [
-        {
-            ident: '24835498561',
-            rolle: ForelderBarnRelasjonRolle.FAR,
-            navn: [
-                {
-                    fornavn: 'ALFABETISK',
-                    mellomnavn: null,
-                    etternavn: 'KLASSE'
-                }
-            ],
-            fodselsdato: ['1954-03-24' as LocalDate],
-            kjonn: [
-                {
-                    kode: Kjonn.M,
-                    beskrivelse: 'Mann'
-                }
-            ],
-            alder: 67,
-            adressebeskyttelse: [],
-            harSammeAdresse: true,
-            personstatus: [
-                {
-                    kode: PersonStatus.BOSATT,
-                    beskrivelse: 'Bosatt'
-                }
-            ]
-        },
-        {
-            ident: '09884397631',
-            rolle: ForelderBarnRelasjonRolle.MOR,
-            navn: [
-                {
-                    fornavn: 'LATTERMILD',
-                    mellomnavn: null,
-                    etternavn: 'HAKKE'
-                }
-            ],
-            fodselsdato: ['1943-08-09' as LocalDate],
-            kjonn: [
-                {
-                    kode: Kjonn.K,
-                    beskrivelse: 'Kvinne'
-                }
-            ],
-            alder: 78,
-            adressebeskyttelse: [],
-            harSammeAdresse: false,
-            personstatus: [
-                {
-                    kode: PersonStatus.BOSATT,
-                    beskrivelse: 'Bosatt'
-                }
-            ]
-        }
-    ]
+    forelderBarnRelasjon: forelderBarnRelasjonMock
 };

--- a/src/mock/persondata/personDod.ts
+++ b/src/mock/persondata/personDod.ts
@@ -99,21 +99,7 @@ export const personDod: Person = {
             }
         }
     ],
-    foreldreansvar: [
-        {
-            ansvar: 'felles',
-            ansvarlig: {
-                fornavn: 'GØYAL',
-                mellomnavn: 'MÅPENDE',
-                etternavn: 'TRANFLASKE'
-            },
-            ansvarsubject: {
-                fornavn: 'LITEN',
-                mellomnavn: 'GYNGENDE',
-                etternavn: 'VEGGPRYD'
-            }
-        }
-    ],
+    foreldreansvar: [],
     deltBosted: [],
     dodsbo: [
         {

--- a/src/mock/persondata/personEgenAnsatt.ts
+++ b/src/mock/persondata/personEgenAnsatt.ts
@@ -11,6 +11,68 @@ import {
     SivilstandType
 } from '../../app/personside/visittkort-v2/PersondataDomain';
 
+const forelderBarnRelasjonMock = [
+    {
+        ident: '',
+        rolle: ForelderBarnRelasjonRolle.MOR,
+        navn: [],
+        fodselsdato: [],
+        kjonn: [],
+        alder: null,
+        adressebeskyttelse: [
+            {
+                kode: AdresseBeskyttelse.KODE6_UTLAND,
+                beskrivelse: 'Sperret adresse, strengt fortrolig'
+            }
+        ],
+        harSammeAdresse: false,
+        personstatus: []
+    },
+    {
+        ident: '26115122184',
+        rolle: ForelderBarnRelasjonRolle.FAR,
+        navn: [
+            {
+                fornavn: 'LUGUBER',
+                mellomnavn: 'LURENDE',
+                etternavn: 'KAMELEON'
+            }
+        ],
+        fodselsdato: ['1951-11-26' as LocalDate],
+        kjonn: [
+            {
+                kode: Kjonn.M,
+                beskrivelse: 'Mann'
+            }
+        ],
+        alder: 69,
+        adressebeskyttelse: [],
+        harSammeAdresse: false,
+        personstatus: [
+            {
+                kode: PersonStatus.BOSATT,
+                beskrivelse: 'Bosatt'
+            }
+        ]
+    },
+    {
+        ident: '',
+        rolle: ForelderBarnRelasjonRolle.BARN,
+        navn: [],
+        fodselsdato: [],
+        kjonn: [],
+        alder: null,
+        adressebeskyttelse: [
+            {
+                kode: AdresseBeskyttelse.KODE6,
+                beskrivelse: 'Sperret adresse, strengt fortrolig'
+            }
+        ],
+        harSammeAdresse: false,
+        personstatus: []
+    }
+];
+
 export const personEgenAnsatt: Person = {
     fnr: '05018811814',
     navn: [
@@ -92,17 +154,16 @@ export const personEgenAnsatt: Person = {
             }
         }
     ],
-    foreldreansvar: [
-        {
+    foreldreansvar: forelderBarnRelasjonMock
+        .filter(relasjon => relasjon.rolle === ForelderBarnRelasjonRolle.BARN)
+        .map(barn => ({
             ansvar: 'felles',
             ansvarlig: null,
             ansvarsubject: {
-                fornavn: 'ARTIG',
-                mellomnavn: 'SKJELVENDE',
-                etternavn: 'RHODODENRON'
+                navn: barn.navn.firstOrNull(),
+                ident: barn.ident
             }
-        }
-    ],
+        })),
     deltBosted: [],
     dodsbo: [],
     fullmakt: [
@@ -133,7 +194,8 @@ export const personEgenAnsatt: Person = {
                 etternavn: 'LAPP'
             },
             vergesakstype: 'Voksen',
-            omfang: 'Ivareta personens interesser innenfor det personlige og økonomiske området herunder utlendingssaken (kun for EMA)',
+            omfang:
+                'Ivareta personens interesser innenfor det personlige og økonomiske området herunder utlendingssaken (kun for EMA)',
             embete: 'Fylkesmannen i Møre og Romsdal',
             gyldighetstidspunkt: '2021-11-02' as LocalDate,
             opphorstidspunkt: null
@@ -196,65 +258,5 @@ export const personEgenAnsatt: Person = {
         }
     },
     bankkonto: null,
-    forelderBarnRelasjon: [
-        {
-            ident: '',
-            rolle: ForelderBarnRelasjonRolle.MOR,
-            navn: [],
-            fodselsdato: [],
-            kjonn: [],
-            alder: null,
-            adressebeskyttelse: [
-                {
-                    kode: AdresseBeskyttelse.KODE6_UTLAND,
-                    beskrivelse: 'Sperret adresse, strengt fortrolig'
-                }
-            ],
-            harSammeAdresse: false,
-            personstatus: []
-        },
-        {
-            ident: '26115122184',
-            rolle: ForelderBarnRelasjonRolle.FAR,
-            navn: [
-                {
-                    fornavn: 'LUGUBER',
-                    mellomnavn: 'LURENDE',
-                    etternavn: 'KAMELEON'
-                }
-            ],
-            fodselsdato: ['1951-11-26' as LocalDate],
-            kjonn: [
-                {
-                    kode: Kjonn.M,
-                    beskrivelse: 'Mann'
-                }
-            ],
-            alder: 69,
-            adressebeskyttelse: [],
-            harSammeAdresse: false,
-            personstatus: [
-                {
-                    kode: PersonStatus.BOSATT,
-                    beskrivelse: 'Bosatt'
-                }
-            ]
-        },
-        {
-            ident: '',
-            rolle: ForelderBarnRelasjonRolle.BARN,
-            navn: [],
-            fodselsdato: [],
-            kjonn: [],
-            alder: null,
-            adressebeskyttelse: [
-                {
-                    kode: AdresseBeskyttelse.KODE6,
-                    beskrivelse: 'Sperret adresse, strengt fortrolig'
-                }
-            ],
-            harSammeAdresse: false,
-            personstatus: []
-        }
-    ]
+    forelderBarnRelasjon: forelderBarnRelasjonMock
 };

--- a/src/mock/persondata/personKode6.ts
+++ b/src/mock/persondata/personKode6.ts
@@ -11,6 +11,196 @@ import {
     SivilstandType
 } from '../../app/personside/visittkort-v2/PersondataDomain';
 
+const forelderBarnRelasjonMock = [
+    {
+        ident: '25075405645',
+        rolle: ForelderBarnRelasjonRolle.MOR,
+        navn: [
+            {
+                fornavn: 'RASK',
+                mellomnavn: 'SLØVENDE',
+                etternavn: 'BUSK'
+            }
+        ],
+        fodselsdato: ['1954-07-25' as LocalDate],
+        kjonn: [
+            {
+                kode: Kjonn.K,
+                beskrivelse: 'Kvinne'
+            }
+        ],
+        alder: 67,
+        adressebeskyttelse: [
+            {
+                kode: AdresseBeskyttelse.KODE6_UTLAND,
+                beskrivelse: 'Sperret adresse, strengt fortrolig'
+            }
+        ],
+        harSammeAdresse: false,
+        personstatus: [
+            {
+                kode: PersonStatus.BOSATT,
+                beskrivelse: 'Bosatt'
+            }
+        ]
+    },
+    {
+        ident: '13022081416',
+        rolle: ForelderBarnRelasjonRolle.BARN,
+        navn: [
+            {
+                fornavn: 'GØYAL',
+                mellomnavn: 'TIKKENDE',
+                etternavn: 'MULDVARP'
+            }
+        ],
+        fodselsdato: ['2020-02-13' as LocalDate],
+        kjonn: [
+            {
+                kode: Kjonn.K,
+                beskrivelse: 'Kvinne'
+            }
+        ],
+        alder: 1,
+        adressebeskyttelse: [],
+        harSammeAdresse: false,
+        personstatus: [
+            {
+                kode: PersonStatus.DOD,
+                beskrivelse: 'Død'
+            }
+        ]
+    },
+    {
+        ident: '03060777011',
+        rolle: ForelderBarnRelasjonRolle.BARN,
+        navn: [
+            {
+                fornavn: 'ARTIG',
+                mellomnavn: 'SKJELVENDE',
+                etternavn: 'RHODODENRON'
+            }
+        ],
+        fodselsdato: ['2007-06-03' as LocalDate],
+        kjonn: [
+            {
+                kode: Kjonn.K,
+                beskrivelse: 'Kvinne'
+            }
+        ],
+        alder: 14,
+        adressebeskyttelse: [
+            {
+                kode: AdresseBeskyttelse.KODE6,
+                beskrivelse: 'Sperret adresse, strengt fortrolig'
+            }
+        ],
+        harSammeAdresse: false,
+        personstatus: [
+            {
+                kode: PersonStatus.BOSATT,
+                beskrivelse: 'Bosatt'
+            }
+        ]
+    },
+    {
+        ident: '26115122184',
+        rolle: ForelderBarnRelasjonRolle.FAR,
+        navn: [
+            {
+                fornavn: 'LUGUBER',
+                mellomnavn: 'LURENDE',
+                etternavn: 'KAMELEON'
+            }
+        ],
+        fodselsdato: ['1951-11-26' as LocalDate],
+        kjonn: [
+            {
+                kode: Kjonn.M,
+                beskrivelse: 'Mann'
+            }
+        ],
+        alder: 69,
+        adressebeskyttelse: [
+            {
+                kode: AdresseBeskyttelse.KODE6_UTLAND,
+                beskrivelse: 'Sperret adresse, strengt fortrolig'
+            }
+        ],
+        harSammeAdresse: false,
+        personstatus: [
+            {
+                kode: PersonStatus.BOSATT,
+                beskrivelse: 'Bosatt'
+            }
+        ]
+    },
+    {
+        ident: '10050550120',
+        rolle: ForelderBarnRelasjonRolle.BARN,
+        navn: [
+            {
+                fornavn: 'ROBUST',
+                mellomnavn: 'DANSENDE',
+                etternavn: 'VEPS'
+            }
+        ],
+        fodselsdato: ['2005-05-10' as LocalDate],
+        kjonn: [
+            {
+                kode: Kjonn.M,
+                beskrivelse: 'Mann'
+            }
+        ],
+        alder: 16,
+        adressebeskyttelse: [
+            {
+                kode: AdresseBeskyttelse.KODE7,
+                beskrivelse: 'Sperret adresse, fortrolig'
+            }
+        ],
+        harSammeAdresse: false,
+        personstatus: [
+            {
+                kode: PersonStatus.BOSATT,
+                beskrivelse: 'Bosatt'
+            }
+        ]
+    },
+    {
+        ident: '23060450188',
+        rolle: ForelderBarnRelasjonRolle.BARN,
+        navn: [
+            {
+                fornavn: 'TRIVIELL',
+                mellomnavn: 'DRØVTYGGENDE',
+                etternavn: 'VEPS'
+            }
+        ],
+        fodselsdato: ['2004-06-23' as LocalDate],
+        kjonn: [
+            {
+                kode: Kjonn.M,
+                beskrivelse: 'Mann'
+            }
+        ],
+        alder: 17,
+        adressebeskyttelse: [
+            {
+                kode: AdresseBeskyttelse.KODE6,
+                beskrivelse: 'Sperret adresse, strengt fortrolig'
+            }
+        ],
+        harSammeAdresse: false,
+        personstatus: [
+            {
+                kode: PersonStatus.BOSATT,
+                beskrivelse: 'Bosatt'
+            }
+        ]
+    }
+];
+
 export const personKode6: Person = {
     fnr: '03016516057',
     navn: [
@@ -90,44 +280,16 @@ export const personKode6: Person = {
             }
         }
     ],
-    foreldreansvar: [
-        {
+    foreldreansvar: forelderBarnRelasjonMock
+        .filter(relasjon => relasjon.rolle === ForelderBarnRelasjonRolle.BARN)
+        .map(barn => ({
             ansvar: 'felles',
             ansvarlig: null,
             ansvarsubject: {
-                fornavn: 'ARTIG',
-                mellomnavn: 'SKJELVENDE',
-                etternavn: 'RHODODENRON'
+                navn: barn.navn.firstOrNull(),
+                ident: barn.ident
             }
-        },
-        {
-            ansvar: 'felles',
-            ansvarlig: null,
-            ansvarsubject: {
-                fornavn: 'ROBUST',
-                mellomnavn: 'DANSENDE',
-                etternavn: 'VEPS'
-            }
-        },
-        {
-            ansvar: 'felles',
-            ansvarlig: null,
-            ansvarsubject: {
-                fornavn: 'GØYAL',
-                mellomnavn: 'TIKKENDE',
-                etternavn: 'MULDVARP'
-            }
-        },
-        {
-            ansvar: 'felles',
-            ansvarlig: null,
-            ansvarsubject: {
-                fornavn: 'TRIVIELL',
-                mellomnavn: 'DRØVTYGGENDE',
-                etternavn: 'VEPS'
-            }
-        }
-    ],
+        })),
     deltBosted: [],
     dodsbo: [],
     fullmakt: [
@@ -158,7 +320,8 @@ export const personKode6: Person = {
                 etternavn: 'LAPP'
             },
             vergesakstype: 'Voksen',
-            omfang: 'Ivareta personens interesser innenfor det personlige og økonomiske området herunder utlendingssaken (kun for EMA)',
+            omfang:
+                'Ivareta personens interesser innenfor det personlige og økonomiske området herunder utlendingssaken (kun for EMA)',
             embete: 'Fylkesmannen i Møre og Romsdal',
             gyldighetstidspunkt: '2021-11-02' as LocalDate,
             opphorstidspunkt: null
@@ -211,193 +374,5 @@ export const personKode6: Person = {
         }
     },
     bankkonto: null,
-    forelderBarnRelasjon: [
-        {
-            ident: '25075405645',
-            rolle: ForelderBarnRelasjonRolle.MOR,
-            navn: [
-                {
-                    fornavn: 'RASK',
-                    mellomnavn: 'SLØVENDE',
-                    etternavn: 'BUSK'
-                }
-            ],
-            fodselsdato: ['1954-07-25' as LocalDate],
-            kjonn: [
-                {
-                    kode: Kjonn.K,
-                    beskrivelse: 'Kvinne'
-                }
-            ],
-            alder: 67,
-            adressebeskyttelse: [
-                {
-                    kode: AdresseBeskyttelse.KODE6_UTLAND,
-                    beskrivelse: 'Sperret adresse, strengt fortrolig'
-                }
-            ],
-            harSammeAdresse: false,
-            personstatus: [
-                {
-                    kode: PersonStatus.BOSATT,
-                    beskrivelse: 'Bosatt'
-                }
-            ]
-        },
-        {
-            ident: '13022081416',
-            rolle: ForelderBarnRelasjonRolle.BARN,
-            navn: [
-                {
-                    fornavn: 'GØYAL',
-                    mellomnavn: 'TIKKENDE',
-                    etternavn: 'MULDVARP'
-                }
-            ],
-            fodselsdato: ['2020-02-13' as LocalDate],
-            kjonn: [
-                {
-                    kode: Kjonn.K,
-                    beskrivelse: 'Kvinne'
-                }
-            ],
-            alder: 1,
-            adressebeskyttelse: [],
-            harSammeAdresse: false,
-            personstatus: [
-                {
-                    kode: PersonStatus.DOD,
-                    beskrivelse: 'Død'
-                }
-            ]
-        },
-        {
-            ident: '03060777011',
-            rolle: ForelderBarnRelasjonRolle.BARN,
-            navn: [
-                {
-                    fornavn: 'ARTIG',
-                    mellomnavn: 'SKJELVENDE',
-                    etternavn: 'RHODODENRON'
-                }
-            ],
-            fodselsdato: ['2007-06-03' as LocalDate],
-            kjonn: [
-                {
-                    kode: Kjonn.K,
-                    beskrivelse: 'Kvinne'
-                }
-            ],
-            alder: 14,
-            adressebeskyttelse: [
-                {
-                    kode: AdresseBeskyttelse.KODE6,
-                    beskrivelse: 'Sperret adresse, strengt fortrolig'
-                }
-            ],
-            harSammeAdresse: false,
-            personstatus: [
-                {
-                    kode: PersonStatus.BOSATT,
-                    beskrivelse: 'Bosatt'
-                }
-            ]
-        },
-        {
-            ident: '26115122184',
-            rolle: ForelderBarnRelasjonRolle.FAR,
-            navn: [
-                {
-                    fornavn: 'LUGUBER',
-                    mellomnavn: 'LURENDE',
-                    etternavn: 'KAMELEON'
-                }
-            ],
-            fodselsdato: ['1951-11-26' as LocalDate],
-            kjonn: [
-                {
-                    kode: Kjonn.M,
-                    beskrivelse: 'Mann'
-                }
-            ],
-            alder: 69,
-            adressebeskyttelse: [
-                {
-                    kode: AdresseBeskyttelse.KODE6_UTLAND,
-                    beskrivelse: 'Sperret adresse, strengt fortrolig'
-                }
-            ],
-            harSammeAdresse: false,
-            personstatus: [
-                {
-                    kode: PersonStatus.BOSATT,
-                    beskrivelse: 'Bosatt'
-                }
-            ]
-        },
-        {
-            ident: '10050550120',
-            rolle: ForelderBarnRelasjonRolle.BARN,
-            navn: [
-                {
-                    fornavn: 'ROBUST',
-                    mellomnavn: 'DANSENDE',
-                    etternavn: 'VEPS'
-                }
-            ],
-            fodselsdato: ['2005-05-10' as LocalDate],
-            kjonn: [
-                {
-                    kode: Kjonn.M,
-                    beskrivelse: 'Mann'
-                }
-            ],
-            alder: 16,
-            adressebeskyttelse: [
-                {
-                    kode: AdresseBeskyttelse.KODE7,
-                    beskrivelse: 'Sperret adresse, fortrolig'
-                }
-            ],
-            harSammeAdresse: false,
-            personstatus: [
-                {
-                    kode: PersonStatus.BOSATT,
-                    beskrivelse: 'Bosatt'
-                }
-            ]
-        },
-        {
-            ident: '23060450188',
-            rolle: ForelderBarnRelasjonRolle.BARN,
-            navn: [
-                {
-                    fornavn: 'TRIVIELL',
-                    mellomnavn: 'DRØVTYGGENDE',
-                    etternavn: 'VEPS'
-                }
-            ],
-            fodselsdato: ['2004-06-23' as LocalDate],
-            kjonn: [
-                {
-                    kode: Kjonn.M,
-                    beskrivelse: 'Mann'
-                }
-            ],
-            alder: 17,
-            adressebeskyttelse: [
-                {
-                    kode: AdresseBeskyttelse.KODE6,
-                    beskrivelse: 'Sperret adresse, strengt fortrolig'
-                }
-            ],
-            harSammeAdresse: false,
-            personstatus: [
-                {
-                    kode: PersonStatus.BOSATT,
-                    beskrivelse: 'Bosatt'
-                }
-            ]
-        }
-    ]
+    forelderBarnRelasjon: forelderBarnRelasjonMock
 };

--- a/src/mock/persondata/personKode6Utland.ts
+++ b/src/mock/persondata/personKode6Utland.ts
@@ -11,6 +11,36 @@ import {
     SivilstandType
 } from '../../app/personside/visittkort-v2/PersondataDomain';
 
+const forelderBarnRelasjonMock = [
+    {
+        ident: '05031577278',
+        rolle: ForelderBarnRelasjonRolle.BARN,
+        navn: [
+            {
+                fornavn: 'NOBEL',
+                mellomnavn: 'SLØVENDE',
+                etternavn: 'POTET'
+            }
+        ],
+        fodselsdato: ['2015-03-05' as LocalDate],
+        kjonn: [
+            {
+                kode: Kjonn.K,
+                beskrivelse: 'Kvinne'
+            }
+        ],
+        alder: 6,
+        adressebeskyttelse: [],
+        harSammeAdresse: true,
+        personstatus: [
+            {
+                kode: PersonStatus.BOSATT,
+                beskrivelse: 'Bosatt'
+            }
+        ]
+    }
+];
+
 export const personKode6Utland: Person = {
     fnr: '27118410268',
     navn: [
@@ -110,17 +140,16 @@ export const personKode6Utland: Person = {
             }
         }
     ],
-    foreldreansvar: [
-        {
+    foreldreansvar: forelderBarnRelasjonMock
+        .filter(relasjon => relasjon.rolle === ForelderBarnRelasjonRolle.BARN)
+        .map(barn => ({
             ansvar: 'felles',
             ansvarlig: null,
             ansvarsubject: {
-                fornavn: 'NOBEL',
-                mellomnavn: 'SLØVENDE',
-                etternavn: 'POTET'
+                navn: barn.navn.firstOrNull(),
+                ident: barn.ident
             }
-        }
-    ],
+        })),
     deltBosted: [],
     dodsbo: [],
     fullmakt: [
@@ -183,33 +212,5 @@ export const personKode6Utland: Person = {
         mobiltelefonnummer: null
     },
     bankkonto: null,
-    forelderBarnRelasjon: [
-        {
-            ident: '05031577278',
-            rolle: ForelderBarnRelasjonRolle.BARN,
-            navn: [
-                {
-                    fornavn: 'NOBEL',
-                    mellomnavn: 'SLØVENDE',
-                    etternavn: 'POTET'
-                }
-            ],
-            fodselsdato: ['2015-03-05' as LocalDate],
-            kjonn: [
-                {
-                    kode: Kjonn.K,
-                    beskrivelse: 'Kvinne'
-                }
-            ],
-            alder: 6,
-            adressebeskyttelse: [],
-            harSammeAdresse: true,
-            personstatus: [
-                {
-                    kode: PersonStatus.BOSATT,
-                    beskrivelse: 'Bosatt'
-                }
-            ]
-        }
-    ]
+    forelderBarnRelasjon: forelderBarnRelasjonMock
 };

--- a/src/mock/persondata/personKode7.ts
+++ b/src/mock/persondata/personKode7.ts
@@ -10,6 +10,36 @@ import {
     SivilstandType
 } from '../../app/personside/visittkort-v2/PersondataDomain';
 
+const forelderBarnRelasjonMock = [
+    {
+        ident: '06051780203',
+        rolle: ForelderBarnRelasjonRolle.BARN,
+        navn: [
+            {
+                fornavn: 'LITEN',
+                mellomnavn: 'GYNGENDE',
+                etternavn: 'VEGGPRYD'
+            }
+        ],
+        fodselsdato: ['2017-05-06' as LocalDate],
+        kjonn: [
+            {
+                kode: Kjonn.K,
+                beskrivelse: 'Kvinne'
+            }
+        ],
+        alder: 4,
+        adressebeskyttelse: [],
+        harSammeAdresse: true,
+        personstatus: [
+            {
+                kode: PersonStatus.BOSATT,
+                beskrivelse: 'Bosatt'
+            }
+        ]
+    }
+];
+
 export const personKode7: Person = {
     fnr: '09057118773',
     navn: [
@@ -115,17 +145,16 @@ export const personKode7: Person = {
             }
         }
     ],
-    foreldreansvar: [
-        {
+    foreldreansvar: forelderBarnRelasjonMock
+        .filter(relasjon => relasjon.rolle === ForelderBarnRelasjonRolle.BARN)
+        .map(barn => ({
             ansvar: 'felles',
             ansvarlig: null,
             ansvarsubject: {
-                fornavn: 'LITEN',
-                mellomnavn: 'GYNGENDE',
-                etternavn: 'VEGGPRYD'
+                navn: barn.navn.firstOrNull(),
+                ident: barn.ident
             }
-        }
-    ],
+        })),
     deltBosted: [],
     dodsbo: [],
     fullmakt: [],
@@ -161,33 +190,5 @@ export const personKode7: Person = {
         mobiltelefonnummer: null
     },
     bankkonto: null,
-    forelderBarnRelasjon: [
-        {
-            ident: '06051780203',
-            rolle: ForelderBarnRelasjonRolle.BARN,
-            navn: [
-                {
-                    fornavn: 'LITEN',
-                    mellomnavn: 'GYNGENDE',
-                    etternavn: 'VEGGPRYD'
-                }
-            ],
-            fodselsdato: ['2017-05-06' as LocalDate],
-            kjonn: [
-                {
-                    kode: Kjonn.K,
-                    beskrivelse: 'Kvinne'
-                }
-            ],
-            alder: 4,
-            adressebeskyttelse: [],
-            harSammeAdresse: true,
-            personstatus: [
-                {
-                    kode: PersonStatus.BOSATT,
-                    beskrivelse: 'Bosatt'
-                }
-            ]
-        }
-    ]
+    forelderBarnRelasjon: forelderBarnRelasjonMock
 };

--- a/src/mock/persondata/persondata.ts
+++ b/src/mock/persondata/persondata.ts
@@ -14,6 +14,7 @@ import {
     SivilstandType,
     Skifteform
 } from '../../app/personside/visittkort-v2/PersondataDomain';
+import { harDiskresjonskode } from '../../app/personside/visittkort-v2/visittkort-utils';
 import { aremark } from './aremark';
 import { personDeltBosted } from './personDeltBosted';
 import { personDod } from './personDod';
@@ -205,21 +206,16 @@ function lagPerson(fnr: string): Person {
                 }
             }
         ],
-        foreldreansvar: [
-            {
+        foreldreansvar: forelderBarnMock
+            .filter(relasjon => relasjon.rolle === ForelderBarnRelasjonRolle.BARN)
+            .map(barn => ({
                 ansvar: 'felles',
-                ansvarlig: {
-                    fornavn: 'Test',
-                    etternavn: 'Testesen',
-                    mellomnavn: null
-                },
+                ansvarlig: null,
                 ansvarsubject: {
-                    fornavn: 'Barn',
-                    etternavn: 'Barnesen',
-                    mellomnavn: null
+                    navn: harDiskresjonskode(barn.adressebeskyttelse) ? null : barn.navn.firstOrNull(),
+                    ident: barn.ident
                 }
-            }
-        ],
+            })),
         deltBosted: [
             {
                 startdatoForKontrakt: '2000-10-10' as LocalDate,
@@ -513,24 +509,19 @@ const forelderBarnMock: ForelderBarnRelasjon[] = [
             }
         ],
         fodselsdato: ['1998-04-09' as LocalDate],
-        alder: 23,
+        alder: 13,
         kjonn: [
             {
                 kode: Kjonn.U,
                 beskrivelse: 'Ukjent kjønn'
             }
         ],
-        adressebeskyttelse: [
-            {
-                kode: AdresseBeskyttelse.UGRADERT,
-                beskrivelse: 'UGRADERT'
-            }
-        ],
+        adressebeskyttelse: [],
         harSammeAdresse: true,
         personstatus: [
             {
-                kode: PersonStatus.UTFLYTTET,
-                beskrivelse: 'UTFLYTTET'
+                kode: PersonStatus.BOSATT,
+                beskrivelse: 'BOSATT'
             }
         ]
     },


### PR DESCRIPTION
Vi utvider foreldreansvar for å vise ident også. I tillegg oppdateres visningen litt.
Det krever en del håndtering rundt feks barn eller foreldre med diskresjonskode. 
Da viser vi feks `Ansvarlig: Ukjent navn`.

PDL fungerer slik at dersom man slår opp et barn, så vil `ansvarsubject` være `null` (for dette er selve personen man slår opp på), og motsatt, dersom man slår opp en forelder, vil `ansvarlig` være `null`. Dermed vil feltene skjules/vises basert på dette.