### PR TITLE
[FAGSYSTEM-199808] fjerne bool-cast på alder i familievisning

### DIFF
--- a/src/app/personside/visittkort-v2/body/familie/Familie.tsx
+++ b/src/app/personside/visittkort-v2/body/familie/Familie.tsx
@@ -10,7 +10,7 @@ interface Props {
 }
 
 function Familie({ person }: Props) {
-    const erUnder22 = !!person.alder && person.alder <= 21;
+    const erUnder22 = person.alder !== null && person.alder <= 21;
 
     return (
         <VisittkortGruppe tittel={'Familie'}>


### PR DESCRIPTION
Når en person er 0 år gammel, vil ikke erUnder22 bli true ved forrige løsning, som gjør at foreldrene ikke vises. Dette rettes opp ved å fjerne !! som i javascript caster en variabel til dens boolske verdi, og heller bare sjekke for null.