### PR TITLE
[OPP-1390] bruke nyeste sivilstandrelasjon i visittkort

### DIFF
--- a/src/app/personside/kontrollsporsmal/SporsmalExtractors.tsx
+++ b/src/app/personside/kontrollsporsmal/SporsmalExtractors.tsx
@@ -2,13 +2,12 @@ import {
     DigitalKontaktinformasjon,
     ForelderBarnRelasjon,
     Person,
-    PersonStatus,
-    SivilstandType
+    PersonStatus
 } from '../visittkort-v2/PersondataDomain';
 import { shuffle } from './list-utils';
 import { Svar } from '../../../redux/kontrollSporsmal/types';
 import { formatertKontonummerString } from '../../../utils/FormatertKontonummer';
-import { harDiskresjonskode, hentBarnUnder22, hentNavn, hentPartner } from '../visittkort-v2/visittkort-utils';
+import { erPartner, harDiskresjonskode, hentBarnUnder22, hentNavn } from '../visittkort-v2/visittkort-utils';
 import { formatterDato } from '../../../utils/date-utils';
 
 export interface SporsmalsExtractor<T> {
@@ -75,8 +74,7 @@ function ettTilfeldigBarn(barn: ForelderBarnRelasjon[]): ForelderBarnRelasjon {
 
 export function hentGiftedato(person: Person) {
     const sivilstand = person.sivilstand.firstOrNull();
-    const partner = hentPartner(person.sivilstand);
-    if (sivilstand?.type.kode !== SivilstandType.GIFT) {
+    if (!sivilstand || !erPartner(sivilstand)) {
         return '';
     }
 
@@ -86,14 +84,14 @@ export function hentGiftedato(person: Person) {
     }
 
     if (
-        partner?.sivilstandRelasjon?.adressebeskyttelse &&
-        harDiskresjonskode(partner?.sivilstandRelasjon?.adressebeskyttelse)
+        sivilstand?.sivilstandRelasjon?.adressebeskyttelse &&
+        harDiskresjonskode(sivilstand?.sivilstandRelasjon?.adressebeskyttelse)
     ) {
         return '';
     }
 
-    const partnerNavn = partner?.sivilstandRelasjon?.navn
-        ? hentNavn(partner?.sivilstandRelasjon?.navn.firstOrNull())
+    const partnerNavn = sivilstand?.sivilstandRelasjon?.navn
+        ? hentNavn(sivilstand?.sivilstandRelasjon?.navn.firstOrNull())
         : '';
     return `${dato} (${partnerNavn})`;
 }

--- a/src/app/personside/visittkort-v2/body/familie/Sivilstand.tsx
+++ b/src/app/personside/visittkort-v2/body/familie/Sivilstand.tsx
@@ -3,7 +3,7 @@ import { Normaltekst } from 'nav-frontend-typografi';
 import VisittkortElement from '../VisittkortElement';
 import HeartIkon from '../../../../../svg/Heart';
 import { Sivilstand as SivilstandInterface, SivilstandType } from '../../PersondataDomain';
-import { hentNavn, hentPartner } from '../../visittkort-utils';
+import { erPartner, hentNavn } from '../../visittkort-utils';
 import Diskresjonskode from './common/Diskresjonskode';
 import { formaterDato } from '../../../../../utils/string-utils';
 
@@ -51,7 +51,6 @@ function Partner(props: { partner: SivilstandInterface }) {
 }
 
 function SivilstandWrapper({ sivilstandListe }: Props) {
-    const partner = hentPartner(sivilstandListe);
     const sivilstand = sivilstandListe.firstOrNull();
 
     if (!sivilstand) {
@@ -60,8 +59,8 @@ function SivilstandWrapper({ sivilstandListe }: Props) {
 
     return (
         <VisittkortElement beskrivelse="Sivilstand" ikon={<HeartIkon />}>
-            {partner ? (
-                <Partner partner={partner} />
+            {erPartner(sivilstand) ? (
+                <Partner partner={sivilstand} />
             ) : (
                 <Normaltekst>
                     <Sivilstand sivilstand={sivilstand} />

--- a/src/app/personside/visittkort-v2/visittkort-utils.ts
+++ b/src/app/personside/visittkort-v2/visittkort-utils.ts
@@ -17,11 +17,11 @@ function erDod(person: Person) {
 }
 
 export function hentBarnUnder22(forelderBarnRelasjon: ForelderBarnRelasjon[]) {
-    return hentBarn(forelderBarnRelasjon).filter(barn => hentAlderOrDefault(barn) <= 21);
+    return hentBarn(forelderBarnRelasjon).filter((barn) => hentAlderOrDefault(barn) <= 21);
 }
 
 export function hentBarn(forelderBarnRelasjon: ForelderBarnRelasjon[]) {
-    return forelderBarnRelasjon.filter(relasjon => relasjon.rolle === ForelderBarnRelasjonRolle.BARN);
+    return forelderBarnRelasjon.filter((relasjon) => relasjon.rolle === ForelderBarnRelasjonRolle.BARN);
 }
 
 function hentAlderOrDefault(relasjon: ForelderBarnRelasjon) {
@@ -30,7 +30,7 @@ function hentAlderOrDefault(relasjon: ForelderBarnRelasjon) {
 
 export function hentForeldre(relasjoner: ForelderBarnRelasjon[]) {
     return relasjoner.filter(
-        relasjon =>
+        (relasjon) =>
             relasjon.rolle === ForelderBarnRelasjonRolle.FAR ||
             relasjon.rolle === ForelderBarnRelasjonRolle.MOR ||
             relasjon.rolle === ForelderBarnRelasjonRolle.MEDMOR
@@ -39,16 +39,16 @@ export function hentForeldre(relasjoner: ForelderBarnRelasjon[]) {
 
 export function harDiskresjonskode(adressebeskyttelse: KodeBeskrivelse<AdresseBeskyttelse>[]) {
     return adressebeskyttelse.some(
-        beskyttelse =>
+        (beskyttelse) =>
             beskyttelse.kode === AdresseBeskyttelse.KODE6 ||
             beskyttelse.kode === AdresseBeskyttelse.KODE6_UTLAND ||
             beskyttelse.kode === AdresseBeskyttelse.KODE7
     );
 }
 
-export function hentPartner(sivilstand: Sivilstand[]) {
+export function erPartner(sivilstand: Sivilstand): boolean {
     const aktuelleRelasjoner = [SivilstandType.GIFT, SivilstandType.REGISTRERT_PARTNER];
-    return sivilstand.find(relasjon => aktuelleRelasjoner.includes(relasjon.type.kode));
+    return sivilstand?.type && aktuelleRelasjoner.includes(sivilstand?.type.kode);
 }
 
 export function hentNavn(navn: Navn | null, feilmelding: string = 'Ukjent navn'): string {


### PR DESCRIPTION
Tidligere lette vi etter partner i en liste av sivilstandrelasjoner.
Ved situasjoner der en person har vært gift og så skilt seg,
vil begge disse ligge i lista, selv om giftemålet har opphørt.
Da får vi en situasjon der personen står som ugift i headeren,
men som gift i body. Det var tilfellet på aremark i q1 nå.
Dette tar også forebehold om at det første elementet i sivilstand-listen
er det nyeste. Her kunne man også sjekket på gyldighetsdato
for å være helt sikker.