### PR TITLE
[KAIZEN-0] fjerne ubrukelige felter fra melding

### DIFF
--- a/src/app/personside/infotabs/meldinger/traadliste/__snapshots__/TraadListe.test.tsx.snap
+++ b/src/app/personside/infotabs/meldinger/traadliste/__snapshots__/TraadListe.test.tsx.snap
@@ -394,15 +394,7 @@ exports[`Viser Traadliste 1`] = `
         >
           <div
             className="c5"
-          >
-            <p
-              className="typo-element"
-            >
-              Henvendelsen er avsluttet uten å svare bruker
-               
-               
-            </p>
-          </div>
+          />
           <div
             className="c6"
           >

--- a/src/app/personside/infotabs/meldinger/traadvisning/TraadVisning.tsx
+++ b/src/app/personside/infotabs/meldinger/traadvisning/TraadVisning.tsx
@@ -54,14 +54,6 @@ function Topplinje({ valgtTraad }: { valgtTraad: Traad }) {
 
     const traadKanBesvares = kanBesvares(valgtTraad);
     const melding = eldsteMelding(valgtTraad);
-    if (melding.erFerdigstiltUtenSvar) {
-        return (
-            <AlertStripeInfo>
-                Henvendelsen er avsluttet uten å svare bruker av {saksbehandlerTekst(melding.ferdigstiltUtenSvarAv)}{' '}
-                {melding.ferdigstiltUtenSvarDato && formatterDatoMedMaanedsnavn(melding.ferdigstiltUtenSvarDato)}
-            </AlertStripeInfo>
-        );
-    }
 
     if (melding.markertSomFeilsendtAv) {
         return (

--- a/src/app/personside/infotabs/meldinger/traadvisning/__snapshots__/TraadVisningWrapper.test.tsx.snap
+++ b/src/app/personside/infotabs/meldinger/traadvisning/__snapshots__/TraadVisningWrapper.test.tsx.snap
@@ -11,7 +11,7 @@ exports[`Viser traad med verktøylinje 1`] = `
   margin-top: 1rem;
 }
 
