### PR TITLE
[KAIZEN-0] legge til muligheten for å oppdatere/slette drafts via websockets

### DIFF
--- a/src/app/personside/dialogpanel/use-draft.ts
+++ b/src/app/personside/dialogpanel/use-draft.ts
@@ -70,10 +70,6 @@ function useDraftWS(context: DraftContext, ifPresent: (draft: Draft) => void = (
             }, 500),
         [context]
     );
-    // const update = useCallback((content: string) => {
-    //     const data: WsEvent = { type: "UPDATE", context, content };
-    //     wsRef.current?.send(JSON.stringify(data))
-    // }, [context]);
 
     const remove = useCallback(() => {
         const data: WsEvent = { type: 'DELETE', context, content: null };

--- a/src/mock/context-mock.ts
+++ b/src/mock/context-mock.ts
@@ -11,15 +11,7 @@ export const enheter = [
     { enhetId: '0602', navn: 'NAV Drammer' }
 ];
 
-class VoidWebSocket {
-    addEventListener() {}
-    removeEventListener() {}
-    send() {}
-    close() {}
-}
-
 export function setupWsControlAndMock(mock: FetchMock) {
-    (window as any).WebSocket = VoidWebSocket;
     const baseUrl = `https://${window.location.host}`;
 
     mock.post(baseUrl + '/modiacontextholder/api/context', ({ body }, res, ctx) => {

--- a/src/mock/draft-mock.ts
+++ b/src/mock/draft-mock.ts
@@ -3,6 +3,7 @@ import { getMockInnloggetSaksbehandler } from './innloggetSaksbehandler-mock';
 import { Draft, DraftContext } from '../app/personside/dialogpanel/use-draft';
 import { randomDelay } from './index';
 import { delayed } from './utils-mock';
+import MockWebsocket from './mock-websocket';
 
 const innloggetSaksbehandler = getMockInnloggetSaksbehandler();
 const storage = window.localStorage;
@@ -28,11 +29,11 @@ function matchContext(context: DraftContext, other: DraftContext, exact: boolean
     const otherKeys = Object.keys(other);
     if (exact && keys.length !== otherKeys.length) {
         return false;
-    } else if (exact && !keys.every(key => otherKeys.includes(key))) {
+    } else if (exact && !keys.every((key) => otherKeys.includes(key))) {
         return false;
     }
 
-    return otherKeys.every(key => {
+    return otherKeys.every((key) => {
         const value = context[key];
         const otherValue = other[key];
         return value === otherValue;
@@ -71,9 +72,16 @@ const deleteDraft: MockHandler = ({ body }, res, ctx) => {
     return res(ctx.status(200));
 };
 
+const generateUid: MockHandler = ({ body }, res, ctx) => {
+    return res(ctx.status(200), ctx.text('abba-acdc-1231-beef'));
+};
+
+MockWebsocket.setup();
+
 export function setupDraftMock(mock: FetchMock) {
     // console.log(findDrafts, updateDraft, deleteDraft);
     mock.get('/modiapersonoversikt-draft/api/draft', delayed(2 * randomDelay(), findDrafts));
     mock.post('/modiapersonoversikt-draft/api/draft', delayed(2 * randomDelay(), updateDraft));
     mock.delete('/modiapersonoversikt-draft/api/draft', delayed(2 * randomDelay(), deleteDraft));
+    mock.get('/modiapersonoversikt-draft/api/generate-uid', delayed(2 * randomDelay(), generateUid));
 }

--- a/src/mock/mock-websocket.ts
+++ b/src/mock/mock-websocket.ts
@@ -1,0 +1,75 @@
+type WebSocketIsh = Pick<WebSocket, 'close' | 'send' | 'addEventListener'>;
+
+class VoidWebSocket {
+    addEventListener() {}
+    removeEventListener() {}
+    send() {}
+    close() {}
+}
+export default class MockWebsocket implements WebSocketIsh {
+    private openEventListeners: Array<(this: WebSocket, ev: WebSocketEventMap['open']) => any> = [];
+    private closeEventListeners: Array<(this: WebSocket, ev: WebSocketEventMap['close']) => any> = [];
+    private messageEventListeners: Array<(this: WebSocket, ev: WebSocketEventMap['message']) => any> = [];
+    private errorEventListeners: Array<(this: WebSocket, ev: WebSocketEventMap['error']) => any> = [];
+    private openEvent: Array<WebSocketEventMap['open']> = [];
+    private closeEvent: Array<WebSocketEventMap['close']> = [];
+    private static draftConnectionAttempt: number = 0;
+
+    constructor(url: string) {
+        this.openEvent.push(new Event('open'));
+        if (MockWebsocket.draftConnectionAttempt++ < 2) {
+            this.closeEvent.push(new CloseEvent('close', { code: 4010, reason: 'Unauthorized' } as CloseEventInit));
+        }
+    }
+
+    close(code?: number, reason?: string): void {
+        this.closeEvent.push(new CloseEvent('close', { code, reason } as CloseEventInit));
+    }
+
+    send(data: string | ArrayBuffer | ArrayBufferView | Blob): void {
+        console.log('sending WS data', data);
+    }
+
+    addEventListener<K extends keyof WebSocketEventMap>(
+        type: K,
+        listener: (this: WebSocket, ev: WebSocketEventMap[K]) => any,
+        options?: boolean | AddEventListenerOptions
+    ): void {
+        switch (type) {
+            case 'message':
+                this.messageEventListeners.push(listener as any);
+                break;
+            case 'error':
+                this.errorEventListeners.push(listener as any);
+                break;
+            case 'open':
+                this.openEventListeners.push(listener as any);
+                break;
+            case 'close':
+                this.closeEventListeners.push(listener as any);
+                break;
+        }
+        if (type === 'open') {
+            this.openEvent.forEach((event) => listener.call(this as unknown as WebSocket, event as any));
+        } else if (type === 'close') {
+            this.closeEvent.forEach((event) => listener.call(this as unknown as WebSocket, event as any));
+        }
+    }
+
+    static wsOriginal: WebSocket = (window as any).WebSocket;
+    static setup() {
+        (window as any).WebSocket = (url: string) => {
+            if (url.includes('@localhost:3000/modiapersonoversikt-draft/api/draft/ws')) {
+                return new MockWebsocket(url);
+            } else if (url.includes('veilederflatehendelser')) {
+                return new VoidWebSocket();
+            } else {
+                // @ts-ignore
+                return new MockWebsocket.wsOriginal(url);
+            }
+        };
+    }
+    static restore() {
+        (window as any).WebSocket = MockWebsocket.wsOriginal;
+    }
+}

--- a/src/utils/retry.ts
+++ b/src/utils/retry.ts
@@ -1,0 +1,30 @@
+export function retry<T>(max: number = 3, block: () => T): T {
+    let count = 0;
+    let error: unknown | undefined = undefined;
+
+    while (count < max) {
+        try {
+            return block();
+        } catch (e: unknown) {
+            error = e;
+        }
+        count++;
+    }
+    throw error;
+}
+
+export async function retryAsync<T>(max: number = 3, block: () => Promise<T>): Promise<T> {
+    let count = 0;
+    let error: unknown | undefined = undefined;
+
+    while (count < max) {
+        try {
+            return await block();
+        } catch (e: unknown) {
+            error = e;
+        }
+
+        count++;
+    }
+    throw error;
+}

--- a/src/utils/websocket-impl.ts
+++ b/src/utils/websocket-impl.ts
@@ -1,0 +1,162 @@
+const SECONDS: number = 1000;
+const MINUTES: number = 60 * SECONDS;
+const MAX_RETRIES: number = 30;
+
+export enum Status {
+    INIT,
+    OPEN,
+    CLOSE,
+    REFRESH
+}
+
+export interface Listeners {
+    onMessage?(event: MessageEvent, connection: WebSocketImpl): void;
+    onOpen?(event: Event, connection: WebSocketImpl): void;
+    onError?(event: Event, connection: WebSocketImpl): void;
+    onClose?(event: CloseEvent, connection: WebSocketImpl): void;
+}
+
+function fuzzy(min: number, max: number): number {
+    const diff = max - min;
+    const rnd = Math.round(Math.random() * diff);
+    return min + rnd;
+}
+
+function createDelay(basedelay: number): number {
+    return basedelay + fuzzy(5 * SECONDS, 15 * SECONDS);
+}
+
+function createRetrytime(tryCount: number): number {
+    if (tryCount === MAX_RETRIES) {
+        return Number.MAX_SAFE_INTEGER;
+    }
+
+    const basedelay = Math.min(Math.pow(2, tryCount), 180) * SECONDS;
+    return basedelay + fuzzy(5 * SECONDS, 15 * SECONDS);
+}
+
+class WebSocketImpl {
+    private status: Status;
+    private readonly wsUrl: string;
+    private readonly listeners: Listeners;
+    private connection?: WebSocket;
+    private resettimer?: number | null;
+    private retrytimer?: number | null;
+    private retryCounter: number = 0;
+
+    constructor(wsUrl: string, listeners: Listeners) {
+        this.wsUrl = wsUrl;
+        this.listeners = listeners;
+        this.status = Status.INIT;
+    }
+
+    public open() {
+        if (this.status === Status.CLOSE) {
+            WebSocketImpl.print('Stopping creation of WS, since it is closed');
+            return;
+        }
+        WebSocketImpl.print('Opening WS', this.wsUrl);
+        this.connection = new WebSocket(this.wsUrl);
+        this.connection.addEventListener('open', this.onWSOpen.bind(this));
+        this.connection.addEventListener('message', this.onWSMessage.bind(this));
+        this.connection.addEventListener('error', this.onWSError.bind(this));
+        this.connection.addEventListener('close', this.onWSClose.bind(this));
+    }
+
+    public close() {
+        WebSocketImpl.print('Closing WS', this.wsUrl);
+        this.clearResetTimer();
+        this.clearRetryTimer();
+        this.status = Status.CLOSE;
+        if (this.connection) {
+            this.connection.close();
+        }
+    }
+
+    public getStatus() {
+        return this.status;
+    }
+
+    public send(data: string | ArrayBuffer | ArrayBufferView | Blob): void {
+        if (this.connection) {
+            this.connection.send(data);
+        }
+    }
+
+    private onWSOpen(event: Event) {
+        WebSocketImpl.print('open', event);
+        this.clearResetTimer();
+        this.clearRetryTimer();
+
+        const delay = createDelay(45 * MINUTES);
+        WebSocketImpl.print('Creating resettimer', delay);
+
+        this.resettimer = window.setTimeout(() => {
+            this.status = Status.REFRESH;
+            if (this.connection) {
+                this.connection.close();
+            }
+        }, delay);
+
+        this.status = Status.OPEN;
+
+        if (this.listeners.onOpen) {
+            this.listeners.onOpen(event, this);
+        }
+    }
+
+    private onWSMessage(event: MessageEvent) {
+        WebSocketImpl.print('message', event);
+        if (this.listeners.onMessage) {
+            this.listeners.onMessage(event, this);
+        }
+    }
+
+    private onWSError(event: Event) {
+        WebSocketImpl.print('error', event);
+        if (this.listeners.onError) {
+            this.listeners.onError(event, this);
+        }
+    }
+
+    private onWSClose(event: CloseEvent) {
+        WebSocketImpl.print('close', event);
+        if (this.status === Status.REFRESH) {
+            this.open();
+            return;
+        }
+
+        if (this.status !== Status.CLOSE) {
+            const delay = createRetrytime(this.retryCounter++);
+            WebSocketImpl.print('Creating retrytimer', delay);
+
+            this.retrytimer = window.setTimeout(this.open.bind(this), delay);
+        }
+        if (this.listeners.onClose) {
+            this.listeners.onClose(event, this);
+        }
+    }
+
+    private clearResetTimer() {
+        if (this.resettimer) {
+            window.clearTimeout(this.resettimer);
+        }
+        this.resettimer = null;
+    }
+
+    private clearRetryTimer() {
+        if (this.retrytimer) {
+            window.clearTimeout(this.retrytimer);
+        }
+        this.retrytimer = null;
+        this.retryCounter = 0;
+    }
+
+    private static print(...args: any[]) {
+        if (process.env.REACT_APP_MOCK_ENABLED === 'true') {
+            console.log('WS:', ...args); // tslint:disable-line
+        }
+    }
+}
+
+export default WebSocketImpl;


### PR DESCRIPTION
ved en overgang til obo-tokens mellom apper må kall gjennom en frontend-proxy. Draft-appen kan motta veldig mange kall da vi automatisk synker data hit når folk skriver en melding. For å unngå at alle disse kallene må gjennom frontend-proxy legges det til en måte å oppdatere tekstene via websockets.
