### PR TITLE
[FAGSYSTEM-194254] Henter enhet fra nytt endepunkt for kontorsperre

### DIFF
--- a/src/app/personside/MainLayout.tsx
+++ b/src/app/personside/MainLayout.tsx
@@ -16,6 +16,9 @@ import BrukerHarUbesvarteMeldinger from './dialogpanel/BrukerHarUbesvarteMelding
 import { guid } from 'nav-frontend-js-utils';
 import useFeatureToggle from '../../components/featureToggle/useFeatureToggle';
 import { FeatureToggles } from '../../components/featureToggle/toggleIDs';
+import { useOnMount } from '../../utils/customHooks';
+import { isNotStarted } from '../../rest/utils/restResource';
+import { useRestResource } from '../../rest/consumer/useRestResource';
 
 const Scrollbar = styled.div`
     overflow-y: auto;
@@ -23,11 +26,23 @@ const Scrollbar = styled.div`
     flex-shrink: 1;
 `;
 
+function useBrukersNavKontor() {
+    const resource = useRestResource((resource) => resource.brukersNavKontor).resource;
+    const dispatch = useDispatch();
+
+    useOnMount(() => {
+        if (isNotStarted(resource)) {
+            dispatch(resource.actions.fetch);
+        }
+    });
+}
+
 function MainLayout() {
     const UI = useSelector((state: AppState) => state.ui);
     const dispatch = useDispatch();
     const tittelId = useRef(guid());
     const usingSFBackend = useFeatureToggle(FeatureToggles.BrukSalesforceDialoger).isOn ?? false;
+    useBrukersNavKontor();
 
     const ekspanderDialogpanelHandler = () => {
         if (!UI.dialogPanel.ekspandert) {

--- a/src/app/personside/infotabs/meldinger/traadvisning/verktoylinje/merk/Kontorsperr.tsx
+++ b/src/app/personside/infotabs/meldinger/traadvisning/verktoylinje/merk/Kontorsperr.tsx
@@ -8,10 +8,11 @@ import { Traad } from '../../../../../../../models/meldinger/meldinger';
 import { MerkKontorsperrRequest } from '../../../../../../../models/meldinger/merk';
 import styled from 'styled-components/macro';
 import { Hovedknapp } from 'nav-frontend-knapper';
-import { useRestResource } from '../../../../../../../rest/consumer/useRestResource';
 import { useSelector } from 'react-redux';
 import { AppState } from '../../../../../../../redux/reducers';
 import { AlertStripeAdvarsel } from 'nav-frontend-alertstriper';
+import { useHentPersondata } from '../../../../../../../utils/customHooks';
+import { hasError, isPending } from '@nutgaard/use-fetch';
 
 interface Props {
     valgtTraad: Traad;
@@ -31,7 +32,7 @@ const Margin = styled.div`
 `;
 
 function getMerkKontrorsperretRequest(fnr: String, enhet: string, traad: Traad): MerkKontorsperrRequest {
-    const meldingsidListe = traad.meldinger.map(melding => melding.id);
+    const meldingsidListe = traad.meldinger.map((melding) => melding.id);
     return {
         fnr: fnr,
         enhet: enhet,
@@ -42,8 +43,10 @@ function getMerkKontrorsperretRequest(fnr: String, enhet: string, traad: Traad):
 export function Kontorsperr(props: Props) {
     const [opprettOppgave, settOpprettOppgave] = useState(true);
     const valgtBrukersFnr = useSelector((state: AppState) => state.gjeldendeBruker.fødselsnummer);
-    const brukersKontor = useRestResource(resource => resource.brukersNavKontor);
-    const brukersEnhetID = brukersKontor.data?.enhetId ? brukersKontor.data.enhetId : '';
+    const hentPersondata = useHentPersondata();
+    const brukersNavEnhet =
+        isPending(hentPersondata) || hasError(hentPersondata) ? null : hentPersondata.data.person.navEnhet;
+    const brukersEnhetID = brukersNavEnhet?.id ? brukersNavEnhet.id : '';
     const [error, setError] = useState(false);
 
     const kontorsperr = () => {
@@ -68,7 +71,7 @@ export function Kontorsperr(props: Props) {
             <Checkbox
                 label={'Opprett oppgave'}
                 checked={opprettOppgave}
-                onChange={_ => settOpprettOppgave(!opprettOppgave)}
+                onChange={(_) => settOpprettOppgave(!opprettOppgave)}
             />
             <UnmountClosed isOpened={opprettOppgave}>
                 <OpprettOppgaveContainer

--- a/src/app/personside/infotabs/meldinger/traadvisning/verktoylinje/merk/Kontorsperr.tsx
+++ b/src/app/personside/infotabs/meldinger/traadvisning/verktoylinje/merk/Kontorsperr.tsx
@@ -11,8 +11,7 @@ import { Hovedknapp } from 'nav-frontend-knapper';
 import { useSelector } from 'react-redux';
 import { AppState } from '../../../../../../../redux/reducers';
 import { AlertStripeAdvarsel } from 'nav-frontend-alertstriper';
-import { useHentPersondata } from '../../../../../../../utils/customHooks';
-import { hasError, isPending } from '@nutgaard/use-fetch';
+import { useRestResource } from '../../../../../../../rest/consumer/useRestResource';
 
 interface Props {
     valgtTraad: Traad;
@@ -43,10 +42,9 @@ function getMerkKontrorsperretRequest(fnr: String, enhet: string, traad: Traad):
 export function Kontorsperr(props: Props) {
     const [opprettOppgave, settOpprettOppgave] = useState(true);
     const valgtBrukersFnr = useSelector((state: AppState) => state.gjeldendeBruker.fødselsnummer);
-    const hentPersondata = useHentPersondata();
-    const brukersNavEnhet =
-        isPending(hentPersondata) || hasError(hentPersondata) ? null : hentPersondata.data.person.navEnhet;
-    const brukersEnhetID = brukersNavEnhet?.id ? brukersNavEnhet.id : '';
+    const brukersNavEnhetTPS = useRestResource((resource) => resource.brukersNavKontor);
+    const brukersEnhetID = brukersNavEnhetTPS.data?.enhetId ? brukersNavEnhetTPS.data?.enhetId : '';
+
     const [error, setError] = useState(false);
 
     const kontorsperr = () => {
@@ -71,7 +69,7 @@ export function Kontorsperr(props: Props) {
             <Checkbox
                 label={'Opprett oppgave'}
                 checked={opprettOppgave}
-                onChange={(_) => settOpprettOppgave(!opprettOppgave)}
+                onChange={() => settOpprettOppgave(!opprettOppgave)}
             />
             <UnmountClosed isOpened={opprettOppgave}>
                 <OpprettOppgaveContainer

--- a/src/utils/customHooks.ts
+++ b/src/utils/customHooks.ts
@@ -5,6 +5,9 @@ import { useSelector } from 'react-redux';
 import { AppState } from '../redux/reducers';
 import { erKontaktsenter } from './enheter-utils';
 import Hotjar, { HotjarTriggers } from './hotjar';
+import useFetch, { FetchResult } from '@nutgaard/use-fetch';
+import { apiBaseUri } from '../api/config';
+import { Data as Persondata } from '../app/personside/visittkort-v2/PersondataDomain';
 
 export function useFocusOnMount(ref: React.RefObject<HTMLElement>) {
     useOnMount(() => {
@@ -68,14 +71,14 @@ export function useAppState<T>(selector: (state: AppState) => T) {
 }
 
 export function useFodselsnummer() {
-    return useAppState(state => state.gjeldendeBruker.fødselsnummer);
+    return useAppState((state) => state.gjeldendeBruker.fødselsnummer);
 }
 
 export function useTriggerHotjarForLokalKontor() {
-    const valgtEnhet = useAppState(state => state.session.valgtEnhetId);
+    const valgtEnhet = useAppState((state) => state.session.valgtEnhetId);
 
     useJustOnceEffect(
-        done => {
+        (done) => {
             if (valgtEnhet && !erKontaktsenter(valgtEnhet)) {
                 Hotjar.trigger(HotjarTriggers.BRUKSMONSTER);
                 done();
@@ -83,4 +86,9 @@ export function useTriggerHotjarForLokalKontor() {
         },
         [valgtEnhet]
     );
+}
+
+export function useHentPersondata(): FetchResult<Persondata> {
+    const fnr = useFodselsnummer();
+    return useFetch<Persondata>(`${apiBaseUri}/v2/person/${fnr}`);
 }


### PR DESCRIPTION
Fikser så man kan merke kontorsperret på samtalereferat når man bruker det nye endepunktet