### PR TITLE
[OPP-1416] legge til innstilling for oppgave destinasjon

### DIFF
--- a/src/app/innstillinger/modal/innstillinger-modal-form.tsx
+++ b/src/app/innstillinger/modal/innstillinger-modal-form.tsx
@@ -31,10 +31,12 @@ const Label = styled.span`
 `;
 
 const defaultInnstillinger: Innstillinger = {
-    defaultTagsStandardtekster: 'na'
+    defaultTagsStandardtekster: 'na',
+    defaultOppgaveDestinasjon: 'MinListe'
 };
 const useFormState = formstateFactory<Innstillinger>({
-    defaultTagsStandardtekster: () => undefined
+    defaultTagsStandardtekster: () => undefined,
+    defaultOppgaveDestinasjon: () => undefined
 });
 
 const AutomatiskeTagsLabel = (
@@ -42,6 +44,15 @@ const AutomatiskeTagsLabel = (
         <b>Automatiske tags</b>
         <Hjelpetekst id="AutomatiskeTagsLabel" type={PopoverOrientering.UnderVenstre}>
             Vil legge til henholdsvis #sto og #samref automatisk når man bruker standardtekstene-søket (alt + c).
+        </Hjelpetekst>
+    </Label>
+);
+const OppgaveDestinasjonLabel = (
+    <Label>
+        <b>Oppgave destinasjon ved svar</b>
+        <Hjelpetekst id="OppgaveDestinasjonLabel" type={PopoverOrientering.UnderVenstre}>
+            Setter standardvalget for hvor oppgaver skal sendes når bruker svarer. Det vil fortsatt være mulig å
+            overstyre dette ved utsending.
         </Hjelpetekst>
     </Label>
 );
@@ -64,7 +75,7 @@ function InnstillingerModalForm(props: Props) {
     const onSubmitHandler = (nyeInnstillinger: Innstillinger): Promise<any> => {
         return props.actions
             .oppdaterInnstillinger({ ...innstillinger.data.innstillinger, ...nyeInnstillinger })
-            .then(oppdaterteInnstillinger => {
+            .then((oppdaterteInnstillinger) => {
                 state.reinitialize(oppdaterteInnstillinger.innstillinger);
                 settInnsendingFeilet(false);
             })
@@ -79,10 +90,22 @@ function InnstillingerModalForm(props: Props) {
                 <Undertekst className="blokk-xxs">
                     Sist oppdatert: {new Date(props.innstillinger.data.sistLagret).toLocaleString('nb')}
                 </Undertekst>
-                <Select label={AutomatiskeTagsLabel} {...state.fields.defaultTagsStandardtekster.input}>
+                <Select
+                    className="blokk-s"
+                    label={AutomatiskeTagsLabel}
+                    {...state.fields.defaultTagsStandardtekster.input}
+                >
                     <option value="na">Ikke valgt</option>
                     <option value="sto">Skriv til oss (#sto)</option>
                     <option value="samref">Samtalereferat (#samref)</option>
+                </Select>
+                <Select
+                    className="blokk-s"
+                    label={OppgaveDestinasjonLabel}
+                    {...state.fields.defaultOppgaveDestinasjon.input}
+                >
+                    <option value="MinListe">Svar skal til min oppgaveliste hos valgt enhet</option>
+                    <option value="Enhetensliste">Svar skal til valgt enhet sin oppgaveliste</option>
                 </Select>
             </ModalContent>
             {innsendingFeilet && (

--- a/src/app/innstillinger/modal/innstillinger-modal-form.tsx
+++ b/src/app/innstillinger/modal/innstillinger-modal-form.tsx
@@ -49,7 +49,7 @@ const AutomatiskeTagsLabel = (
 );
 const OppgaveDestinasjonLabel = (
     <Label>
-        <b>Oppgave destinasjon ved svar</b>
+        <b>Destinasjon for oppgave ved svar</b>
         <Hjelpetekst id="OppgaveDestinasjonLabel" type={PopoverOrientering.UnderVenstre}>
             Setter standardvalget for hvor oppgaver skal sendes når bruker svarer. Det vil fortsatt være mulig å
             overstyre dette ved utsending.

--- a/src/app/personside/dialogpanel/DialogPanel.tsx
+++ b/src/app/personside/dialogpanel/DialogPanel.tsx
@@ -5,6 +5,9 @@ import { useAppState } from '../../../utils/customHooks';
 import SendNyMeldingContainer from './sendMelding/SendNyMeldingContainer';
 import FortsettDialogContainer from './fortsettDialog/FortsettDialogContainer';
 import useVisTraadTilknyttetPlukketOppgave from './fortsettDialog/useVisTraadTilknyttetPlukketOppgave';
+import { getInnstillingPending } from '../../../redux/innstillinger';
+import { OppgavelisteValg } from './sendMelding/SendNyMelding';
+import LazySpinner from '../../../components/LazySpinner';
 
 const DialogPanelWrapper = styled.div`
     flex-grow: 1;
@@ -12,11 +15,17 @@ const DialogPanelWrapper = styled.div`
 `;
 
 function DialogPanel() {
-    const dialogpanelTraad = useAppState(state => state.oppgaver.dialogpanelTraad);
+    const dialogpanelTraad = useAppState((state) => state.oppgaver.dialogpanelTraad);
     const slaaOppOppgave = useVisTraadTilknyttetPlukketOppgave(dialogpanelTraad);
+    const defaultOppgaveDestinasjon = useAppState((appstate) =>
+        getInnstillingPending<OppgavelisteValg>(appstate, 'defaultOppgaveDestinasjon', OppgavelisteValg.MinListe)
+    );
 
     if (slaaOppOppgave.pending) {
         return slaaOppOppgave.placeholder;
+    }
+    if (defaultOppgaveDestinasjon.pending) {
+        return <LazySpinner type="M" />;
     }
 
     return (
@@ -25,10 +34,11 @@ function DialogPanel() {
                 {dialogpanelTraad ? (
                     <FortsettDialogContainer
                         traad={dialogpanelTraad}
+                        defaultOppgaveDestinasjon={defaultOppgaveDestinasjon.data}
                         key={dialogpanelTraad.traadId} // for å tvinge refresh dersom man velger en ny tråd
                     />
                 ) : (
-                    <SendNyMeldingContainer />
+                    <SendNyMeldingContainer defaultOppgaveDestinasjon={defaultOppgaveDestinasjon.data} />
                 )}
             </DialogPanelWrapper>
         </ErrorBoundary>

--- a/src/app/personside/dialogpanel/fortsettDialog/FortsettDialog.test.tsx
+++ b/src/app/personside/dialogpanel/fortsettDialog/FortsettDialog.test.tsx
@@ -5,13 +5,14 @@ import { getTestStore } from '../../../../test/testStore';
 import { setValgtTraadDialogpanel } from '../../../../redux/oppgave/actions';
 import { statiskTraadMock } from '../../../../mock/meldinger/statiskTraadMock';
 import FortsettDialogContainer from './FortsettDialogContainer';
+import { OppgavelisteValg } from '../sendMelding/SendNyMelding';
 
 test('viser fortsett dialog', () => {
     const testStore = getTestStore();
     testStore.dispatch(setValgtTraadDialogpanel(statiskTraadMock));
     const dialogPanelBody = renderer.create(
         <TestProvider customStore={testStore}>
-            <FortsettDialogContainer traad={statiskTraadMock} />
+            <FortsettDialogContainer traad={statiskTraadMock} defaultOppgaveDestinasjon={OppgavelisteValg.MinListe} />
         </TestProvider>
     );
 

--- a/src/app/personside/dialogpanel/fortsettDialog/FortsettDialogContainer.tsx
+++ b/src/app/personside/dialogpanel/fortsettDialog/FortsettDialogContainer.tsx
@@ -50,6 +50,7 @@ export type FortsettDialogType =
 
 interface Props {
     traad: Traad;
+    defaultOppgaveDestinasjon: OppgavelisteValg;
 }
 
 const StyledArticle = styled.article`
@@ -73,27 +74,31 @@ export function finnPlukketOppgaveForTraad(
 }
 
 function FortsettDialogContainer(props: Props) {
-    const initialState = {
-        tekst: '',
-        dialogType: Meldingstype.SVAR_SKRIFTLIG as FortsettDialogType,
-        tema: undefined,
-        visFeilmeldinger: false,
-        sak: undefined,
-        oppgaveListe: OppgavelisteValg.MinListe
-    };
+    const initialState = useMemo(
+        () => ({
+            tekst: '',
+            dialogType: Meldingstype.SVAR_SKRIFTLIG as FortsettDialogType,
+            tema: undefined,
+            visFeilmeldinger: false,
+            sak: undefined,
+            oppgaveListe: props.defaultOppgaveDestinasjon
+        }),
+        [props.defaultOppgaveDestinasjon]
+    );
 
     const fnr = useFodselsnummer();
     const tittelId = useRef(guid());
     const [state, setState] = useState<FortsettDialogState>(initialState);
     const valgtEnhet = useAppState(selectValgtEnhet);
     const usingSFBackend = useFeatureToggle(FeatureToggles.BrukSalesforceDialoger).isOn ?? false;
-    const draftLoader = useCallback((draft: Draft) => setState(current => ({ ...current, tekst: draft.content })), [
-        setState
-    ]);
+    const draftLoader = useCallback(
+        (draft: Draft) => setState((current) => ({ ...current, tekst: draft.content })),
+        [setState]
+    );
     const draftContext = useMemo(() => ({ fnr }), [fnr]);
     const { update: updateDraft, remove: removeDraft } = useDraft(draftContext, draftLoader);
-    const reloadMeldinger = useRestResource(resources => resources.traader).actions.reload;
-    const tildelteOppgaverResource = useRestResource(resources => resources.tildelteOppgaver);
+    const reloadMeldinger = useRestResource((resources) => resources.traader).actions.reload;
+    const tildelteOppgaverResource = useRestResource((resources) => resources.tildelteOppgaver);
     const tildelteOppgaver = tildelteOppgaverResource.resource;
     const reloadTildelteOppgaver = tildelteOppgaverResource.actions.reload;
     const [dialogStatus, setDialogStatus] = useState<FortsettDialogPanelState>({
@@ -102,7 +107,7 @@ function FortsettDialogContainer(props: Props) {
     const dispatch = useDispatch();
     const updateState = useCallback(
         (change: Partial<FortsettDialogState>) =>
-            setState(currentState => {
+            setState((currentState) => {
                 if (change.tekst !== undefined) {
                     updateDraft(change.tekst);
                 }
@@ -239,7 +244,7 @@ function FortsettDialogContainer(props: Props) {
         }
     };
 
-    const meldingMedTemagruppe = props.traad.meldinger.find(melding => melding.temagruppe);
+    const meldingMedTemagruppe = props.traad.meldinger.find((melding) => melding.temagruppe);
     const temagruppe = meldingMedTemagruppe ? meldingMedTemagruppe.temagruppe : undefined;
 
     return (

--- a/src/app/personside/dialogpanel/sendMelding/SendNyMelding.test.tsx
+++ b/src/app/personside/dialogpanel/sendMelding/SendNyMelding.test.tsx
@@ -2,6 +2,7 @@ import * as React from 'react';
 import * as renderer from 'react-test-renderer';
 import TestProvider from '../../../../test/Testprovider';
 import SendNyMeldingContainer from './SendNyMeldingContainer';
+import { OppgavelisteValg } from './SendNyMelding';
 
 beforeEach(() => {
     Date.prototype.getTime = jest.fn(() => 0);
@@ -11,7 +12,7 @@ beforeEach(() => {
 test('viser send ny melding', () => {
     const dialogPanelBody = renderer.create(
         <TestProvider>
-            <SendNyMeldingContainer />
+            <SendNyMeldingContainer defaultOppgaveDestinasjon={OppgavelisteValg.MinListe} />
         </TestProvider>
     );
 

--- a/src/app/personside/dialogpanel/sendMelding/SendNyMeldingContainer.tsx
+++ b/src/app/personside/dialogpanel/sendMelding/SendNyMeldingContainer.tsx
@@ -25,30 +25,37 @@ import { feilMeldinger } from './FeilMeldinger';
 import * as JournalforingUtils from '../../journalforings-use-fetch-utils';
 import { selectValgtEnhet } from '../../../../redux/session/session';
 
-const initialState: SendNyMeldingState = {
-    tekst: '',
-    dialogType: Meldingstype.SAMTALEREFERAT_TELEFON,
-    tema: undefined,
-    sak: undefined,
-    oppgaveListe: OppgavelisteValg.MinListe,
-    visFeilmeldinger: false
-};
+interface Props {
+    defaultOppgaveDestinasjon: OppgavelisteValg;
+}
 
-function SendNyMeldingContainer() {
+function SendNyMeldingContainer(props: Props) {
+    const initialState: SendNyMeldingState = useMemo(
+        () => ({
+            tekst: '',
+            dialogType: Meldingstype.SAMTALEREFERAT_TELEFON,
+            tema: undefined,
+            sak: undefined,
+            oppgaveListe: props.defaultOppgaveDestinasjon,
+            visFeilmeldinger: false
+        }),
+        [props.defaultOppgaveDestinasjon]
+    );
     const dispatch = useDispatch();
     const fnr = useFodselsnummer();
-    const reloadMeldinger = useRestResource(resources => resources.traader).actions.reload;
+    const reloadMeldinger = useRestResource((resources) => resources.traader).actions.reload;
 
     const valgtEnhet = useAppState(selectValgtEnhet);
     const [state, setState] = useState<SendNyMeldingState>(initialState);
-    const draftLoader = useCallback((draft: Draft) => setState(current => ({ ...current, tekst: draft.content })), [
-        setState
-    ]);
+    const draftLoader = useCallback(
+        (draft: Draft) => setState((current) => ({ ...current, tekst: draft.content })),
+        [setState]
+    );
     const draftContext = useMemo(() => ({ fnr }), [fnr]);
     const { update: updateDraft, remove: removeDraft } = useDraft(draftContext, draftLoader);
     const updateState = useCallback(
         (change: Partial<SendNyMeldingState>) =>
-            setState(currentState => {
+            setState((currentState) => {
                 if (change.tekst !== undefined) {
                     updateDraft(change.tekst);
                 }
@@ -120,7 +127,7 @@ function SendNyMeldingContainer() {
                     callback();
                     setSendNyMeldingStatus({ type: SendNyMeldingStatus.REFERAT_SENDT, request: request });
                 })
-                .catch(error => {
+                .catch((error) => {
                     console.error('Send-Referat feilet', error);
                     setSendNyMeldingStatus({ type: SendNyMeldingStatus.ERROR, fritekst: request.fritekst });
                 });
@@ -138,7 +145,7 @@ function SendNyMeldingContainer() {
                     callback();
                     setSendNyMeldingStatus({ type: SendNyMeldingStatus.SPORSMAL_SENDT, fritekst: request.fritekst });
                 })
-                .catch(error => {
+                .catch((error) => {
                     callback();
                     console.error('Send-Sporsmal feilet', error);
                     setSendNyMeldingStatus({
@@ -162,7 +169,7 @@ function SendNyMeldingContainer() {
                         fritekst: request.fritekst
                     });
                 })
-                .catch(error => {
+                .catch((error) => {
                     callback();
                     setSendNyMeldingStatus({
                         type: SendNyMeldingStatus.ERROR,

--- a/src/redux/innstillinger.ts
+++ b/src/redux/innstillinger.ts
@@ -1,5 +1,5 @@
 import { Action } from 'redux';
-import { STATUS } from '../rest/utils/utils';
+import { Pending, STATUS } from '../rest/utils/utils';
 import { assertUnreachable } from '../utils/assertUnreachable';
 import { ThunkAction } from 'redux-thunk';
 import { AppState } from './reducers';
@@ -118,12 +118,27 @@ export function oppdaterInnstillinger(
 }
 
 export const sliceSelector = (state: AppState) => state.innstillinger;
-export function getInnstilling(appState: AppState, key: InnstillingerKeys, defaultValue: string): string {
+export function getInnstilling<T extends string>(appState: AppState, key: InnstillingerKeys, defaultValue: T): T {
     const state = sliceSelector(appState);
     if (isOk(state)) {
-        return state.data.innstillinger[key] || defaultValue;
+        return (state.data.innstillinger[key] as T) || defaultValue;
     } else {
         return defaultValue;
+    }
+}
+
+export function getInnstillingPending<T extends string>(
+    appState: AppState,
+    key: InnstillingerKeys,
+    defaultValue: T
+): Pending<T> {
+    const state = sliceSelector(appState);
+    if (isOk(state)) {
+        return { pending: false, data: (state.data.innstillinger[key] as T) || defaultValue };
+    } else if (hasError(state)) {
+        return { pending: false, data: defaultValue };
+    } else {
+        return { pending: true };
     }
 }
 
@@ -141,4 +156,8 @@ export function isOk(state: State): state is OkState {
 }
 export function hasError(state: State): state is ErrorState {
     return [STATUS.FAILED, STATUS.FORBIDDEN, STATUS.NOT_FOUND].includes(state.status);
+}
+
+export function setInnstillingerData(innstillinger: SaksbehandlerInnstillinger): HentInnstillingerOk {
+    return { type: Typekeys.HENT_INNSTILLINGER_OK, data: innstillinger };
 }

--- a/src/rest/utils/utils.ts
+++ b/src/rest/utils/utils.ts
@@ -18,6 +18,7 @@ export enum STATUS {
     FAILED = 'FAILED',
     FORBIDDEN = 'FORBIDDEN'
 }
+export type Pending<T> = { pending: true } | { pending: false; data: T };
 
 export interface FetchSuccess<T> extends Action {
     data: T;

--- a/src/test/testStore.ts
+++ b/src/test/testStore.ts
@@ -17,6 +17,7 @@ import { statiskMockUtbetalingRespons } from '../mock/utbetalinger/statiskMockUt
 import { SaksbehandlerRoller } from '../app/personside/dialogpanel/RollerUtils';
 import { apiBaseUri } from '../api/config';
 import { aremark } from '../mock/persondata/aremark';
+import { setInnstillingerData } from '../redux/innstillinger';
 
 export function getTestStore(): Store<AppState> {
     const testStore = createStore(reducers, applyMiddleware(thunkMiddleware));
@@ -25,6 +26,12 @@ export function getTestStore(): Store<AppState> {
 
     const dispatch = testStore.dispatch as Dispatch<any>;
     dispatch(setGjeldendeBrukerIRedux(aremarkFnr));
+    dispatch(
+        setInnstillingerData({
+            sistLagret: new Date().toISOString(),
+            innstillinger: {}
+        })
+    );
     dispatch(restResources.innloggetSaksbehandler.actions.setData(getMockInnloggetSaksbehandler()));
     dispatch(restResources.baseUrl.actions.setData(mockBaseUrls()));
     dispatch(restResources.veilederRoller.actions.setData({ roller: [SaksbehandlerRoller.HentOppgave] }));
@@ -43,7 +50,6 @@ export function getTestStore(): Store<AppState> {
     dispatch(restResources.pleiepenger.actions.setData({ pleiepenger: [pleiepengerTestData] }));
     dispatch(restResources.foreldrepenger.actions.setData({ foreldrepenger: [statiskForeldrepengeMock] }));
     dispatch(restResources.sykepenger.actions.setData({ sykepenger: [statiskSykepengerMock] }));
-
     setupFetchCache();
 
     return testStore;


### PR DESCRIPTION
gjør det mulig for veileder/saksbehandler å velge en standard for hvor oppgaven som genereres når bruker svarer skal havne.
det er fortsatt mulig å overstyre dette ved utsending av spørsmål.

Innstillinger:
![image](https://user-images.githubusercontent.com/1413417/151339108-61f74925-0396-4af2-a18a-8d1a67decb70.png)

Dialogpanelet:
![image](https://user-images.githubusercontent.com/1413417/151339204-527d5b51-77ca-40a4-8b9d-93ba04924061.png)
