### PR TITLE
[OPP-1441] sette opp pass-through via proxy-appen

### DIFF
--- a/preprod-proxy-config.json
+++ b/preprod-proxy-config.json
@@ -20,8 +20,12 @@
         "rewriteDirectives": ["SET_ON_BEHALF_OF_TOKEN dev-fss personoversikt modiacontextholder$env{MILJO_SUFFIX}"]
     },
     {
-        "prefix": "proxy/api",
-        "url": "http://modiapersonoversikt-api$env{MILJO_SUFFIX}.personoversikt.svc.nais.local/modiapersonoversikt-api",
+        "prefix": "proxy/azure-api",
+        "url": "http://modiapersonoversikt-api$env{MILJO_SUFFIX}.personoversikt.svc.nais.local/modiapersonoversikt-api/rest",
         "rewriteDirectives": ["SET_ON_BEHALF_OF_TOKEN dev-fss personoversikt modiapersonoversikt-api$env{MILJO_SUFFIX}"]
+    },
+    {
+        "prefix": "proxy/api",
+        "url": "http://modiapersonoversikt-api$env{MILJO_SUFFIX}.personoversikt.svc.nais.local/modiapersonoversikt-api/rest"
     }
 ]

--- a/proxy-config.json
+++ b/proxy-config.json
@@ -14,5 +14,9 @@
     {
         "prefix": "proxy/modiacontextholder",
         "url": "http://modiacontextholder.personoversikt.svc.nais.local/modiacontextholder"
+    },
+    {
+        "prefix": "proxy/api",
+        "url": "http://modiapersonoversikt-api.personoversikt.svc.nais.local/modiapersonoversikt-api/rest"
     }
 ]

--- a/src/api/config.ts
+++ b/src/api/config.ts
@@ -14,4 +14,4 @@ export function postConfig(body?: object | string) {
 
 export const includeCredentials: RequestInit = { credentials: 'include' };
 
-export const apiBaseUri = '/modiapersonoversikt-api/rest';
+export const apiBaseUri = '/modiapersonoversikt/proxy/api';

--- a/src/mock/index.ts
+++ b/src/mock/index.ts
@@ -75,12 +75,12 @@ function setUpSaksbehandlersEnheterMock(mock: FetchMock) {
 
 function setupTilgangskontroll(mock: FetchMock) {
     mock.get(
-        '/modiapersonoversikt-api/rest/tilgang/auth',
+        apiBaseUri + '/tilgang/auth',
         withDelayedResponse(randomDelay(), () => 200, authMock)
     );
 
     mock.get(
-        '/modiapersonoversikt-api/rest/tilgang/:fodselsnummer?',
+        apiBaseUri + '/tilgang/:fodselsnummer?',
         withDelayedResponse(
             randomDelay(),
             () => (Math.random() > 0.98 ? 400 : 200),

--- a/src/redux/gjeldendeBruker/actions.ts
+++ b/src/redux/gjeldendeBruker/actions.ts
@@ -6,19 +6,20 @@ import { resetKeepScroll } from '../../utils/hooks/useKeepScroll';
 import { AppState } from '../reducers';
 import { resetKeepQueryParams } from '../../utils/hooks/useKeepQueryParams';
 import { createTrie, searchTrie } from '../../utils/trie';
+import { apiBaseUri } from '../../api/config';
 
 const trieDelimiter = /\/|\|\|.*/;
 const protectedCache = createTrie(
     [
-        '/modiapersonoversikt-api/rest/hode/me',
-        '/modiapersonoversikt-api/rest/hode/enheter',
-        '/modiapersonoversikt-api/rest/baseurls',
-        '/modiapersonoversikt-api/rest/enheter/oppgavebehandlere/alle',
-        '/modiapersonoversikt-api/rest/dialogoppgave/v2/tema',
-        '/modiapersonoversikt-api/rest/tilgang/auth',
-        '/modiapersonoversikt-api/rest/featuretoggle',
-        '/modiapersonoversikt/proxy/modia-skrivestotte/skrivestotte',
-        '/modiapersonoversikt/proxy/modia-innstillinger/api/innstillinger'
+        `${apiBaseUri}/hode/me`,
+        `${apiBaseUri}/hode/enheter`,
+        `${apiBaseUri}/baseurls`,
+        `${apiBaseUri}/enheter/oppgavebehandlere/alle`,
+        `${apiBaseUri}/dialogoppgave/v2/tema`,
+        `${apiBaseUri}/tilgang/auth`,
+        `${apiBaseUri}/featuretoggle`,
+        `/modiapersonoversikt/proxy/modia-skrivestotte/skrivestotte`,
+        `/modiapersonoversikt/proxy/modia-innstillinger/api/innstillinger`
     ],
     trieDelimiter
 );


### PR DESCRIPTION
Alle kall til api vil bli sendt via proxy, med alle cookies etc.
modiapersonoversikt-api vil derfor fortsatt bruke isso/openAM her frem til vi legger til OBO-direktivet i konfigurasjonen.

Dette gjør det mulig å få  sjekket ytelsen på proxy-appen uten av vi skrur på azuread i produksjon