### PR TITLE
[KAIZEN-0] ikke vise null om vi mangler ident ved foreldreansvar

### DIFF
--- a/src/app/personside/visittkort-v2/body/foreldreansvar/Foreldreansvar.tsx
+++ b/src/app/personside/visittkort-v2/body/foreldreansvar/Foreldreansvar.tsx
@@ -14,8 +14,11 @@ function kombinerNavnOgIdent(personInfo: NavnOgIdent | null): string | null {
     if (!personInfo) {
         return null;
     }
+
     const navn = hentNavn(personInfo.navn);
-    return personInfo.navn ? `${navn} (${personInfo.ident})` : navn;
+    const ident = personInfo.ident ? personInfo.ident : 'Ukjent fnr/dnr';
+
+    return personInfo.navn ? `${navn} (${ident})` : navn;
 }
 
 function ForeldreansvarElement(props: { foreldreansvar: Foreldreansvar }) {


### PR DESCRIPTION
det finnes tilfeller hvor person under foreldreansvar kommer tilbake fra pdl med `ansvarligUtenIdentifikator`, i disse tilfellene har vi bare navn (og alder) på ansvarlig.
I stedet for å vise `(null)` viser vi nå `(Ukjent fnr/dnr)`
