### PR TITLE
[OPP-1043] filtrere ut saker basert på fagsystem saksID

### DIFF
--- a/src/app/personside/infotabs/meldinger/traadvisning/verktoylinje/journalforing/JournalforingPanel.tsx
+++ b/src/app/personside/infotabs/meldinger/traadvisning/verktoylinje/journalforing/JournalforingPanel.tsx
@@ -38,7 +38,7 @@ export interface JournalforingsSak {
 
 export interface JournalforingsSakIdentifikator {
     temaKode: string;
-    saksId?: string;
+    fagsystemSaksId?: string;
 }
 
 export type Result = { saker: Array<JournalforingsSak>; feiledeSystemer: Array<string> };
@@ -69,7 +69,7 @@ function JournalforingPanel(props: Props) {
     const kanJournalforeFlere = useFeatureToggle(FeatureToggles.KanJournalforeFlere)?.isOn ?? false;
     const eksisterendeJournalposter: Array<JournalforingsSakIdentifikator> = props.traad.journalposter.map((jp) => ({
         temaKode: jp.journalfortTema,
-        saksId: jp.journalfortSaksid
+        fagsystemSaksId: jp.journalfortSaksid
     }));
 
     const kanJournalfores = kanTraadJournalfores(props.traad, kanJournalforeFlere);

--- a/src/app/personside/infotabs/meldinger/traadvisning/verktoylinje/journalforing/VelgSak.test.ts
+++ b/src/app/personside/infotabs/meldinger/traadvisning/verktoylinje/journalforing/VelgSak.test.ts
@@ -1,8 +1,8 @@
 import { fjernSakerSomAlleredeErTilknyttet, fordelSaker } from './VelgSak';
 import { JournalforingsSak, JournalforingsSakIdentifikator, SakKategori } from './JournalforingPanel';
 
-function sak(sakstype: 'GEN' | 'FAG', temaKode: string, saksId?: string): JournalforingsSak {
-    return { sakstype, temaKode, temaNavn: temaKode, saksId } as JournalforingsSak;
+function sak(sakstype: 'GEN' | 'FAG', temaKode: string, fagsystemSaksId?: string): JournalforingsSak {
+    return { sakstype, temaKode, temaNavn: temaKode, fagsystemSaksId } as JournalforingsSak;
 }
 
 describe('fordelSaker', () => {
@@ -41,7 +41,9 @@ describe('fjernSakerSomAlleredeErTilknyttet', () => {
     ];
 
     it('skal fjerne sak som allerede er journalført på', () => {
-        const eksisterendeSaker: Array<JournalforingsSakIdentifikator> = [{ temaKode: 'DAG', saksId: 'DAG_ID_2' }];
+        const eksisterendeSaker: Array<JournalforingsSakIdentifikator> = [
+            { temaKode: 'DAG', fagsystemSaksId: 'DAG_ID_2' }
+        ];
 
         const lovligeSaker = fjernSakerSomAlleredeErTilknyttet(saker, eksisterendeSaker);
 
@@ -57,5 +59,16 @@ describe('fjernSakerSomAlleredeErTilknyttet', () => {
 
         const lovligeSaker = fjernSakerSomAlleredeErTilknyttet(saker, eksisterendeSaker);
         expect(lovligeSaker).toHaveLength(4);
+    });
+
+    it('skal fjerne saker på tvers av ulike tema', () => {
+        const eksisterendeSaker: Array<JournalforingsSakIdentifikator> = [
+            { temaKode: 'AAP', fagsystemSaksId: 'DAG_ID_2' }
+        ];
+
+        const lovligeSaker = fjernSakerSomAlleredeErTilknyttet(saker, eksisterendeSaker);
+
+        expect(lovligeSaker).not.toContainEqual(sak('FAG', 'DAG', 'DAG_ID_2'));
+        expect(lovligeSaker).toHaveLength(3);
     });
 });

--- a/src/app/personside/infotabs/meldinger/traadvisning/verktoylinje/journalforing/VelgSak.tsx
+++ b/src/app/personside/infotabs/meldinger/traadvisning/verktoylinje/journalforing/VelgSak.tsx
@@ -85,18 +85,20 @@ export function fjernSakerSomAlleredeErTilknyttet(
     saker: Array<JournalforingsSak>,
     eksisterendeSaker: Array<JournalforingsSakIdentifikator>
 ): Array<JournalforingsSak> {
-    const temagrupperte = eksisterendeSaker
-        .filter((it) => it.saksId !== undefined)
+    const eksisterendeSakerMap: Group<string> = eksisterendeSaker
+        .filter((it) => it.fagsystemSaksId !== undefined)
+        .map((it) => it.fagsystemSaksId as string)
         .reduce(
-            groupBy((it) => it.temaKode),
+            groupBy((it) => it),
             {}
         );
 
     return saker.filter((sak) => {
-        const tema = sak.temaKode;
-        const temasaker: JournalforingsSakIdentifikator[] = temagrupperte[tema] ?? [];
-        const erJournalfortPaSak = temasaker.find((it) => it.saksId === sak.saksId);
-        return !erJournalfortPaSak;
+        if (sak.fagsystemSaksId) {
+            return eksisterendeSakerMap[sak.fagsystemSaksId] === undefined;
+        } else {
+            return true;
+        }
     });
 }
 


### PR DESCRIPTION
Salesforce returnerer fagsystems saksid og vanlig saksId. Vi må derfor filtrere på denne id'en istedetfor.
Vi filtrerer også utelukkende på fagsystemSakID og fjerner tema fra sjekken for å unngå trøbbel med duplikat-saker som kan forekomme for UFO/PEN.
