### PR TITLE
[KAIZEN-0] gjøre kall til modia-apper via proxy

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,3 +1,3 @@
-FROM ghcr.io/navikt/modialogin/modialogin-frontend:d8a85b849e50a2c57a4376b2fe6b67ecbdb2098d
+FROM ghcr.io/navikt/modialogin/modialogin-frontend:486149d77668084f0f19510c27cf2aa941004f40-beta
 ADD proxy.json /proxy-config.json
 COPY build /www

--- a/proxy.json
+++ b/proxy.json
@@ -3,5 +3,21 @@
         "prefix": "proxy/dittnav-eventer-modia",
         "url": "$env{APP_ADEO_DOMAIN}/dittnav-eventer-modia",
         "rewriteDirectives": ["SET_HEADER Cookie 'ID_token=$cookie{modia_ID_token}'"]
+    },
+    {
+        "prefix": "proxy/modia-skrivestotte",
+        "url": "$env{APP_ADEO_DOMAIN}/modiapersonoversikt-skrivestotte"
+    },
+    {
+        "prefix": "proxy/modia-draft",
+        "url": "$env{APP_ADEO_DOMAIN}/modiapersonoversikt-draft"
+    },
+    {
+        "prefix": "proxy/modia-innstillinger",
+        "url": "$env{APP_ADEO_DOMAIN}/modiapersonoversikt-innstillinger"
+    },
+    {
+        "prefix": "proxy/modiacontextholder",
+        "url": "$env{APP_ADEO_DOMAIN}/modiacontextholder"
     }
 ]

--- a/src/app/internarbeidsflatedecorator/Decorator.tsx
+++ b/src/app/internarbeidsflatedecorator/Decorator.tsx
@@ -93,7 +93,7 @@ function lagConfig(
         },
         // modiacontextholder kjører på samme domene som modiapersonoversikt.
         // Som default brukes app.adeo.no, så her tvinger vi dekoratøren over på nytt domene
-        useProxy: `https://${window.location.host}`
+        useProxy: `https://${window.location.host}/proxy`
     };
 }
 
