### PR TITLE
[FAGSYSTEM-167161] legge til aareg autocomplete

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -132,7 +132,7 @@
                 "typescript": "^3.9.6"
             },
             "engines": {
-                "node": ">=14.17.0"
+                "node": "^14.17.0 || ^16.13.0"
             }
         },
         "node_modules/@babel/code-frame": {

--- a/src/app/personside/dialogpanel/__snapshots__/DialogPanel.test.tsx.snap
+++ b/src/app/personside/dialogpanel/__snapshots__/DialogPanel.test.tsx.snap
@@ -452,6 +452,9 @@ exports[`viser dialogpanel 1`] = `
                             <li>
                               baor + mellomrom: ordinær barnetrygd
                             </li>
+                            <li>
+                              aareg + mellomrom: arbeidstaker og arbeidsgiver registeret
+                            </li>
                           </ul>
                         </div>
                       </div>

--- a/src/app/personside/dialogpanel/sendMelding/__snapshots__/SendNyMelding.test.tsx.snap
+++ b/src/app/personside/dialogpanel/sendMelding/__snapshots__/SendNyMelding.test.tsx.snap
@@ -441,6 +441,9 @@ exports[`viser send ny melding 1`] = `
                           <li>
                             baor + mellomrom: ordinær barnetrygd
                           </li>
+                          <li>
+                            aareg + mellomrom: arbeidstaker og arbeidsgiver registeret
+                          </li>
                         </ul>
                       </div>
                     </div>

--- a/src/components/autocomplete-textarea/autocomplete-textarea.tsx
+++ b/src/components/autocomplete-textarea/autocomplete-textarea.tsx
@@ -190,6 +190,11 @@ function useRules(): Regler {
             type: 'internal',
             regex: /^baor$/i,
             replacement: () => 'ordinær barnetrygd '
+        },
+        {
+            type: 'internal',
+            regex: /^aareg$/i,
+            replacement: () => 'arbeidstaker og arbeidsgiver registeret '
         }
     ];
 }
@@ -242,6 +247,7 @@ function AutoTekstTips() {
                     <li>info + mellomrom: informasjon</li>
                     <li>baut + mellomrom: utvidet barnetrygd</li>
                     <li>baor + mellomrom: ordinær barnetrygd</li>
+                    <li>aareg + mellomrom: arbeidstaker og arbeidsgiver registeret</li>
                 </ul>
             </Hjelpetekst>
         </HjelpetekstStyle>


### PR DESCRIPTION
ble etterspurt "aa" som tekst, men siden dette er en brukt bokstav-kombinasjon som kan dukke opp naturlig så legger vi til den litt mer utfyllende "aareg"
