### PR TITLE
[FAGSYSTEM-210073] pakke filterboks i ekspanderbartpanel for smale skjermer

### DIFF
--- a/src/app/personside/infotabs/utbetalinger/filter/Filter.tsx
+++ b/src/app/personside/infotabs/utbetalinger/filter/Filter.tsx
@@ -8,6 +8,7 @@ import UtbetaltTilValg from './UtbetaltTilValg';
 import YtelseValg from './YtelseValg';
 import { restoreScroll } from '../../../../../utils/restoreScroll';
 import { Knapp } from 'nav-frontend-knapper';
+import Ekspanderbartpanel from 'nav-frontend-ekspanderbartpanel';
 import { AppState } from '../../../../../redux/reducers';
 import { useDispatch, useSelector } from 'react-redux';
 import { oppdaterFilter } from '../../../../../redux/utbetalinger/actions';
@@ -18,6 +19,7 @@ import EgendefinertDatoInputs from './EgendefinertDatoInputs';
 import Panel from 'nav-frontend-paneler';
 import dayjs from 'dayjs';
 import { ISO_DATE_STRING_FORMAT } from 'nav-datovelger/lib/utils/dateFormatUtils';
+import MediaQueryAwareRenderer from '../../../../../components/MediaQueryAwareRenderer';
 
 const FiltreringsPanel = styled(Panel)`
     padding: ${pxToRem(15)};
@@ -100,7 +102,7 @@ function Filtrering() {
         dispatch(reloadUtbetalingerAction);
     }, [dispatch, reloadUtbetalingerAction, filter.periode]);
 
-    const radios = Object.keys(PeriodeValg).map(key => {
+    const radios = Object.keys(PeriodeValg).map((key) => {
         const label = PeriodeValg[key];
         const checked = filter.periode.radioValg === label;
         return (
@@ -162,14 +164,34 @@ function Filtrering() {
 
     return (
         <nav>
-            <FiltreringsPanel onClick={restoreScroll} aria-label="Filtrering utbetalinger">
-                <Undertittel>Filtrering</Undertittel>
+            <MediaQueryAwareRenderer
+                alternatives={{
+                    [`(min-width: ${theme.media.utbetalinger.minWidth})`]: () => (
+                        <FiltreringsPanel onClick={restoreScroll} aria-label="Filtrering utbetalinger">
+                            <Undertittel>Filtrering</Undertittel>
 
-                <WrapOnSmallScreen>
-                    {hentUtbetalingerPanel}
-                    {checkBokser}
-                </WrapOnSmallScreen>
-            </FiltreringsPanel>
+                            <WrapOnSmallScreen>
+                                {hentUtbetalingerPanel}
+                                {checkBokser}
+                            </WrapOnSmallScreen>
+                        </FiltreringsPanel>
+                    ),
+                    screen: () => (
+                        <Ekspanderbartpanel
+                            tittel="Filtrering"
+                            onClick={restoreScroll}
+                            aria-label="Filtrering utbetalinger"
+                            apen
+                            border={false}
+                        >
+                            <WrapOnSmallScreen>
+                                {hentUtbetalingerPanel}
+                                {checkBokser}
+                            </WrapOnSmallScreen>
+                        </Ekspanderbartpanel>
+                    )
+                }}
+            />
         </nav>
     );
 }

--- a/src/components/MediaQueryAwareRenderer.tsx
+++ b/src/components/MediaQueryAwareRenderer.tsx
@@ -1,0 +1,44 @@
+import * as React from 'react';
+import { useEffect, useMemo, useState } from 'react';
+
+type Alternatives = {
+    [mediaQuery: string]: () => React.ReactElement;
+};
+
+interface Props {
+    alternatives: Alternatives;
+}
+
+function useMatchMediaListeners(mediaQueries: Array<string>): Array<boolean> {
+    const listeners = useMemo(() => mediaQueries.map((it) => window.matchMedia(it)), mediaQueries); // eslint-disable-line react-hooks/exhaustive-deps
+    const [state, setState] = useState(listeners.map((it) => it.matches));
+
+    useEffect(() => {
+        const changeHandlers = listeners.map((_, i) => (e: MediaQueryListEvent) => {
+            setState((prevState) => {
+                const copy = [...prevState];
+                copy[i] = e.matches;
+                return copy;
+            });
+        });
+
+        listeners.forEach((it, i) => it.addEventListener('change', changeHandlers[i]));
+
+        return () => listeners.forEach((it, i) => it.removeEventListener('change', changeHandlers[i]));
+    }, [listeners, setState]);
+
+    return state;
+}
+
+function MediaQueryAwareRenderer(props: Props) {
+    const matchingMediaQueries = useMatchMediaListeners(Object.keys(props.alternatives));
+    const indexOfFirstMatching = matchingMediaQueries.findIndex((it) => it);
+
+    if (indexOfFirstMatching === -1) {
+        return null;
+    } else {
+        return Object.values(props.alternatives)[indexOfFirstMatching]();
+    }
+}
+
+export default MediaQueryAwareRenderer;

--- a/src/setupTests.ts
+++ b/src/setupTests.ts
@@ -22,6 +22,15 @@ JSutils.getScrollParents = () => [];
 
 window['frontendlogger'] = { info: () => null, warn: () => null, error: () => null, event: () => null };
 
+window.matchMedia = (query: string) => {
+    const querylist = {
+        matches: true,
+        addEventListener() {},
+        removeEventListener() {}
+    };
+    return querylist as unknown as MediaQueryList;
+};
+
 // Mock react collapse sin UnmountClosed
 jest.mock('react-collapse', () => {
     return {


### PR DESCRIPTION
ved smale skjermer tar filter-boksen i utbetaling-lamellen opp nesten hele skjermen.
for å gjøre denne visningen enklere så pakkes denne inn i ett ekspanderbart-panel, slik at boksen kan skjules og mer utbetalingsdata vises.

**Stor skjerm:**
![image](https://user-images.githubusercontent.com/1413417/156193866-764b8d6e-d7bf-4b10-b57a-66fcb464985d.png)

**Liten skjerm:**
![image](https://user-images.githubusercontent.com/1413417/156194007-0f0437a9-657d-4333-acab-2e76027663a1.png)

![image](https://user-images.githubusercontent.com/1413417/156193984-fdf95bed-e954-469a-9abe-894649eac6c8.png)

