### PR TITLE
[FAGSYSTEM-241955] legge til manuell oppfølging etikett

### DIFF
--- a/src/app/personside/visittkort-v2/PersondataDomain.ts
+++ b/src/app/personside/visittkort-v2/PersondataDomain.ts
@@ -31,7 +31,7 @@ export interface Person extends PersonMedAlderOgDodsdato {
     vergemal: Array<Verge>;
     tilrettelagtKommunikasjon: TilrettelagtKommunikasjon;
     telefonnummer: Array<Telefon>;
-    kontaktOgReservasjon: DigitalKontaktinformasjon | null;
+    kontaktInformasjon: KontaktInformasjon;
     bankkonto: Bankkonto | null;
     forelderBarnRelasjon: Array<ForelderBarnRelasjon>;
 }
@@ -282,23 +282,13 @@ export enum ForelderBarnRelasjonRolle {
     UKJENT = 'UKJENT'
 }
 
-/**
- * DKIF Data klasser
- */
-export interface DigitalKontaktinformasjon {
-    personident: string | null;
-    reservasjon: string | null;
-    epostadresse: Epostadresse | null;
-    mobiltelefonnummer: MobilTelefon | null;
+export interface KontaktInformasjon {
+    erManuell: boolean | null;
+    erReservert: boolean | null;
+    epost: DkifVerdi | null;
+    mobil: DkifVerdi | null;
 }
-
-export interface Epostadresse {
-    value: string | null;
-    sistOppdatert: LocalDate | null;
-    sistVerifisert: LocalDate | null;
-}
-
-export interface MobilTelefon {
+export interface DkifVerdi {
     value: string | null;
     sistOppdatert: LocalDate | null;
     sistVerifisert: LocalDate | null;

--- a/src/app/personside/visittkort-v2/body/kontaktinformasjon/DigitalKontaktinformasjon.tsx
+++ b/src/app/personside/visittkort-v2/body/kontaktinformasjon/DigitalKontaktinformasjon.tsx
@@ -3,13 +3,13 @@ import * as React from 'react';
 import EtikettGraa from '../../../../../components/EtikettGraa';
 
 interface Props {
-    reservasjon: string | null;
+    erReservert: boolean | null;
     kontaktinformasjonVerdi: string | null;
     sistOppdatert: string | null;
 }
 
-function DigitalKontaktinformasjon({ reservasjon, kontaktinformasjonVerdi, sistOppdatert }: Props) {
-    if (reservasjon === 'true') {
+function DigitalKontaktinformasjon({ erReservert, kontaktinformasjonVerdi, sistOppdatert }: Props) {
+    if (erReservert) {
         return (
             <>
                 <Normaltekst>Reservert</Normaltekst>

--- a/src/app/personside/visittkort-v2/body/kontaktinformasjon/Kontaktinformasjon.tsx
+++ b/src/app/personside/visittkort-v2/body/kontaktinformasjon/Kontaktinformasjon.tsx
@@ -26,11 +26,11 @@ export default function Kontaktinformasjon({ persondata }: Props) {
             <Adresse person={persondata.person} />
             <Epost
                 harFeilendeSystem={harFeilendeSystemer(persondata.feilendeSystemer, InformasjonElement.DKIF)}
-                kontaktinformasjon={persondata.person.kontaktOgReservasjon}
+                kontaktinformasjon={persondata.person.kontaktInformasjon}
             />
             <Telefon
                 harFeilendeSystem={harFeilendeSystemer(persondata.feilendeSystemer, InformasjonElement.DKIF)}
-                kontaktinformasjon={persondata.person.kontaktOgReservasjon}
+                kontaktinformasjon={persondata.person.kontaktInformasjon}
             />
             <NavKontaktinformasjon
                 harFeilendeSystem={harFeilendeSystemer(

--- a/src/app/personside/visittkort-v2/body/kontaktinformasjon/epost/Epost.tsx
+++ b/src/app/personside/visittkort-v2/body/kontaktinformasjon/epost/Epost.tsx
@@ -1,14 +1,14 @@
 import * as React from 'react';
 import EmailIkon from '../../../../../../svg/Email';
 import VisittkortElement from '../../VisittkortElement';
-import { DigitalKontaktinformasjon as DigitalKontaktinformasjonInterface } from '../../../PersondataDomain';
+import { KontaktInformasjon } from '../../../PersondataDomain';
 import DigitalKontaktinformasjon from '../DigitalKontaktinformasjon';
 import { formaterDato } from '../../../../../../utils/string-utils';
 import { Feilmelding } from 'nav-frontend-typografi';
 
 interface Props {
     harFeilendeSystem: boolean;
-    kontaktinformasjon: DigitalKontaktinformasjonInterface | null;
+    kontaktinformasjon: KontaktInformasjon | null;
 }
 
 function Epost({ harFeilendeSystem, kontaktinformasjon }: Props) {
@@ -22,15 +22,15 @@ function Epost({ harFeilendeSystem, kontaktinformasjon }: Props) {
     if (!kontaktinformasjon) {
         return null;
     }
-    const epost = kontaktinformasjon.epostadresse?.value ?? null;
-    const sistOppdatert = kontaktinformasjon.epostadresse?.sistOppdatert
-        ? formaterDato(kontaktinformasjon.epostadresse.sistOppdatert)
+    const epost = kontaktinformasjon.epost?.value ?? null;
+    const sistOppdatert = kontaktinformasjon.epost?.sistOppdatert
+        ? formaterDato(kontaktinformasjon.epost.sistOppdatert)
         : null;
 
     return (
         <VisittkortElement beskrivelse="E-post" ikon={<EmailIkon />}>
             <DigitalKontaktinformasjon
-                reservasjon={kontaktinformasjon.reservasjon}
+                erReservert={kontaktinformasjon.erReservert}
                 kontaktinformasjonVerdi={epost}
                 sistOppdatert={sistOppdatert}
             />

--- a/src/app/personside/visittkort-v2/body/kontaktinformasjon/telefon/Telefon.tsx
+++ b/src/app/personside/visittkort-v2/body/kontaktinformasjon/telefon/Telefon.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import PhoneIkon from '../../../../../../svg/Phone';
 import VisittkortElement from '../../VisittkortElement';
-import { DigitalKontaktinformasjon as DigitalKontaktinformasjonInterface } from '../../../PersondataDomain';
+import { KontaktInformasjon } from '../../../PersondataDomain';
 import DigitalKontaktinformasjon from '../DigitalKontaktinformasjon';
 import { formaterMobiltelefonnummer } from '../../../../../../utils/telefon-utils';
 import { formaterDato } from '../../../../../../utils/string-utils';
@@ -9,7 +9,7 @@ import { Feilmelding } from 'nav-frontend-typografi';
 
 interface Props {
     harFeilendeSystem: boolean;
-    kontaktinformasjon: DigitalKontaktinformasjonInterface | null;
+    kontaktinformasjon: KontaktInformasjon | null;
 }
 
 function Telefon({ harFeilendeSystem, kontaktinformasjon }: Props) {
@@ -25,15 +25,15 @@ function Telefon({ harFeilendeSystem, kontaktinformasjon }: Props) {
         return null;
     }
 
-    const telefonnummer = formaterMobiltelefonnummer(kontaktinformasjon.mobiltelefonnummer?.value ?? '');
-    const sistOppdatert = kontaktinformasjon.mobiltelefonnummer?.sistOppdatert
-        ? formaterDato(kontaktinformasjon.mobiltelefonnummer.sistOppdatert)
+    const telefonnummer = formaterMobiltelefonnummer(kontaktinformasjon.mobil?.value ?? '');
+    const sistOppdatert = kontaktinformasjon.mobil?.sistOppdatert
+        ? formaterDato(kontaktinformasjon.mobil.sistOppdatert)
         : null;
 
     return (
         <VisittkortElement beskrivelse="Telefon" ikon={<PhoneIkon />}>
             <DigitalKontaktinformasjon
-                reservasjon={kontaktinformasjon.reservasjon}
+                erReservert={kontaktinformasjon.erReservert}
                 kontaktinformasjonVerdi={telefonnummer}
                 sistOppdatert={sistOppdatert}
             />

--- a/src/app/personside/visittkort-v2/header/__snapshots__/VisittkortHeader.test.tsx.snap
+++ b/src/app/personside/visittkort-v2/header/__snapshots__/VisittkortHeader.test.tsx.snap
@@ -453,6 +453,15 @@ exports[`Tester visittkort-header sin funksjonalitet viser info om bruker i visi
           <span
             className="typo-normal"
           >
+            Manuell oppfølging
+          </span>
+        </div>
+        <div
+          className="etikett etikett--fokus"
+        >
+          <span
+            className="typo-normal"
+          >
             Vergemål
           </span>
         </div>

--- a/src/app/personside/visittkort-v2/header/etiketter/Etiketter.tsx
+++ b/src/app/personside/visittkort-v2/header/etiketter/Etiketter.tsx
@@ -32,7 +32,7 @@ function Etiketter({ person }: Props) {
                 <DiskresjonskodeEtikett adressebeskyttelser={person.adressebeskyttelse} />
                 <EgenAnsattEtikett erEgenansatt={person.erEgenAnsatt} />
                 <SikkerhetstiltakEtikett sikkerhetstiltak={person.sikkerhetstiltak} />
-                <ReservertIKRREtikett kontaktOgReservasjon={person.kontaktOgReservasjon} />
+                <ReservertIKRREtikett kontaktInformasjon={person.kontaktInformasjon} />
                 <VergemalsEtikett vergemal={person.vergemal} />
                 <TilrettelagtKommunikasjonsEtiketter tilrettelagtKommunikasjon={person.tilrettelagtKommunikasjon} />
                 <DodsboEtikett dodsbo={person.dodsbo} />

--- a/src/app/personside/visittkort-v2/header/etiketter/Etiketter.tsx
+++ b/src/app/personside/visittkort-v2/header/etiketter/Etiketter.tsx
@@ -10,6 +10,7 @@ import VergemalsEtikett from './VergemalsEtikett';
 import TilrettelagtKommunikasjonsEtiketter from './TilrettelagtKommunikasjonsEtiketter';
 import DodsboEtikett from './DodsboEtikett';
 import FullmaktEtikett from './FullmaktEtikett';
+import ManuellStatusEtikett from './ManuellStatusEtikett';
 
 interface Props {
     person: Person;
@@ -33,6 +34,7 @@ function Etiketter({ person }: Props) {
                 <EgenAnsattEtikett erEgenansatt={person.erEgenAnsatt} />
                 <SikkerhetstiltakEtikett sikkerhetstiltak={person.sikkerhetstiltak} />
                 <ReservertIKRREtikett kontaktInformasjon={person.kontaktInformasjon} />
+                <ManuellStatusEtikett kontaktInformasjon={person.kontaktInformasjon} />
                 <VergemalsEtikett vergemal={person.vergemal} />
                 <TilrettelagtKommunikasjonsEtiketter tilrettelagtKommunikasjon={person.tilrettelagtKommunikasjon} />
                 <DodsboEtikett dodsbo={person.dodsbo} />

--- a/src/app/personside/visittkort-v2/header/etiketter/ManuellStatusEtikett.tsx
+++ b/src/app/personside/visittkort-v2/header/etiketter/ManuellStatusEtikett.tsx
@@ -1,0 +1,18 @@
+import * as React from 'react';
+import EtikettBase from 'nav-frontend-etiketter';
+import { KontaktInformasjon } from '../../PersondataDomain';
+
+interface Props {
+    kontaktInformasjon: KontaktInformasjon | null;
+}
+
+function ManuellStatusEtikett(props: Props) {
+    const { kontaktInformasjon } = props;
+    if (kontaktInformasjon?.erManuell) {
+        return <EtikettBase type="fokus">Manuell oppfølging</EtikettBase>;
+    } else {
+        return null;
+    }
+}
+
+export default ManuellStatusEtikett;

--- a/src/app/personside/visittkort-v2/header/etiketter/ReservertIKRREtikett.tsx
+++ b/src/app/personside/visittkort-v2/header/etiketter/ReservertIKRREtikett.tsx
@@ -1,19 +1,16 @@
 import * as React from 'react';
 import EtikettBase from 'nav-frontend-etiketter';
-import { DigitalKontaktinformasjon } from '../../PersondataDomain';
+import { KontaktInformasjon } from '../../PersondataDomain';
 
 interface Props {
-    kontaktOgReservasjon: DigitalKontaktinformasjon | null;
+    kontaktInformasjon: KontaktInformasjon | null;
 }
 
-function ReservertIKRREtikett({ kontaktOgReservasjon }: Props) {
-    if (kontaktOgReservasjon?.reservasjon === 'true') {
+function ReservertIKRREtikett(props: Props) {
+    const { kontaktInformasjon } = props;
+    if (kontaktInformasjon?.erReservert) {
         return <EtikettBase type="fokus">Reservert i KRR</EtikettBase>;
-    } else if (
-        kontaktOgReservasjon &&
-        !kontaktOgReservasjon.epostadresse?.value &&
-        !kontaktOgReservasjon.mobiltelefonnummer?.value
-    ) {
+    } else if (kontaktInformasjon && !kontaktInformasjon.epost?.value && !kontaktInformasjon.mobil?.value) {
         return <EtikettBase type="fokus">Ikke registrert i KRR</EtikettBase>;
     }
     return null;

--- a/src/mock/persondata/aremark.ts
+++ b/src/mock/persondata/aremark.ts
@@ -390,15 +390,15 @@ export const aremark: Person = {
             prioritet: -1
         }
     ],
-    kontaktOgReservasjon: {
-        personident: '10108000398',
-        reservasjon: 'true',
-        epostadresse: {
+    kontaktInformasjon: {
+        erReservert: true,
+        erManuell: true,
+        epost: {
             value: 'epost@nav.no',
             sistOppdatert: null,
             sistVerifisert: '2013-01-01' as LocalDate
         },
-        mobiltelefonnummer: {
+        mobil: {
             value: '12345678',
             sistOppdatert: '2021-11-02' as LocalDate,
             sistVerifisert: '2021-11-02' as LocalDate

--- a/src/mock/persondata/persondata.ts
+++ b/src/mock/persondata/persondata.ts
@@ -411,34 +411,22 @@ export function lagPerson(fnr: string): Person {
                 prioritet: -1
             }
         ],
-        kontaktOgReservasjon: ikkeRegistrert
+        kontaktInformasjon: ikkeRegistrert
             ? {
-                  personident: '10108000398',
-                  reservasjon: erReservert ? 'true' : 'false',
-                  epostadresse: {
-                      value: null,
-                      sistOppdatert: null,
-                      sistVerifisert: null
-                  },
-                  mobiltelefonnummer: {
-                      value: null,
-                      sistOppdatert: null,
-                      sistVerifisert: null
-                  }
+                  erReservert,
+                  erManuell: true,
+                  epost: { value: null, sistOppdatert: null, sistVerifisert: null },
+                  mobil: { value: null, sistOppdatert: null, sistVerifisert: null }
               }
             : {
-                  personident: '10108000398',
-                  reservasjon: erReservert ? 'true' : 'false',
-                  epostadresse: {
+                  erReservert,
+                  erManuell: true,
+                  epost: {
                       value: 'epost@nav.no',
                       sistOppdatert: '2013-01-01' as LocalDate,
                       sistVerifisert: '2013-01-01' as LocalDate
                   },
-                  mobiltelefonnummer: {
-                      value: '90000000',
-                      sistOppdatert: '2015-02-01' as LocalDate,
-                      sistVerifisert: null
-                  }
+                  mobil: { value: '90000000', sistOppdatert: '2015-02-01' as LocalDate, sistVerifisert: null }
               },
         bankkonto: {
             kontonummer: '12345678910',


### PR DESCRIPTION
- [FAGSYSTEM-241955] bytte til nytt informasjonselement for kontaktinformasjon
- [FAGSYSTEM-241955] legge til manuell oppfølging etikett

![image](https://user-images.githubusercontent.com/1413417/192252129-9ee442a5-24c1-455a-aa69-6353788e73e8.png)

Avhengig av: https://github.com/navikt/modiapersonoversikt-api/pull/907
