### PR TITLE
[FAGSYSTEM-210465] vise informasjon om død for sivilstand

### DIFF
--- a/src/app/personside/visittkort-v2/PersondataDomain.ts
+++ b/src/app/personside/visittkort-v2/PersondataDomain.ts
@@ -6,7 +6,7 @@ export interface Data {
 export type LocalDate = string & { __type__: 'LocalDate' };
 export type LocalDateTime = string & { __type__: 'LocalDateTime' };
 
-export interface Person {
+export interface Person extends PersonMedAlderOgDodsdato {
     personIdent: string;
     navn: Array<Navn>;
     kjonn: Array<KodeBeskrivelse<Kjonn>>;
@@ -36,6 +36,11 @@ export interface Person {
     forelderBarnRelasjon: Array<ForelderBarnRelasjon>;
 }
 
+export interface PersonMedAlderOgDodsdato {
+    alder: number | null;
+    dodsdato: Array<LocalDate>;
+}
+
 export interface KodeBeskrivelse<T> {
     kode: T;
     beskrivelse: string;
@@ -52,12 +57,13 @@ export interface Statsborgerskap {
     gyldighetsPeriode: GyldighetsPeriode | null;
 }
 
-export interface SivilstandRelasjon {
+export interface SivilstandRelasjon extends PersonMedAlderOgDodsdato {
     fnr: string;
     navn: Array<Navn>;
     alder: number | null;
     adressebeskyttelse: Array<KodeBeskrivelse<AdresseBeskyttelse>>;
     harSammeAdresse: boolean;
+    dodsdato: Array<LocalDate>;
 }
 
 export interface Sivilstand {
@@ -195,7 +201,7 @@ export interface DeltBosted {
     gyldighetsPeriode: GyldighetsPeriode | null;
 }
 
-export interface ForelderBarnRelasjon {
+export interface ForelderBarnRelasjon extends PersonMedAlderOgDodsdato {
     ident: string;
     rolle: ForelderBarnRelasjonRolle;
     navn: Array<Navn>;

--- a/src/app/personside/visittkort-v2/body/__snapshots__/VisittkortBody.test.tsx.snap
+++ b/src/app/personside/visittkort-v2/body/__snapshots__/VisittkortBody.test.tsx.snap
@@ -841,8 +841,9 @@ exports[`viser info om bruker i visittkortbody 1`] = `
           className="typo-normal"
         >
           BAREMARK TESTFAMILIEN
-           
-          (40)
+           (
+          Død
+          )
         </p>
         <p
           className="typo-normal"

--- a/src/app/personside/visittkort-v2/body/familie/ForelderBarnRelasjon.tsx
+++ b/src/app/personside/visittkort-v2/body/familie/ForelderBarnRelasjon.tsx
@@ -1,7 +1,7 @@
 import { Normaltekst } from 'nav-frontend-typografi';
 import * as React from 'react';
 import { ForelderBarnRelasjon } from '../../PersondataDomain';
-import { hentAlderEllerDodRelasjon, hentNavn } from '../../visittkort-utils';
+import { hentAlderEllerDod, hentNavn } from '../../visittkort-utils';
 import VisittkortElement from '../VisittkortElement';
 import BostedForRelasjon from './common/BostedForRelasjon';
 import Diskresjonskode from './common/Diskresjonskode';
@@ -14,7 +14,7 @@ interface Props {
 }
 
 function ForelderBarnRelasjonVisning({ relasjon, beskrivelse, erBarn }: Props) {
-    const alder = hentAlderEllerDodRelasjon(relasjon) ? `(${hentAlderEllerDodRelasjon(relasjon)})` : null;
+    const alder = hentAlderEllerDod(relasjon) ? `(${hentAlderEllerDod(relasjon)})` : null;
     const navn = relasjon.navn.firstOrNull();
     return (
         <VisittkortElement beskrivelse={beskrivelse} ikon={<FamilierelasjonIkon relasjon={relasjon} erBarn={erBarn} />}>

--- a/src/app/personside/visittkort-v2/body/familie/Sivilstand.tsx
+++ b/src/app/personside/visittkort-v2/body/familie/Sivilstand.tsx
@@ -3,7 +3,7 @@ import { Normaltekst } from 'nav-frontend-typografi';
 import VisittkortElement from '../VisittkortElement';
 import HeartIkon from '../../../../../svg/Heart';
 import { Sivilstand as SivilstandInterface, SivilstandType } from '../../PersondataDomain';
-import { erPartner, hentNavn } from '../../visittkort-utils';
+import { erPartner, hentAlderEllerDod, hentNavn } from '../../visittkort-utils';
 import Diskresjonskode from './common/Diskresjonskode';
 import { formaterDato } from '../../../../../utils/string-utils';
 
@@ -32,7 +32,6 @@ function Partner(props: { partner: SivilstandInterface }) {
         return null;
     }
     const navn = partnerRelasjon.navn.firstOrNull();
-    const alder = partnerRelasjon.alder ? `(${partnerRelasjon.alder})` : null;
     return (
         <>
             <Normaltekst>
@@ -40,7 +39,7 @@ function Partner(props: { partner: SivilstandInterface }) {
             </Normaltekst>
             <Diskresjonskode adressebeskyttelse={partnerRelasjon.adressebeskyttelse} />
             <Normaltekst>
-                {navn && hentNavn(navn)} {alder}
+                {navn && hentNavn(navn)} ({hentAlderEllerDod(partnerRelasjon)})
             </Normaltekst>
             <Normaltekst>{partnerRelasjon.fnr}</Normaltekst>
             <Normaltekst>

--- a/src/app/personside/visittkort-v2/body/familie/__snapshots__/Sivilstand.test.tsx.snap
+++ b/src/app/personside/visittkort-v2/body/familie/__snapshots__/Sivilstand.test.tsx.snap
@@ -79,8 +79,9 @@ exports[`viser sivilstand 1`] = `
     className="typo-normal"
   >
     BAREMARK TESTFAMILIEN
-     
-    (40)
+     (
+    Død
+    )
   </p>
   <p
     className="typo-normal"

--- a/src/app/personside/visittkort-v2/visittkort-utils.ts
+++ b/src/app/personside/visittkort-v2/visittkort-utils.ts
@@ -3,9 +3,10 @@ import {
     AdresseBeskyttelse,
     ForelderBarnRelasjon,
     ForelderBarnRelasjonRolle,
-    KodeBeskrivelse, LocalDate,
+    KodeBeskrivelse,
+    LocalDate,
     Navn,
-    Person,
+    PersonMedAlderOgDodsdato,
     Sivilstand,
     SivilstandType
 } from './PersondataDomain';
@@ -56,18 +57,11 @@ export function hentNavn(navn: Navn | null, feilmelding: string = 'Ukjent navn')
     return navn.fornavn + (navn.mellomnavn ? ' ' + navn.mellomnavn + ' ' : ' ') + navn.etternavn;
 }
 
-export function hentAlderEllerDod(person: Person): string | undefined {
+export function hentAlderEllerDod(person: PersonMedAlderOgDodsdato): string | undefined {
     if (erDod(person.dodsdato)) {
         return 'Død';
     }
     return person.alder?.toString();
-}
-
-export function hentAlderEllerDodRelasjon(relasjon: ForelderBarnRelasjon): string | undefined {
-    if (erDod(relasjon.dodsdato)) {
-        return 'Død';
-    }
-    return relasjon.alder?.toString();
 }
 
 export function hentPeriodeTekst(gyldighetstidspunkt: string | null, opphorstidspunkt?: string | null) {

--- a/src/mock/persondata/aremark.ts
+++ b/src/mock/persondata/aremark.ts
@@ -212,7 +212,8 @@ export const aremark: Person = {
                         beskrivelse: 'UGRADERT'
                     }
                 ],
-                harSammeAdresse: true
+                harSammeAdresse: true,
+                dodsdato: ['2022-01-01' as LocalDate]
             }
         }
     ],

--- a/src/mock/persondata/persondata.ts
+++ b/src/mock/persondata/persondata.ts
@@ -212,7 +212,8 @@ export function lagPerson(fnr: string): Person {
                             beskrivelse: 'Sperret adresse, strengt fortrolig'
                         }
                     ],
-                    harSammeAdresse: false
+                    harSammeAdresse: false,
+                    dodsdato: []
                 }
             }
         ],


### PR DESCRIPTION
- [FAGSYSTEM-210465] utvide persondata modell med dodsdato for sivilstand
  legger til markerings-interfacet `PersonMedAlderOgDodsdato` for å markere alle interface som har infomasjonen nødvendig for å vise alder eller "(Død)". I første omgang er det snakk om `Person`, `SivilstandRelasjon` og `ForelderBarnRelasjon`.
- [FAGSYSTEM-210465] bruke samme logikk for utledning av alder/død
  pga markerings-interfacet `PersonMedAlderOgDodsdato` kan vi nå bruke samme logikk for utledning av alder/død på tvers av `Person` og `ForeldreBarnRelasjon`.
- [FAGSYSTEM-210465] utvide sivilstandvisning til å inkludere informasjon om person er død
