### PR TITLE
[PROD][KAIZEN-0] bytte ikon når tråd er avsluttet

### DIFF
--- a/src/app/personside/infotabs/varsel/Varsel.tsx
+++ b/src/app/personside/infotabs/varsel/Varsel.tsx
@@ -110,7 +110,7 @@ function DittNavEventVarsel({ varsel }: { varsel: DittNavEvent }) {
             <StyledPanel>
                 <article aria-labelledby={tittelId.current}>
                     <HeaderStyle onClick={toggleOpen}>
-                        <Normaltekst>{formaterDato(varsel.sistOppdatert)}</Normaltekst>
+                        <Normaltekst>{formaterDato(varsel.eventTidspunkt)}</Normaltekst>
                         <Element id={tittelId.current} tag="h4">
                             {varsel.tekst}
                         </Element>

--- a/src/mock/varsler/statiskVarselMock.ts
+++ b/src/mock/varsler/statiskVarselMock.ts
@@ -52,10 +52,10 @@ export const statiskDittnavEventVarselMock: DittNavEvent[] = [
         fodselsnummer: '',
         grupperingsId: '',
         eventId: '',
-        eventTidspunkt: '',
+        eventTidspunkt: '2018-03-01',
         produsent: '',
         sikkerhetsnivaa: 4,
-        sistOppdatert: '2018-03-01',
+        sistOppdatert: '2018-04-01',
         tekst: 'Tekst her',
         link: '',
         aktiv: true


### PR DESCRIPTION
i tilfeller hvor en tråd bare inneholder ett spørsmål fra bruker, men har blitt avsluttet så ønsker vi ikke at tråden skal regnes som ubesvart.

Denne endringen vil gjøre at ikonet for tråden endres, samt at info-alertstripen ikke teller med disse i "Bruker har XX ubesvarte henvendelser"
