### PR TITLE
[PROD][OPP-1462] endre valideringstekst på søk for kontonummer

### DIFF
--- a/.nais/prod.yaml
+++ b/.nais/prod.yaml
@@ -23,10 +23,10 @@ spec:
   resources:
     requests:
       cpu: 100m
-      memory: 256Mi
+      memory: 128Mi
     limits:
       cpu: 200m
-      memory: 512Mi
+      memory: 192Mi
   ingresses:
     - https://app.adeo.no/modiapersonoversikt
   replicas:

--- a/.nais/qa-template.yaml
+++ b/.nais/qa-template.yaml
@@ -23,10 +23,10 @@ spec:
   resources:
     requests:
       cpu: 100m
-      memory: 256Mi
+      memory: 128Mi
     limits:
-      cpu: 2000m
-      memory: 512Mi
+      cpu: 200m
+      memory: 192Mi
   ingresses:
     - https://app-{{ q_env }}.adeo.no/modiapersonoversikt
   replicas:

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,3 +1,3 @@
-FROM ghcr.io/navikt/modialogin/modialogin-frontend:13bb4e101997429eeef15066dd60fc9580b31cc6
-ADD proxy.json /proxy-config.json
-COPY build /www
+FROM ghcr.io/navikt/modialogin/frontend:07ae8590782619aa863c4ee66bf3d13c745d9261
+ADD proxy.nginx /nginx
+COPY build /app

--- a/proxy.json
+++ b/proxy.json
@@ -1,7 +1,0 @@
-[
-    {
-        "prefix": "proxy/dittnav-eventer-modia",
-        "url": "$env{APP_ADEO_DOMAIN}/dittnav-eventer-modia",
-        "rewriteDirectives": ["SET_HEADER Cookie 'ID_token=$cookie{modia_ID_token}'"]
-    }
-]

--- a/proxy.nginx
+++ b/proxy.nginx
@@ -1,0 +1,7 @@
+location  /modiapersonoversikt/proxy/dittnav-eventer-modia/ {
+    # dittnav-eventer-modia forventer ID_token, så bytter navn på cookie her.
+    proxy_set_header Cookie "ID_token=$cookie_modia_ID_token;";
+    # Sender det så videre til riktig domene.
+    # APP_ADEO_DOMAIN er definert som en miljøvariabel i nais.yaml, og blir injected inn av modialogin-imaget.
+    proxy_pass "${APP_ADEO_DOMAIN}/dittnav-eventer-modia/";
+}


### PR DESCRIPTION
Sjekken på om det er gyldig norsk kontonummer er flyttet til en egen tilbakemelding, slik at brukeren vet hva som er feil selv om man oppfyller de to andre kravene om lengde og siffer:
<img width="567" alt="image" src="https://user-images.githubusercontent.com/37441744/169017383-e7bd58f9-1ff2-4eca-935d-e981ab74f89f.png">