@@ -129,7 +129,7 @@ function getFnrFraUrl(): { sokFnr: string | null; pathFnr: string | null } {
 
 function Decorator() {
     const reduxErKlar = useVenterPaRedux();
-    const valgtEnhet = useAppState(state => state.session.valgtEnhetId);
+    const valgtEnhet = useAppState((state) => state.session.valgtEnhetId);
     const history = useHistory();
     const dispatch = useDispatch();
     const queryParams = useQueryParams<{ sokFnr?: string }>();

--- a/src/app/personside/dialogpanel/sendMelding/standardTekster/StandardTekster.tsx
+++ b/src/app/personside/dialogpanel/sendMelding/standardTekster/StandardTekster.tsx
@@ -114,7 +114,7 @@ function velgTekst(
 
 function StandardTekster(props: Props) {
     const sokRef = React.useRef<HTMLElement>(null);
-    const standardTekster = useFetch<StandardTeksterModels.Tekster>('/modiapersonoversikt-skrivestotte/skrivestotte');
+    const standardTekster = useFetch<StandardTeksterModels.Tekster>('/proxy/modia-skrivestotte/skrivestotte');
     const debouncedSokefelt = useDebounce(props.sokefelt.input.value, 250);
     const [filtrerteTekster, settFiltrerteTekster] = useState(() =>
         sokEtterTekster(standardTekster, debouncedSokefelt)

--- a/src/app/personside/dialogpanel/sendMelding/standardTekster/sokUtils.tsx
+++ b/src/app/personside/dialogpanel/sendMelding/standardTekster/sokUtils.tsx
@@ -3,7 +3,7 @@ import { parseTekst } from '@navikt/tag-input';
 import * as StandardTekster from './domain';
 
 export function rapporterBruk(tekst: StandardTekster.Tekst): void {
-    fetch(`/modiapersonoversikt-skrivestotte/skrivestotte/statistikk/${tekst.id}`, { method: 'POST' });
+    fetch(`/proxy/modia-skrivestotte/skrivestotte/statistikk/${tekst.id}`, { method: 'POST' });
 }
 
 export function sokEtterTekster(
@@ -17,23 +17,23 @@ export function sokEtterTekster(
 
     const { tags: queryTags, text } = parseTekst(query);
 
-    const tags = queryTags.map(tag => tag.toLowerCase());
+    const tags = queryTags.map((tag) => tag.toLowerCase());
     const words = text
         .split(' ')
-        .map(word => word.toLowerCase().replace('#', ''))
-        .filter(it => it);
+        .map((word) => word.toLowerCase().replace('#', ''))
+        .filter((it) => it);
 
     return tekster
-        .filter(tekst => {
-            const searchTags = tekst.tags.map(tag => tag.toLowerCase());
-            return tags.every(tag => searchTags.includes(tag));
+        .filter((tekst) => {
+            const searchTags = tekst.tags.map((tag) => tag.toLowerCase());
+            return tags.every((tag) => searchTags.includes(tag));
         })
-        .filter(tekst => {
+        .filter((tekst) => {
             const matchtext = [tekst.overskrift, Object.values(tekst.innhold).join('\u0000'), tekst.tags.join('\u0000')]
                 .join('\u0000')
                 .toLowerCase();
 
-            return words.every(word => matchtext.includes(word));
+            return words.every((word) => matchtext.includes(word));
         });
 }
 

--- a/src/app/personside/dialogpanel/use-draft.ts
+++ b/src/app/personside/dialogpanel/use-draft.ts
@@ -29,7 +29,7 @@ function useDraftWS(context: DraftContext, ifPresent: (draft: Draft) => void = (
     const wsRef = useRef<WebSocketImpl>();
     useEffect(() => {
         const urlProvider = async (ws: WebSocketImpl) => {
-            const response: Response = await fetch(`/modiapersonoversikt-draft/api/generate-uid`);
+            const response: Response = await fetch(`/proxy/modia-draft/api/generate-uid`);
             if (response.status === 401) {
                 ws.close();
                 return '\u0000';
@@ -73,7 +73,7 @@ function useDraftWS(context: DraftContext, ifPresent: (draft: Draft) => void = (
             .map(([key, value]) => `${key}=${value}`)
             .join('&');
 
-        fetch(`/modiapersonoversikt-draft/api/draft?exact=true&${queryParams}`)
+        fetch(`/proxy/modia-draft/api/draft?exact=true&${queryParams}`)
             .then((resp) => resp.json())
             .then((json: Array<Draft>) => {
                 if (json.length > 0) {
@@ -92,7 +92,7 @@ export function useDraft(context: DraftContext, ifPresent: (draft: Draft) => voi
     const update = useMemo(
         () =>
             debounce((content: string) => {
-                fetch('/modiapersonoversikt-draft/api/draft', {
+                fetch('/proxy/modia-draft/api/draft', {
                     method: 'POST',
                     headers: {
                         'Content-Type': 'application/json'
@@ -106,7 +106,7 @@ export function useDraft(context: DraftContext, ifPresent: (draft: Draft) => voi
     );
 
     const remove = useCallback(() => {
-        fetch('/modiapersonoversikt-draft/api/draft', {
+        fetch('/proxy/modia-draft/api/draft', {
             method: 'DELETE',
             headers: {
                 'Content-Type': 'application/json'
@@ -122,7 +122,7 @@ export function useDraft(context: DraftContext, ifPresent: (draft: Draft) => voi
             .map(([key, value]) => `${key}=${value}`)
             .join('&');
 
-        fetch(`/modiapersonoversikt-draft/api/draft?exact=true&${queryParams}`)
+        fetch(`/proxy/modia-draft/api/draft?exact=true&${queryParams}`)
             .then((resp) => resp.json())
             .then((json: Array<Draft>) => {
                 if (json.length > 0) {

--- a/src/components/autocomplete-textarea/autocomplete-textarea.tsx
+++ b/src/components/autocomplete-textarea/autocomplete-textarea.tsx
@@ -312,7 +312,7 @@ function AutocompleteTextarea(props: TextareaProps) {
     const autofullforData = useAutoFullforData();
     const [feilmelding, settFeilmelding] = useState<string>();
     const standardtekster: FetchResult<StandardTeksterModels.Tekster> = useFetch<StandardTeksterModels.Tekster>(
-        '/modiapersonoversikt-skrivestotte/skrivestotte'
+        '/proxy/modia-skrivestotte/skrivestotte'
     );
     const rules = useRules();
     const onChange = props.onChange;

--- a/src/mock/context-mock.ts
+++ b/src/mock/context-mock.ts
@@ -14,7 +14,7 @@ export const enheter = [
 export function setupWsControlAndMock(mock: FetchMock) {
     const baseUrl = `https://${window.location.host}`;
 
-    mock.post(baseUrl + '/modiacontextholder/api/context', ({ body }, res, ctx) => {
+    mock.post(baseUrl + '/proxy/modiacontextholder/api/context', ({ body }, res, ctx) => {
         if (body.eventType === 'NY_AKTIV_ENHET') {
             context.aktivEnhet = body.verdi;
             return res(ctx.status(200));
@@ -26,13 +26,13 @@ export function setupWsControlAndMock(mock: FetchMock) {
         }
     });
 
-    mock.delete(baseUrl + '/modiacontextholder/api/context', (req, res, ctx) => {
+    mock.delete(baseUrl + '/proxy/modiacontextholder/api/context', (req, res, ctx) => {
         context.aktivBruker = null;
         context.aktivEnhet = null;
         return res(ctx.status(200));
     });
 
-    mock.get(baseUrl + '/modiacontextholder/api/context/aktivenhet', (req, res, ctx) =>
+    mock.get(baseUrl + '/proxy/modiacontextholder/api/context/aktivenhet', (req, res, ctx) =>
         res(
             ctx.json({
                 aktivEnhet: context.aktivEnhet,
@@ -41,12 +41,12 @@ export function setupWsControlAndMock(mock: FetchMock) {
         )
     );
 
-    mock.delete(baseUrl + '/modiacontextholder/api/context/aktivbruker', (req, res, ctx) => {
+    mock.delete(baseUrl + '/proxy/modiacontextholder/api/context/aktivbruker', (req, res, ctx) => {
         context.aktivBruker = null;
         return res(ctx.status(200));
     });
 
-    mock.get(baseUrl + '/modiacontextholder/api/context/aktivbruker', (req, res, ctx) =>
+    mock.get(baseUrl + '/proxy/modiacontextholder/api/context/aktivbruker', (req, res, ctx) =>
         res(
             ctx.json({
                 aktivEnhet: null,
@@ -55,7 +55,7 @@ export function setupWsControlAndMock(mock: FetchMock) {
         )
     );
 
-    mock.get(baseUrl + '/modiacontextholder/api/context', (req, res, ctx) =>
+    mock.get(baseUrl + '/proxy/modiacontextholder/api/context', (req, res, ctx) =>
         res(
             ctx.json({
                 aktivEnhet: context.aktivEnhet,
@@ -64,7 +64,7 @@ export function setupWsControlAndMock(mock: FetchMock) {
         )
     );
 
-    mock.get(baseUrl + '/modiacontextholder/api/decorator/aktor/:fnr', (req, res, ctx) =>
+    mock.get(baseUrl + '/proxy/modiacontextholder/api/decorator/aktor/:fnr', (req, res, ctx) =>
         res(ctx.json({ fnr: req.pathParams.fnr, aktorId: `0000${req.pathParams.fnr}0000` }))
     );
 
@@ -76,7 +76,7 @@ export function setupWsControlAndMock(mock: FetchMock) {
         enheter: enheter
     };
 
-    mock.get(baseUrl + '/modiacontextholder/api/decorator', (req, res, ctx) => res(ctx.json(me)));
+    mock.get(baseUrl + '/proxy/modiacontextholder/api/decorator', (req, res, ctx) => res(ctx.json(me)));
 
     mock.get('https://app-q0.adeo.no/aktoerregister/api/v1/identer', (req, res, ctx) => {
         const fnr = (req.init!.headers! as Record<string, string>)['Nav-Personidenter'];

--- a/src/mock/index.ts
+++ b/src/mock/index.ts
@@ -319,12 +319,12 @@ function opprettSkjermetOppgaveMock(mock: FetchMock) {
 
 function setupStandardteksterMock(mock: FetchMock) {
     mock.get(
-        '/modiapersonoversikt-skrivestotte/skrivestotte',
+        '/proxy/modia-skrivestotte/skrivestotte',
         withDelayedResponse(randomDelay(), STATUS_OK, () => standardTekster)
     );
 
     mock.post(
-        '/modiapersonoversikt-skrivestotte/skrivestotte/statistikk/:id',
+        '/proxy/modia-skrivestotte/skrivestotte/statistikk/:id',
         withDelayedResponse(randomDelay(), STATUS_OK, () => undefined)
     );
 }

--- a/src/mock/saksbehandlerinnstillinger-mock.ts
+++ b/src/mock/saksbehandlerinnstillinger-mock.ts
@@ -13,12 +13,12 @@ let innstillinger: SaksbehandlerInnstillinger =
 
 export function setupSaksbehandlerInnstillingerMock(mock: FetchMock) {
     mock.get(
-        '/modiapersonoversikt-innstillinger/api/innstillinger',
+        '/proxy/modia-innstillinger/api/innstillinger',
         (req, res, ctx) => res(ctx.delay(500), ctx.json(innstillinger))
         // ResponseUtils.delayed(500, () => Promise.resolve({ status: 404 }))
     );
 
-    mock.post('/modiapersonoversikt-innstillinger/api/innstillinger', (req, res, ctx) => {
+    mock.post('/proxy/modia-innstillinger/api/innstillinger', (req, res, ctx) => {
         innstillinger = {
             sistLagret: new Date().toISOString(),
             innstillinger: req.body

--- a/src/redux/innstillinger.ts
+++ b/src/redux/innstillinger.ts
@@ -82,7 +82,7 @@ export function fetchInnstillinger(): ThunkAction<void, AppState, void, Actions>
             }
 
             dispatch({ type: Typekeys.HENT_INNSTILLINGER_REQUEST });
-            const response = await fetch('/modiapersonoversikt-innstillinger/api/innstillinger');
+            const response = await fetch('/proxy/modia-innstillinger/api/innstillinger');
             if (!response.ok) {
                 dispatch({
                     type: Typekeys.HENT_INNSTILLINGER_ERROR,
@@ -103,10 +103,7 @@ export function oppdaterInnstillinger(
 ): ThunkAction<Promise<SaksbehandlerInnstillinger>, AppState, null, Actions> {
     return async (dispatch) => {
         try {
-            const response = await fetch(
-                '/modiapersonoversikt-innstillinger/api/innstillinger',
-                postConfig(innstillinger)
-            );
+            const response = await fetch('/proxy/modia-innstillinger/api/innstillinger', postConfig(innstillinger));
             const data = await response.json();
             dispatch({ type: Typekeys.HENT_INNSTILLINGER_OK, data });
             return data;


### PR DESCRIPTION
kall til skrivestotte, draft, innstillinger og modiacontextholder gjøres via proxy slik at cookies kan låses ned til kun å gjelde modiapersonoversikt
