### PR TITLE
[FAGSYSTEM-167161] fjerne typo for aareg-forkortelse

### DIFF
--- a/src/app/oppdateringslogg/config/config.tsx
+++ b/src/app/oppdateringslogg/config/config.tsx
@@ -200,13 +200,13 @@ export function lagOppdateringsloggConfig(): EnOppdateringslogg[] {
         },
         {
             id: 11,
-            tittel: 'Forkortelse for arbeidstaker og arbeidsgiver registeret',
+            tittel: 'Forkortelse for arbeidsgiver- og arbeidstakerregisteret',
             dato: new Date('2022-01-06 12:00'),
             aktiv: true,
-            ingress: <Normaltekst>Vi har lagt til en ny forkortelse for AA registeret</Normaltekst>,
+            ingress: <Normaltekst>Vi har lagt til en ny forkortelse for Aa-registeret.</Normaltekst>,
             beskrivelse: (
                 <Normaltekst>
-                    Forkortelsen er AAREG, som gir tekten "arbeidstaker og arbeidsgiver registeret". Trykk på
+                    Forkortelsen er AAREG, som gir teksten "arbeidsgiver- og arbeidstakerregisteret". Trykk på
                     spørsmålstegnet i meldingsboksen for mer informasjon.
                 </Normaltekst>
             ),

--- a/src/app/personside/dialogpanel/__snapshots__/DialogPanel.test.tsx.snap
+++ b/src/app/personside/dialogpanel/__snapshots__/DialogPanel.test.tsx.snap
@@ -453,7 +453,7 @@ exports[`viser dialogpanel 1`] = `
                               baor + mellomrom: ordinær barnetrygd
                             </li>
                             <li>
-                              aareg + mellomrom: arbeidstaker og arbeidsgiver registeret
+                              aareg + mellomrom: arbeidsgiver- og arbeidstakerregisteret
                             </li>
                           </ul>
                         </div>

--- a/src/app/personside/dialogpanel/sendMelding/__snapshots__/SendNyMelding.test.tsx.snap
+++ b/src/app/personside/dialogpanel/sendMelding/__snapshots__/SendNyMelding.test.tsx.snap
@@ -442,7 +442,7 @@ exports[`viser send ny melding 1`] = `
                             baor + mellomrom: ordinær barnetrygd
                           </li>
                           <li>
-                            aareg + mellomrom: arbeidstaker og arbeidsgiver registeret
+                            aareg + mellomrom: arbeidsgiver- og arbeidstakerregisteret
                           </li>
                         </ul>
                       </div>

--- a/src/components/autocomplete-textarea/autocomplete-textarea.tsx
+++ b/src/components/autocomplete-textarea/autocomplete-textarea.tsx
@@ -194,7 +194,7 @@ function useRules(): Regler {
         {
             type: 'internal',
             regex: /^aareg$/i,
-            replacement: () => 'arbeidstaker og arbeidsgiver registeret '
+            replacement: () => 'arbeidsgiver- og arbeidstakerregisteret '
         }
     ];
 }
@@ -247,7 +247,7 @@ function AutoTekstTips() {
                     <li>info + mellomrom: informasjon</li>
                     <li>baut + mellomrom: utvidet barnetrygd</li>
                     <li>baor + mellomrom: ordinær barnetrygd</li>
-                    <li>aareg + mellomrom: arbeidstaker og arbeidsgiver registeret</li>
+                    <li>aareg + mellomrom: arbeidsgiver- og arbeidstakerregisteret</li>
                 </ul>
             </Hjelpetekst>
         </HjelpetekstStyle>


### PR DESCRIPTION
Basert på hvordan det er skrevet på nav sine hjemmesider: https://www.nav.no/no/bedrift/tjenester-og-skjemaer/aa-registeret-og-a-meldingen