### PR TITLE
[KAIZEN-0] fjerne dobble scrollbars

### DIFF
--- a/src/app/personside/infotabs/saksoversikt/__snapshots__/SaksoversiktContainer.test.tsx.snap
+++ b/src/app/personside/infotabs/saksoversikt/__snapshots__/SaksoversiktContainer.test.tsx.snap
@@ -384,6 +384,7 @@ exports[`Viser saksoversiktcontainer med alt innhold 1`] = `
 }
 
 .c0 {
+  overflow: hidden;
   position: relative;
 }
 

--- a/src/app/personside/infotabs/utbetalinger/__snapshots__/UtbetalingerContainer.test.tsx.snap
+++ b/src/app/personside/infotabs/utbetalinger/__snapshots__/UtbetalingerContainer.test.tsx.snap
@@ -476,6 +476,7 @@ exports[`Viser utbetalingercontainer med alt innhold 1`] = `
 }
 
 .c0 {
+  overflow: hidden;
   position: relative;
 }
 

--- a/src/app/personside/infotabs/utils/InfoTabsScrollBar.tsx
+++ b/src/app/personside/infotabs/utils/InfoTabsScrollBar.tsx
@@ -4,6 +4,7 @@ import React, { ReactNode, useRef } from 'react';
 import useKeepScroll from '../../../../utils/hooks/useKeepScroll';
 
 export const scrollBarContainerStyle = (minWidth: string) => css`
+    overflow: hidden;
     @media (min-width: ${minWidth}) {
         max-height: 100%;
         max-width: 100%;

--- a/src/app/personside/infotabs/ytelser/__snapshots__/Ytelser.test.tsx.snap
+++ b/src/app/personside/infotabs/ytelser/__snapshots__/Ytelser.test.tsx.snap
@@ -270,6 +270,10 @@ exports[`Om Ytelser matcher snapshot 1`] = `
   margin-bottom: 0.5rem;
 }
 
+.c1 {
+  overflow: hidden;
+}
+
 .c0 {
   -webkit-box-flex: 1;
   -webkit-flex-grow: 1;


### PR DESCRIPTION
Lamellene for meldinger, Saker, utbetaling og yteler har to-kolonne-layout og derfor interne scrollbars.
For å unngå at innholdet i disse lamellene skal påvirke infotab-komponenten som er deres parent så settes `overflow: hidden`.
Scrollbaren som typisk vil bli lagt til av `InfoTabs` blir dermed borte.

Før:
![image](https://user-images.githubusercontent.com/1413417/149332511-919b4e37-a487-4bee-8647-2752ad39850b.png)

Etter: 
![image](https://user-images.githubusercontent.com/1413417/149332549-5ff3776a-883a-4c6e-87b0-f92929928140.png)

