### PR TITLE
[OPP-1462] endre valideringstekst på søk for kontonummer

### DIFF
--- a/src/app/personsok/PersonsokSkjema.test.ts
+++ b/src/app/personsok/PersonsokSkjema.test.ts
@@ -107,7 +107,12 @@ test('Valider krav om gatenavn ved husbokstav', () => {
     expect(validator).toEqual({ ...ingenFeil, gatenavn: 'Gatenavn må være satt hvis husbokstav er satt' });
 });
 
+test('Valider krav om korrekt lengde på kontonummer', () => {
+    const validator = validatorPersonsok({ ...initialValues, kontonummer: '123' });
+    expect(validator).toEqual({ ...ingenFeil, kontonummer: 'Kontonummer må kun bestå av tall og være 11 siffer' });
+});
+
 test('Valider krav om korrekt kontonummer', () => {
     const validator = validatorPersonsok({ ...initialValues, kontonummer: '12345678910' });
-    expect(validator).toEqual({ ...ingenFeil, kontonummer: 'Kontonummer må kun bestå av tall og være 11 siffer' });
+    expect(validator).toEqual({ ...ingenFeil, kontonummer: 'Kontonummer må være et gyldig norsk kontonummer' });
 });

--- a/src/app/personsok/kontonummer/kontonummerUtils.test.ts
+++ b/src/app/personsok/kontonummer/kontonummerUtils.test.ts
@@ -1,19 +1,25 @@
-import { validerKontonummer } from './kontonummerUtils';
+import { erGyldigNorskKontonummer, removeWhitespaceAndDot, validerLengdeOgTallPaKontonummer } from './kontonummerUtils';
 
-it('Validerer gyldig kontonummer', () => {
+it('Validerer gyldig norsk kontonummer', () => {
     const kontonummer = '12345678911';
 
-    expect(validerKontonummer(kontonummer)).toBe(true);
+    expect(erGyldigNorskKontonummer(kontonummer)).toBe(true);
 });
 
-it('Validerer gyldig kontonummer med punktum og mellomrom', () => {
-    const kontonummer = '12345.67 8911';
+it('Validerer fjerning av punktum og whitespace', () => {
+    const kontonummer = '1234.56 78911';
 
-    expect(validerKontonummer(kontonummer)).toBe(true);
+    expect(removeWhitespaceAndDot(kontonummer)).toHaveLength(11);
 });
 
-it('Validerer ikke ugyldig kontonummer', () => {
+it('Validerer ugyldig når bokstaver i kontonummer', () => {
+    const kontonummer = '12345.67 891a';
+
+    expect(validerLengdeOgTallPaKontonummer(kontonummer)).toBe(false);
+});
+
+it('Validerer ugyldig kontonummer', () => {
     const kontonummer = '12345678910';
 
-    expect(validerKontonummer(kontonummer)).toBe(false);
+    expect(erGyldigNorskKontonummer(kontonummer)).toBe(false);
 });

--- a/src/app/personsok/kontonummer/kontonummerUtils.ts
+++ b/src/app/personsok/kontonummer/kontonummerUtils.ts
@@ -1,18 +1,34 @@
-export function validerKontonummer(kontonummer?: string) {
+export function validerLengdeOgTallPaKontonummer(kontonummer?: string): boolean {
     if (!kontonummer) {
         return false;
     }
 
     kontonummer = removeWhitespaceAndDot(kontonummer);
-    if (kontonummer.length !== 11) {
+    if (inneholderBokstaver(kontonummer)) {
         return false;
     }
 
-    return parseInt(kontonummer.charAt(kontonummer.length - 1), 10) === mod11FraTallMedKontrollsiffer(kontonummer);
+    return kontonummer.length === 11;
 }
 
 export function removeWhitespaceAndDot(kontonummer: string): string {
     return kontonummer.toString().replace(/[. ]/g, '');
+}
+
+export function erGyldigNorskKontonummer(kontonummer?: string): boolean {
+    if (!kontonummer) {
+        return false;
+    }
+
+    kontonummer = removeWhitespaceAndDot(kontonummer);
+    return (
+        kontonummer !== undefined &&
+        parseInt(kontonummer.charAt(kontonummer.length - 1), 10) === mod11FraTallMedKontrollsiffer(kontonummer)
+    );
+}
+
+function inneholderBokstaver(kontonummer: string): boolean {
+    return /[a-zA-Z]/i.test(kontonummer);
 }
 
 function mod11FraTallMedKontrollsiffer(kontonummer: string) {

--- a/src/app/personsok/kontonummer/kontonummerUtils.ts
+++ b/src/app/personsok/kontonummer/kontonummerUtils.ts
@@ -21,10 +21,7 @@ export function erGyldigNorskKontonummer(kontonummer?: string): boolean {
     }
 
     kontonummer = removeWhitespaceAndDot(kontonummer);
-    return (
-        kontonummer !== undefined &&
-        parseInt(kontonummer.charAt(kontonummer.length - 1), 10) === mod11FraTallMedKontrollsiffer(kontonummer)
-    );
+    return parseInt(kontonummer.charAt(kontonummer.length - 1), 10) === mod11FraTallMedKontrollsiffer(kontonummer);
 }
 
 function inneholderBokstaver(kontonummer: string): boolean {

--- a/src/app/personsok/personsok-utils.ts
+++ b/src/app/personsok/personsok-utils.ts
@@ -1,6 +1,10 @@
 import { PersonsokRequest } from '../../models/person/personsok';
 import { Mapped, Values } from '@nutgaard/use-formstate';
-import { removeWhitespaceAndDot, validerKontonummer } from './kontonummer/kontonummerUtils';
+import {
+    erGyldigNorskKontonummer,
+    removeWhitespaceAndDot,
+    validerLengdeOgTallPaKontonummer
+} from './kontonummer/kontonummerUtils';
 import { erTall } from '../../utils/string-utils';
 import dayjs from 'dayjs';
 
@@ -54,8 +58,10 @@ export function validatorPersonsok(values: PersonSokFormState) {
 
     const andreFelter = navnFelter.concat(adresseFelter).concat([values.utenlandskID]);
     const andreFelterErSatt = andreFelter.some((it) => it.length > 0);
-    if (values.kontonummer && !validerKontonummer(values.kontonummer)) {
+    if (values.kontonummer && !validerLengdeOgTallPaKontonummer(values.kontonummer)) {
         kontonummer = 'Kontonummer må kun bestå av tall og være 11 siffer';
+    } else if (values.kontonummer && !erGyldigNorskKontonummer(values.kontonummer)) {
+        kontonummer = 'Kontonummer må være et gyldig norsk kontonummer';
     } else if (values.kontonummer && andreFelterErSatt) {
         kontonummer = 'Kan ikke kombinere søk på kontonummer med andre felt';
     }


### PR DESCRIPTION
Sjekken på om det er gyldig norsk kontonummer er flyttet til en egen tilbakemelding, slik at brukeren vet hva som er feil selv om man oppfyller de to andre kravene om lengde og siffer:
<img width="567" alt="image" src="https://user-images.githubusercontent.com/37441744/169017383-e7bd58f9-1ff2-4eca-935d-e981ab74f89f.png">
