### PR TITLE
[KAIZEN-0] fjerne felt fra dittnav-eventer type

### DIFF
--- a/src/models/varsel.ts
+++ b/src/models/varsel.ts
@@ -11,7 +11,6 @@ export interface DittNavEvent {
     aktiv: boolean;
 }
 export interface DittNavBeskjed extends DittNavEvent {
-    uid: string;
     synligFremTil?: string;
 }
 


### PR DESCRIPTION
feltet er ubrukt og nå fjernet fra api
