### PR TITLE
[PROD][OPP-1390] bruke nyeste sivilstandrelasjon i visittkort

### DIFF
--- a/src/app/personside/kontrollsporsmal/SporsmalExtractor.test.ts
+++ b/src/app/personside/kontrollsporsmal/SporsmalExtractor.test.ts
@@ -12,7 +12,7 @@ import {
 import { hentEpost, hentFodselsdatoBarn, hentGiftedato } from './SporsmalExtractors';
 
 describe('hentGiftedato', () => {
-    const GIFTEDATO = '2011-11-11';
+    const GIFTEDATO = '11.11.2011';
 
     it('Gir korrekt navn og dato', () => {
         let person = lagMockGiftPerson();

--- a/src/app/personside/kontrollsporsmal/SporsmalExtractors.tsx
+++ b/src/app/personside/kontrollsporsmal/SporsmalExtractors.tsx
@@ -80,7 +80,7 @@ export function hentGiftedato(person: Person) {
         return '';
     }
 
-    const dato = sivilstand.gyldigFraOgMed;
+    const dato = formatterDato(sivilstand.gyldigFraOgMed?.toString() || '');
     if (!dato) {
         return '';
     }


### PR DESCRIPTION
Tidligere lette vi etter partner i en liste av sivilstandrelasjoner.
Ved situasjoner der en person har vært gift og så skilt seg, vil begge disse ligge i lista, selv om giftemålet har opphørt.
Da får vi en situasjon der personen står som ugift i headeren, men som gift i body. Det var tilfellet på aremark i q1 nå.
Dette tar også forebehold om at det første elementet i sivilstand-listen er det nyeste. Her kunne man også sjekket på gyldighetsdato for å være helt sikker.

Aremark i q1:
![image](https://user-images.githubusercontent.com/37441744/144063658-937c1a91-1fe7-4925-9ee6-730a0b43738b.png)

Dataen man får på aremark, med to sivilstandsrelasjoner:
![image](https://user-images.githubusercontent.com/37441744/144063740-c2f95415-113d-4b3f-a982-ea0eb84d9724.png)