-.c23 {
+.c24 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -235,51 +235,51 @@ exports[`Viser traad med verktøylinje 1`] = `
   white-space: nowrap;
 }
 
-.c21 .snakkeboble-panel {
+.c22 .snakkeboble-panel {
   -webkit-flex-basis: 40rem;
   -ms-flex-preferred-size: 40rem;
   flex-basis: 40rem;
 }
 
-.c21 a {
+.c22 a {
   word-break: break-word;
 }
 
-.c21 .snakkeboble {
+.c22 .snakkeboble {
   margin: 0;
 }
 
-.c24 {
+.c25 {
   font-weight: 600;
 }
 
-.c22 {
+.c23 {
   text-align: left;
 }
 
-.c22 em {
+.c23 em {
   font-style: normal;
   background-color: #eed28c;
   box-shadow: 0 0 0 0.2rem #eed28c;
   border-radius: 0.625rem;
 }
 
-.c22 > *:not(:last-child) {
+.c23 > *:not(:last-child) {
   border-bottom: solid 0.0625rem #b7b1a9;
   padding-bottom: 0.7rem;
   margin-bottom: 0.5rem;
 }
 
-.c27 {
+.c28 {
   color: #0067c5;
 }
 
-.c25 p {
+.c26 p {
   margin-bottom: 0 !important;
 }
 
-.c26 .ekspanderbartPanel__hode,
-.c26 .ekspanderbartPanel__innhold {
+.c27 .ekspanderbartPanel__hode,
+.c27 .ekspanderbartPanel__innhold {
   padding: 0.3rem 0;
 }
 
@@ -293,6 +293,20 @@ exports[`Viser traad med verktøylinje 1`] = `
 
 .c20 > *:last-child {
   margin-top: .5rem;
+}
+
+.c21 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  -webkit-align-items: flex-end;
+  -webkit-box-align: flex-end;
+  -ms-flex-align: flex-end;
+  align-items: flex-end;
 }
 
 .c0 {
@@ -318,19 +332,19 @@ exports[`Viser traad med verktøylinje 1`] = `
 }
 
 @media print {
-  .c21 {
+  .c22 {
     page-break-inside: avoid;
     border: solid 0.0625rem #78706a;
     margin-bottom: 2rem;
   }
 
-  .c21 .snakkeboble__snakkeboble-pil-container,
-  .c21 .nav-ikon,
-  .c21 .bruker-ikon {
+  .c22 .snakkeboble__snakkeboble-pil-container,
+  .c22 .nav-ikon,
+  .c22 .bruker-ikon {
     display: none;
   }
 
-  .c21 .snakkeboble-panel {
+  .c22 .snakkeboble-panel {
     -webkit-flex-basis: 100%;
     -ms-flex-preferred-size: 100%;
     flex-basis: 100%;
@@ -338,7 +352,7 @@ exports[`Viser traad med verktøylinje 1`] = `
 }
 
 @media print {
-  .c26 {
+  .c27 {
     display: none;
   }
 }
@@ -448,15 +462,7 @@ exports[`Viser traad med verktøylinje 1`] = `
         >
           <div
             className="c9"
-          >
-            <p
-              className="typo-element"
-            >
-              Henvendelsen er avsluttet uten å svare bruker
-               
-               
-            </p>
-          </div>
+          />
           <div
             className="c10"
           >
@@ -1213,46 +1219,16 @@ exports[`Viser traad med verktøylinje 1`] = `
     className="c20"
   >
     <div
-      className="alertstripe alertstripe--info"
+      className="c21"
     >
-      <span
-        className="alertstripe__ikon"
+      <button
+        className="knapp knapp--hoved"
+        disabled={false}
+        onClick={[Function]}
+        type="submit"
       >
-        <span
-          className="sr-only"
-        >
-          info
-        </span>
-        <svg
-          aria-label="info-ikon"
-          focusable="false"
-          height="1.5em"
-          kind="info-sirkel-fyll"
-          role="img"
-          viewBox="0 0 24 24"
-          width="1.5em"
-        >
-          <g
-            fill="none"
-          >
-            <path
-              d="M12 0C5.382 0 0 5.382 0 12s5.382 12 12 12c6.617 0 12-5.382 12-12S18.617 0 12 0z"
-              fill="#337C9B"
-            />
-            <path
-              d="M12 5a1.566 1.566 0 1 1 .11 3.13A1.566 1.566 0 0 1 12 5zm2.976 12.01c.563 0 1.043.431 1.043.991s-.48.992-1.043.992H9.39c-.564 0-1.043-.431-1.043-.992 0-.56.479-.99 1.043-.99h1.6v-5.016h-.986c-.565 0-1.044-.43-1.044-.991 0-.56.48-.991 1.044-.991h2.03c.563 0 1.043.43 1.043.99v6.007h1.899z"
-              fill="#FFF"
-            />
-          </g>
-        </svg>
-      </span>
-      <div
-        className="typo-normal alertstripe__tekst"
-      >
-        Henvendelsen er avsluttet uten å svare bruker av 
-        Ukjent saksbehandler
-         
-      </div>
+        Ny melding
+      </button>
     </div>
     <h3
       aria-live="polite"
@@ -1266,7 +1242,7 @@ exports[`Viser traad med verktøylinje 1`] = `
       aria-label="Dialog"
     >
       <li
-        className="c21 snakkeboble_ikoner"
+        className="c22 snakkeboble_ikoner"
       >
         <article
           aria-labelledby="Helt tilfeldig ID"
@@ -1291,13 +1267,13 @@ exports[`Viser traad med verktøylinje 1`] = `
                 className="snakkeboble-panel__tekst"
               >
                 <div
-                  className="c22"
+                  className="c23"
                 >
                   <div
                     className="Enkeltmelding__Topptekst-sc-1l864g6-2"
                   >
                     <div
-                      className="c23"
+                      className="c24"
                     >
                       <h4
                         id="Helt tilfeldig ID"
@@ -1309,7 +1285,7 @@ exports[`Viser traad med verktøylinje 1`] = `
                           4
                         </span>
                         <div
-                          className="c24"
+                          className="c25"
                         >
                           Spørsmål fra NAV - Arbeid
                         </div>
@@ -1333,7 +1309,7 @@ exports[`Viser traad med verktøylinje 1`] = `
                       Melding lest: 23.07.2019 00:00
                     </p>
                     <div
-                      className="c25 typo-normal"
+                      className="c26 typo-normal"
                     >
                       Skrevet av Kristoffer Fredriksen (xy70r8)
                     </div>
@@ -1346,7 +1322,7 @@ exports[`Viser traad med verktøylinje 1`] = `
                     </p>
                   </div>
                   <div
-                    className="ekspanderbartPanel c26 ekspanderbartPanel--lukket"
+                    className="ekspanderbartPanel c27 ekspanderbartPanel--lukket"
                   >
                     <button
                       aria-controls="Helt tilfeldig ID"
@@ -1364,7 +1340,7 @@ exports[`Viser traad med verktøylinje 1`] = `
                           className="ekspanderbartPanel__tittel"
                         >
                           <p
-                            className="typo-undertekst-bold c27"
+                            className="typo-undertekst-bold c28"
                           >
                             Meldingen er journalført
                           </p>
@@ -1393,7 +1369,7 @@ exports[`Viser traad med verktøylinje 1`] = `
         </article>
       </li>
       <li
-        className="c21 snakkeboble_ikoner"
+        className="c22 snakkeboble_ikoner"
       >
         <article
           aria-labelledby="Helt tilfeldig ID"
@@ -1418,13 +1394,13 @@ exports[`Viser traad med verktøylinje 1`] = `
                 className="snakkeboble-panel__tekst"
               >
                 <div
-                  className="c22"
+                  className="c23"
                 >
                   <div
                     className="Enkeltmelding__Topptekst-sc-1l864g6-2"
                   >
                     <div
-                      className="c23"
+                      className="c24"
                     >
                       <h4
                         id="Helt tilfeldig ID"
@@ -1436,7 +1412,7 @@ exports[`Viser traad med verktøylinje 1`] = `
                           3
                         </span>
                         <div
-                          className="c24"
+                          className="c25"
                         >
                           Spørsmål fra bruker - Helse
                         </div>
@@ -1454,7 +1430,7 @@ exports[`Viser traad med verktøylinje 1`] = `
                     </p>
                   </div>
                   <div
-                    className="ekspanderbartPanel c26 ekspanderbartPanel--lukket"
+                    className="ekspanderbartPanel c27 ekspanderbartPanel--lukket"
                   >
                     <button
                       aria-controls="Helt tilfeldig ID"
@@ -1472,7 +1448,7 @@ exports[`Viser traad med verktøylinje 1`] = `
                           className="ekspanderbartPanel__tittel"
                         >
                           <p
-                            className="typo-undertekst-bold c27"
+                            className="typo-undertekst-bold c28"
                           >
                             Meldingen er journalført
                           </p>
@@ -1501,7 +1477,7 @@ exports[`Viser traad med verktøylinje 1`] = `
         </article>
       </li>
       <li
-        className="c21 snakkeboble_ikoner"
+        className="c22 snakkeboble_ikoner"
       >
         <article
           aria-labelledby="Helt tilfeldig ID"
@@ -1526,13 +1502,13 @@ exports[`Viser traad med verktøylinje 1`] = `
                 className="snakkeboble-panel__tekst"
               >
                 <div
-                  className="c22"
+                  className="c23"
                 >
                   <div
                     className="Enkeltmelding__Topptekst-sc-1l864g6-2"
                   >
                     <div
-                      className="c23"
+                      className="c24"
                     >
                       <h4
                         id="Helt tilfeldig ID"
@@ -1544,7 +1520,7 @@ exports[`Viser traad med verktøylinje 1`] = `
                           2
                         </span>
                         <div
-                          className="c24"
+                          className="c25"
                         >
                           Spørsmål fra bruker - Arbeid
                         </div>
@@ -1562,7 +1538,7 @@ exports[`Viser traad med verktøylinje 1`] = `
                     </p>
                   </div>
                   <div
-                    className="ekspanderbartPanel c26 ekspanderbartPanel--lukket"
+                    className="ekspanderbartPanel c27 ekspanderbartPanel--lukket"
                   >
                     <button
                       aria-controls="Helt tilfeldig ID"
@@ -1580,7 +1556,7 @@ exports[`Viser traad med verktøylinje 1`] = `
                           className="ekspanderbartPanel__tittel"
                         >
                           <p
-                            className="typo-undertekst-bold c27"
+                            className="typo-undertekst-bold c28"
                           >
                             Meldingen er journalført
                           </p>
@@ -1609,7 +1585,7 @@ exports[`Viser traad med verktøylinje 1`] = `
         </article>
       </li>
       <li
-        className="c21 snakkeboble_ikoner"
+        className="c22 snakkeboble_ikoner"
       >
         <article
           aria-labelledby="Helt tilfeldig ID"
@@ -1634,13 +1610,13 @@ exports[`Viser traad med verktøylinje 1`] = `
                 className="snakkeboble-panel__tekst"
               >
                 <div
-                  className="c22"
+                  className="c23"
                 >
                   <div
                     className="Enkeltmelding__Topptekst-sc-1l864g6-2"
                   >
                     <div
-                      className="c23"
+                      className="c24"
                     >
                       <h4
                         id="Helt tilfeldig ID"
@@ -1652,7 +1628,7 @@ exports[`Viser traad med verktøylinje 1`] = `
                           1
                         </span>
                         <div
-                          className="c24"
+                          className="c25"
                         >
                           Samtalereferat oppmøte - Arbeid
                         </div>
@@ -1676,7 +1652,7 @@ exports[`Viser traad med verktøylinje 1`] = `
                       Melding lest: 12.07.2019 00:00
                     </p>
                     <div
-                      className="c25 typo-normal"
+                      className="c26 typo-normal"
                     >
                       Skrevet av Sander Hansen (nzxo4q)
                     </div>
@@ -1689,7 +1665,7 @@ exports[`Viser traad med verktøylinje 1`] = `
                     </p>
                   </div>
                   <div
-                    className="ekspanderbartPanel c26 ekspanderbartPanel--lukket"
+                    className="ekspanderbartPanel c27 ekspanderbartPanel--lukket"
                   >
                     <button
                       aria-controls="Helt tilfeldig ID"
@@ -1707,7 +1683,7 @@ exports[`Viser traad med verktøylinje 1`] = `
                           className="ekspanderbartPanel__tittel"
                         >
                           <p
-                            className="typo-undertekst-bold c27"
+                            className="typo-undertekst-bold c28"
                           >
                             Meldingen er journalført
                           </p>

--- a/src/app/personside/infotabs/meldinger/utils/meldingerUtils.test.ts
+++ b/src/app/personside/infotabs/meldinger/utils/meldingerUtils.test.ts
@@ -35,7 +35,6 @@ describe('Dokumentvarsler', () => {
 
 describe('erUbesvartHenvendelseFraBruker', () => {
     const baseMelding: Melding = {
-        erFerdigstiltUtenSvar: false,
         fritekst: '',
         id: '1234',
         meldingstype: Meldingstype.SPORSMAL_SKRIFTLIG,
@@ -64,10 +63,6 @@ describe('erUbesvartHenvendelseFraBruker', () => {
         expect(erUbesvartHenvendelseFraBruker(traad)).toBe(false);
     });
 
-    it('Tråder som er markert med "avslutt uten å svare" skal ikke regnes som ubesvarte', () => {
-        const traad: Traad = { traadId: '', meldinger: [{ ...baseMelding, erFerdigstiltUtenSvar: true }] };
-        expect(erUbesvartHenvendelseFraBruker(traad)).toBe(false);
-    });
     it('Tråder som er avsluttet skal ikke regnes som ubesvarte', () => {
         const traad: Traad = {
             traadId: '',

--- a/src/app/personside/infotabs/meldinger/utils/meldingerUtils.ts
+++ b/src/app/personside/infotabs/meldinger/utils/meldingerUtils.ts
@@ -61,7 +61,7 @@ export function erUbesvartHenvendelseFraBruker(traad: Traad): boolean {
         return false;
     }
 
-    return !melding.avsluttetDato && !melding.erFerdigstiltUtenSvar;
+    return !melding.avsluttetDato;
 }
 
 export function erMeldingFraNav(meldingstype: Meldingstype) {
@@ -100,10 +100,7 @@ export function erMeldingFeilsendt(melding: Melding): boolean {
 }
 
 export function erBehandlet(traad: Traad): boolean {
-    const minstEnMeldingErFraNav: boolean = traad.meldinger.some((melding) => erMeldingFraNav(melding.meldingstype));
-    const erFerdigstiltUtenSvar: boolean = eldsteMelding(traad).erFerdigstiltUtenSvar;
-
-    return minstEnMeldingErFraNav || erFerdigstiltUtenSvar;
+    return traad.meldinger.some((melding) => erMeldingFraNav(melding.meldingstype));
 }
 
 export function saksbehandlerTekst(saksbehandler?: Saksbehandler) {

--- a/src/mock/dialoger/sf-dialoger-mock.ts
+++ b/src/mock/dialoger/sf-dialoger-mock.ts
@@ -48,7 +48,6 @@ function simulateSf(trader: Traad[]): Traad[] {
     trader.forEach((trad: Traad) => {
         trad.meldinger.forEach((melding: Melding, index: number) => {
             melding.id = guid(); // Denne informasjonen får vi ikke, og autogenereres derfor på backend
-            melding.oppgaveId = undefined; // Denne informasjonen får vi ikke
 
             // SF har bare samtalereferat og meldingskjede, så vi utleder de gamle typene etter beste evne.
             melding.meldingstype = (() => {
@@ -60,11 +59,6 @@ function simulateSf(trader: Traad[]): Traad[] {
                     return index === 0 ? Meldingstype.SPORSMAL_MODIA_UTGAAENDE : Meldingstype.SVAR_SKRIFTLIG;
                 }
             })();
-            melding.statusTekst = undefined;
-            // ferdigstilt finnes ikke i SF
-            melding.erFerdigstiltUtenSvar = false;
-            melding.ferdigstiltUtenSvarDato = undefined;
-            melding.ferdigstiltUtenSvarAv = undefined;
         });
     });
     return trader;

--- a/src/mock/meldinger/meldinger-mock.ts
+++ b/src/mock/meldinger/meldinger-mock.ts
@@ -52,7 +52,6 @@ function getMockTraad(): Traad {
 
 function getMelding(temagruppe: Temagruppe): Melding {
     const visKontrosperre = navfaker.random.vektetSjanse(0.1);
-    const ferdigstilUtenSvar = navfaker.random.vektetSjanse(0.1);
     const visMarkertSomFeilsendt = navfaker.random.vektetSjanse(0.1);
     const meldingstype = navfaker.random.arrayElement(Object.entries(Meldingstype))[0];
     const sladdingNiva = navfaker.random.arrayElement([0, 0, 0, 0, 1, 1, 1, 1, 2]);
@@ -93,11 +92,6 @@ function getMelding(temagruppe: Temagruppe): Melding {
         status: navfaker.random.arrayElement([LestStatus.IkkeLest, LestStatus.Lest]),
         opprettetDato: dayjs(faker.date.recent(40)).format(backendDatoTidformat),
         ferdigstiltDato: dayjs(faker.date.recent(40)).format(backendDatoTidformat),
-        erFerdigstiltUtenSvar: ferdigstilUtenSvar,
-        ferdigstiltUtenSvarDato: ferdigstilUtenSvar
-            ? dayjs(faker.date.recent(40)).format(backendDatoTidformat)
-            : undefined,
-        ferdigstiltUtenSvarAv: ferdigstilUtenSvar ? getSaksbehandler() : undefined,
         kontorsperretAv: visKontrosperre ? getSaksbehandler() : undefined,
         kontorsperretEnhet: visKontrosperre ? faker.company.companyName() : undefined,
         sendtTilSladding: sladdingNiva !== 0,

--- a/src/mock/meldinger/statiskTraadMock.ts
+++ b/src/mock/meldinger/statiskTraadMock.ts
@@ -18,7 +18,6 @@ export const statiskTraadMock: Traad = {
             opprettetDato: '2019-07-30',
             journalfortDato: '2019-07-11',
             ferdigstiltDato: '2019-07-07',
-            erFerdigstiltUtenSvar: true,
             sendtTilSladding: false
         },
         {
@@ -34,7 +33,6 @@ export const statiskTraadMock: Traad = {
             opprettetDato: '2019-08-10',
             journalfortDato: '2019-07-21',
             ferdigstiltDato: '2019-07-16',
-            erFerdigstiltUtenSvar: true,
             sendtTilSladding: false
         },
         {
@@ -50,7 +48,6 @@ export const statiskTraadMock: Traad = {
             opprettetDato: '2019-08-06',
             journalfortDato: '2019-08-12',
             ferdigstiltDato: '2019-07-12',
-            erFerdigstiltUtenSvar: true,
             sendtTilSladding: false
         },
         {
@@ -66,7 +63,6 @@ export const statiskTraadMock: Traad = {
             opprettetDato: '2019-08-13',
             journalfortDato: '2019-07-30',
             ferdigstiltDato: '2019-07-27',
-            erFerdigstiltUtenSvar: false,
             sendtTilSladding: false
         }
     ]

--- a/src/mock/mockBackend/meldingerBackendMock.ts
+++ b/src/mock/mockBackend/meldingerBackendMock.ts
@@ -125,7 +125,6 @@ function getMockMelding(): Melding {
         fritekst: 'Dette er en mock-melding',
         status: LestStatus.IkkeLest,
         opprettetDato: dayjs().format(backendDatoTidformat),
-        erFerdigstiltUtenSvar: false,
         sendtTilSladding: false
     };
 }

--- a/src/models/meldinger/meldinger.ts
+++ b/src/models/meldinger/meldinger.ts
@@ -8,7 +8,6 @@ export interface Traad {
 
 export interface Melding {
     id: string;
-    oppgaveId?: string;
     meldingstype: Meldingstype;
     temagruppe: Temagruppe | null;
     skrevetAvTekst: string;
@@ -20,17 +19,13 @@ export interface Melding {
     fritekst: string;
     lestDato?: string;
     status: LestStatus;
-    statusTekst?: string;
     opprettetDato: string;
     ferdigstiltDato?: string;
     avsluttetDato?: string;
-    erFerdigstiltUtenSvar: boolean;
-    ferdigstiltUtenSvarAv?: Saksbehandler;
     kontorsperretEnhet?: string;
     kontorsperretAv?: Saksbehandler;
     sendtTilSladding: boolean;
     markertSomFeilsendtAv?: Saksbehandler;
-    ferdigstiltUtenSvarDato?: string;
 }
 
 export interface Saksbehandler {

--- a/src/utils/print/MeldingerPrintMarkup.tsx
+++ b/src/utils/print/MeldingerPrintMarkup.tsx
@@ -7,7 +7,7 @@ import {
     meldingstittel
 } from '../../app/personside/infotabs/meldinger/utils/meldingerUtils';
 import { Element, Ingress, Normaltekst } from 'nav-frontend-typografi';
-import { datoStigende, formatterDatoMedMaanedsnavn, formatterDatoTid } from '../date-utils';
+import { datoStigende, formatterDatoTid } from '../date-utils';
 import styled from 'styled-components';
 import theme from '../../styles/personOversiktTheme';
 import { formaterDato } from '../string-utils';
@@ -92,23 +92,16 @@ function EnkeltMeldingMarkup({ melding }: { melding: Melding }) {
 function MeldingerPrintMarkup(props: Props) {
     const melding = eldsteMelding(props.valgtTraad);
 
-    const ferdigstiltUtenSvar = melding.erFerdigstiltUtenSvar && (
-        <Element>
-            Henvendelsen er avsluttet uten å svare bruker{' '}
-            {melding.ferdigstiltUtenSvarDato && formatterDatoMedMaanedsnavn(melding.ferdigstiltUtenSvarDato)}{' '}
-        </Element>
-    );
     const feilsendt = melding.markertSomFeilsendtAv && (
         <Element> Markert som feilsendt av {melding.markertSomFeilsendtAv.ident?.toUpperCase()}</Element>
     );
     const kontorsperre = melding.kontorsperretAv && <Element>Kontorsperret for {melding.kontorsperretEnhet}</Element>;
     const enkeltmeldinger = props.valgtTraad.meldinger
-        .sort(datoStigende(melding => melding.opprettetDato))
-        .map(melding => <EnkeltMeldingMarkup melding={melding} key={melding.id} />);
+        .sort(datoStigende((melding) => melding.opprettetDato))
+        .map((melding) => <EnkeltMeldingMarkup melding={melding} key={melding.id} />);
     return (
         <StyledTraad>
             <Topptekst>
-                {ferdigstiltUtenSvar}
                 {feilsendt}
                 {kontorsperre}
             </Topptekst>


### PR DESCRIPTION
feltene er hardkodet i backend etter overgangen til salesforce, og det er derfor ikke noe behov for å håndtere disse i frontend mer
