### PR TITLE
[KAIZEN-0] Legger til egen endringstekst for bankkonto

### DIFF
--- a/src/app/personside/visittkort-v2/body/__snapshots__/VisittkortBody.test.tsx.snap
+++ b/src/app/personside/visittkort-v2/body/__snapshots__/VisittkortBody.test.tsx.snap
@@ -718,9 +718,8 @@ exports[`viser info om bruker i visittkortbody 1`] = `
           >
             Endret 
             15.03.2006
-             av 
-            
              
+            av bruker
           </p>
         </div>
       </div>

--- a/src/app/personside/visittkort-v2/body/endringsTekstTPS/EndringstekstTPS.test.tsx
+++ b/src/app/personside/visittkort-v2/body/endringsTekstTPS/EndringstekstTPS.test.tsx
@@ -1,0 +1,85 @@
+import { endretAvTekst } from './EndringstekstTPS';
+
+it('Formaterer tom endretAv til ønsket visningsformat', () => {
+    const rawString = '';
+    const formatertTekst = endretAvTekst(rawString);
+
+    expect(formatertTekst).toEqual('');
+});
+
+it('Formaterer endretAv tall + BD03 (brukerprofil-app = bruker) tekst til ønsket visningsformat', () => {
+    const rawString = '1010800, BD03';
+    const formatertTekst = endretAvTekst(rawString);
+
+    expect(formatertTekst).toEqual('av bruker');
+});
+
+it('Formaterer endretAv tall + PP01 (PSelv-app - bruker) tekst til ønsket visningsformat', () => {
+    const rawString = 'Srvpsel, PP01';
+    const formatertTekst = endretAvTekst(rawString);
+
+    expect(formatertTekst).toEqual('av bruker');
+});
+
+it('Formaterer endretAv ident + BD06 (modiabrukerdialog-app - NAV) tekst til ønsket visningsformat', () => {
+    const rawString = 'X108000, BD06';
+    const formatertTekst = endretAvTekst(rawString);
+
+    expect(formatertTekst).toEqual('av NAV');
+});
+
+it('Formaterer endretAv ident (med liten bokstav) + BD06 tekst til ønsket visningsformat', () => {
+    const rawString = 'x108000, BD06';
+    const formatertTekst = endretAvTekst(rawString);
+
+    expect(formatertTekst).toEqual('av NAV');
+});
+
+it('Formaterer endretAv gammel type ident + IT00 (Infotrygd-app - NAV) tekst til ønsket visningsformat', () => {
+    const rawString = 'AAH1234, IT00';
+    const formatertTekst = endretAvTekst(rawString);
+
+    expect(formatertTekst).toEqual('av NAV');
+});
+
+it('Formaterer endretAv Konvert + IT00 (Infotrygd-app - NAV) tekst til ønsket visningsformat', () => {
+    const rawString = 'KONVERT, IT00';
+    const formatertTekst = endretAvTekst(rawString);
+
+    expect(formatertTekst).toEqual('av NAV');
+});
+
+it('Formaterer endretAv ident + PP01 (modiabrukerdialog-app - NAV) tekst til ønsket visningsformat', () => {
+    const rawString = 'srvPensjon, PP01';
+    const formatertTekst = endretAvTekst(rawString);
+
+    expect(formatertTekst).toEqual('av NAV');
+});
+
+it('Formaterer endretAv Arena, PP01 (modiabrukerdialog-app - NAV) tekst til ønsket visningsformat', () => {
+    const rawString = 'ARENA, PP01';
+    const formatertTekst = endretAvTekst(rawString);
+
+    expect(formatertTekst).toEqual('av NAV');
+});
+
+it('Formaterer endretAv ident + FS21 (Gosys-app - NAV) tekst til ønsket visningsformat', () => {
+    const rawString = 'X108001, FS21';
+    const formatertTekst = endretAvTekst(rawString);
+
+    expect(formatertTekst).toEqual('av NAV');
+});
+
+it('Formaterer endretAv tekst + SKD (Skatt/Folkeregisteret) tekst til ønsket visningsformat', () => {
+    const rawString = 'AJOURHD, SKD';
+    const formatertTekst = endretAvTekst(rawString);
+
+    expect(formatertTekst).toEqual('i Folkeregisteret');
+});
+
+it('Formaterer endretAv tekst + SKD (Skatt/Folkeregisteret) tekst til ønsket visningsformat', () => {
+    const rawString = 'AAA2101, SKD';
+    const formatertTekst = endretAvTekst(rawString);
+
+    expect(formatertTekst).toEqual('av Skatteetaten');
+});

--- a/src/app/personside/visittkort-v2/body/endringsTekstTPS/EndringstekstTPS.tsx
+++ b/src/app/personside/visittkort-v2/body/endringsTekstTPS/EndringstekstTPS.tsx
@@ -22,7 +22,7 @@ function EndringstekstTPS({ sistEndret }: Props) {
 }
 export default EndringstekstTPS;
 
-export const FOLKEREGISTERET = 'SKD';
+const FOLKEREGISTERET = 'SKD';
 
 export function endretAvTekst(rawString: string): string {
     if (endretAvBruker(rawString) || endretIPSelv(rawString)) {
@@ -34,7 +34,7 @@ export function endretAvTekst(rawString: string): string {
         endretAvKonvertItSystem(rawString)
     ) {
         return 'av NAV';
-    } else if (rawString.match('AAA2101, SKD')) {
+    } else if (rawString.match(`AAA2101, ${FOLKEREGISTERET}`)) {
         return 'av Skatteetaten';
     } else if (endretIFolkeregisteret(rawString)) {
         return 'i Folkeregisteret';

--- a/src/app/personside/visittkort-v2/body/endringsTekstTPS/EndringstekstTPS.tsx
+++ b/src/app/personside/visittkort-v2/body/endringsTekstTPS/EndringstekstTPS.tsx
@@ -1,0 +1,84 @@
+import * as React from 'react';
+import EtikettGraa from '../../../../../components/EtikettGraa';
+import { formaterDato } from '../../../../../utils/string-utils';
+import { SistEndret } from '../../PersondataDomain';
+
+interface Props {
+    sistEndret: SistEndret | null;
+}
+function EndringstekstTPS({ sistEndret }: Props) {
+    if (!sistEndret) {
+        return null;
+    }
+
+    const formatertdato = formaterDato(new Date(sistEndret.tidspunkt));
+    const endretAv = endretAvTekst(sistEndret.ident);
+
+    return (
+        <EtikettGraa>
+            Endret {formatertdato} {endretAv}
+        </EtikettGraa>
+    );
+}
+export default EndringstekstTPS;
+
+export const FOLKEREGISTERET = 'SKD';
+
+export function endretAvTekst(rawString: string): string {
+    if (endretAvBruker(rawString) || endretIPSelv(rawString)) {
+        return 'av bruker';
+    } else if (
+        endretIFagsystem(rawString) ||
+        endretIPesys(rawString) ||
+        endretIArena(rawString) ||
+        endretAvKonvertItSystem(rawString)
+    ) {
+        return 'av NAV';
+    } else if (rawString.match('AAA2101, SKD')) {
+        return 'av Skatteetaten';
+    } else if (endretIFolkeregisteret(rawString)) {
+        return 'i Folkeregisteret';
+    } else {
+        return rawString;
+    }
+}
+
+function endretIFolkeregisteret(rawString: string) {
+    return (
+        rawString.match(FOLKEREGISTERET) ||
+        rawString.toLowerCase() === 'folkeregisteret' ||
+        rawString.toLowerCase() === 'freg'
+    );
+}
+
+function endretIFagsystem(rawString: string) {
+    return rawString && (endretAvNyTypeIdent(rawString) || endretAvGammelTypeIdent(rawString));
+}
+
+function endretAvNyTypeIdent(rawString: string) {
+    return rawString.toUpperCase().match('[A-Z][0-9]{6}');
+}
+
+function endretAvGammelTypeIdent(rawString: string) {
+    return rawString.toUpperCase().match('[A-Z]{3}[0-9]{4}, [A-Z]{2}[0-9]{2}');
+}
+
+function endretIPSelv(rawString: string) {
+    return rawString.match('Srvpsel');
+}
+
+function endretIArena(rawString: string) {
+    return rawString.match(/arena/i);
+}
+
+function endretAvKonvertItSystem(rawString: string) {
+    return rawString.match(/konvert, IT[0-9]{2}/i);
+}
+
+function endretIPesys(rawString: string) {
+    return rawString.match('srvPensjon');
+}
+
+function endretAvBruker(rawString: string) {
+    return rawString.match('[0-9]{7}');
+}

--- a/src/app/personside/visittkort-v2/body/kontaktinformasjon/bankkonto/Bankkonto.tsx
+++ b/src/app/personside/visittkort-v2/body/kontaktinformasjon/bankkonto/Bankkonto.tsx
@@ -4,7 +4,7 @@ import CoinsIkon from '../../../../../../svg/Coins';
 import { Feilmelding, Normaltekst } from 'nav-frontend-typografi';
 import { FormatertKontonummer } from '../../../../../../utils/FormatertKontonummer';
 import { Bankkonto as BankkontoInterface } from '../../../PersondataDomain';
-import Endringstekst from '../../Endringstekst';
+import EndringstekstTPS from '../../endringsTekstTPS/EndringstekstTPS';
 
 interface Props {
     harFeilendeSystem: boolean;
@@ -38,7 +38,7 @@ function Bankkonto({ harFeilendeSystem, bankkonto }: Props) {
             <Normaltekst>
                 <FormatertKontonummer kontonummer={bankkonto.kontonummer} />
             </Normaltekst>
-            <Endringstekst sistEndret={bankkonto.sistEndret} />
+            <EndringstekstTPS sistEndret={bankkonto.sistEndret} />
         </VisittkortElement>
     );
 }


### PR DESCRIPTION
Siden bankkonto blir hentet fra TPS, så har vi ikke samme informasjon tilgjengelig på den. Vi trenger derfor å bruke den gamle måten vi viste endringstekst på, hvor vi også håndterte mapping av ident