### PR TITLE
[OPP-1404] fjerne bruk av FT i oppdateringslogg

### DIFF
--- a/src/app/oppdateringslogg/OppdateringsloggContainer.tsx
+++ b/src/app/oppdateringslogg/OppdateringsloggContainer.tsx
@@ -8,8 +8,6 @@ import useSisteLestOppdateringLogg from './useSisteLestOppdateringLogg';
 import useWaitForElement from '../../utils/hooks/use-wait-for-element';
 import { lagOppdateringsloggConfig } from './config/config';
 import './oppdateringsloggKnapp.less';
-import useFeatureToggle from '../../components/featureToggle/useFeatureToggle';
-import { FeatureToggles } from '../../components/featureToggle/toggleIDs';
 
 export const DecoratorButtonId = 'oppdateringslogg';
 export interface EnOppdateringslogg {
@@ -34,7 +32,7 @@ const StyledSystemtittel = styled(Systemtittel)`
 `;
 
 function harUleste(sistLesteId: number, oppdateringslogg: EnOppdateringslogg[]): boolean {
-    return oppdateringslogg.some(innslag => innslag.id > sistLesteId);
+    return oppdateringslogg.some((innslag) => innslag.id > sistLesteId);
 }
 
 function useHoldUlestIndikatorOppdatert(
@@ -59,7 +57,7 @@ function useApneOppdateringsLoggModal(
     settSistLesteId: (id: number) => void
 ) {
     const listener = useCallback(() => {
-        const nyesteId: number | undefined = oppdateringslogg.map(innslag => innslag.id).sort((a, b) => b - a)[0];
+        const nyesteId: number | undefined = oppdateringslogg.map((innslag) => innslag.id).sort((a, b) => b - a)[0];
 
         settSistLesteId(nyesteId ?? -1);
         settApen(true);
@@ -69,10 +67,7 @@ function useApneOppdateringsLoggModal(
 }
 
 function OppdateringsloggContainer() {
-    const brukerVisittkortV2 = useFeatureToggle(FeatureToggles.BrukV2Visittkort).isOn ?? false;
-    const oppdateringslogg: EnOppdateringslogg[] = lagOppdateringsloggConfig(brukerVisittkortV2).filter(
-        innslag => innslag.aktiv
-    );
+    const oppdateringslogg: EnOppdateringslogg[] = lagOppdateringsloggConfig().filter((innslag) => innslag.aktiv);
 
     const [apen, settApen] = useState(false);
     const [sistLesteId, settSistLesteId] = useSisteLestOppdateringLogg();

--- a/src/app/oppdateringslogg/config/config.tsx
+++ b/src/app/oppdateringslogg/config/config.tsx
@@ -13,7 +13,7 @@ import KassertDokumentBilde from './img/kassert.jpg';
 import VisittkortV2 from './img/visittkortV2.png';
 import { Normaltekst } from 'nav-frontend-typografi';
 
-export function lagOppdateringsloggConfig(skalVisesBakFT: boolean): EnOppdateringslogg[] {
+export function lagOppdateringsloggConfig(): EnOppdateringslogg[] {
     return [
         {
             id: 1,
@@ -167,7 +167,7 @@ export function lagOppdateringsloggConfig(skalVisesBakFT: boolean): EnOppdaterin
             id: 9,
             tittel: 'Endret kilde for informasjon i visittkortet',
             dato: new Date('2021-11-17 10:00'),
-            aktiv: skalVisesBakFT,
+            aktiv: true,
             ingress: (
                 <Normaltekst>
                     Visittkortet i Modia Personoversikt har frem til nå basert seg på NAVs eget personregister.


### PR DESCRIPTION
Vi manglet å rydde opp bruken av VisittkortV2 FT i oppdateringsloggen som ligger i dekoratøren.