### PR TITLE
[KAIZEN-0] bruke samme terminologi

### DIFF
--- a/src/app/personside/infotabs/meldinger/traadvisning/TraadVisning.tsx
+++ b/src/app/personside/infotabs/meldinger/traadvisning/TraadVisning.tsx
@@ -75,9 +75,7 @@ function Topplinje({ valgtTraad }: { valgtTraad: Traad }) {
                 {melding.sendtTilSladding && (
                     <AlertStripeInfo>Tråden ligger til behandling for sladding</AlertStripeInfo>
                 )}
-                {melding.avsluttetDato && !traadKanBesvares && (
-                    <AlertStripeInfo>Henvendelsen er avsluttet</AlertStripeInfo>
-                )}
+                {melding.avsluttetDato && !traadKanBesvares && <AlertStripeInfo>Dialogen er avsluttet</AlertStripeInfo>}
             </>
         );
     }


### PR DESCRIPTION
Operasjonen for avsluttning heter "Avslutt dialog", og det bør derfor samsvare med alertstripen som dukker opp etter gjennomføring
