### PR TITLE
[KAIZEN-0] bytte ut useFetch for react-query for saksbehandlers enheter

### DIFF
--- a/src/app/FetchSessionInfoOgLeggIRedux.tsx
+++ b/src/app/FetchSessionInfoOgLeggIRedux.tsx
@@ -2,7 +2,7 @@ import { useInitializeLogger } from '../utils/logger/frontendLogger';
 import gsaktemaResource from '../rest/resources/gsaktemaResource';
 import baseurls from '../rest/resources/baseurlsResource';
 import innloggetSaksbehandler from '../rest/resources/innloggetSaksbehandlerResource';
-import saksbehandlersEnheter from '../rest/resources/saksbehandlersEnheter';
+import saksbehandlersEnheter from '../rest/resources/saksbehandlersEnheterResource';
 import { useQueryClient } from '@tanstack/react-query';
 
 function FetchSessionInfoOgLeggIRedux() {

--- a/src/app/PersonOppslagHandler/LyttPåNyttFnrIReduxOgHentAllPersoninfo.tsx
+++ b/src/app/PersonOppslagHandler/LyttPåNyttFnrIReduxOgHentAllPersoninfo.tsx
@@ -3,7 +3,7 @@ import { useDispatch } from 'react-redux';
 import { useGjeldendeBruker } from '../../redux/gjeldendeBruker/types';
 import { useFetchFeatureTogglesOnNewFnr } from './FetchFeatureToggles';
 import { loggEvent } from '../../utils/logger/frontendLogger';
-import tildelteoppgaver from '../../rest/resources/tildelteoppgaver';
+import tildelteoppgaver from '../../rest/resources/tildelteoppgaverResource';
 
 function LyttPåNyttFnrIReduxOgHentAllPersoninfo() {
     const dispatch = useDispatch();

--- a/src/app/VelgEnhet.tsx
+++ b/src/app/VelgEnhet.tsx
@@ -3,8 +3,7 @@ import { ChangeEvent, useEffect } from 'react';
 import styled from 'styled-components/macro';
 import { Select } from 'nav-frontend-skjema';
 import theme from '../styles/personOversiktTheme';
-import saksbehandlersEnheter from '../rest/resources/saksbehandlersEnheter';
-import { hasData, hasError, isPending } from '@nutgaard/use-fetch';
+import saksbehandlersEnheter from '../rest/resources/saksbehandlersEnheterResource';
 import { AlertStripeAdvarsel } from 'nav-frontend-alertstriper';
 import LazySpinner from '../components/LazySpinner';
 import { useValgtenhet } from '../context/valgtenhet-state';
@@ -24,14 +23,14 @@ function VelgEnhet() {
     const setEnhetId = useValgtenhet().setEnhetId;
 
     useEffect(() => {
-        if (hasData(enheter) && enheter.data?.enhetliste.length === 1) {
+        if (enheter.data && enheter.data?.enhetliste.length === 1) {
             setEnhetId(enheter.data.enhetliste[0].enhetId);
         }
     }, [enheter, setEnhetId]);
 
-    if (isPending(enheter)) {
+    if (enheter.isLoading) {
         return <LazySpinner type="M" />;
-    } else if (hasError(enheter)) {
+    } else if (enheter.isError) {
         return <AlertStripeAdvarsel>Kunne ikke hente enhetsliste</AlertStripeAdvarsel>;
     }
 

--- a/src/app/personside/BegrensetTilgangSide.tsx
+++ b/src/app/personside/BegrensetTilgangSide.tsx
@@ -7,7 +7,7 @@ import styled from 'styled-components/macro';
 import Ekspanderbartpanel from 'nav-frontend-ekspanderbartpanel';
 import { useState, useCallback } from 'react';
 import gsaktemaResource from '../../rest/resources/gsaktemaResource';
-import { HarIkkeTilgang } from '../../rest/resources/tilgangskontroll';
+import { HarIkkeTilgang } from '../../rest/resources/tilgangskontrollResource';
 
 interface BegrensetTilgangProps {
     tilgangsData: HarIkkeTilgang;

--- a/src/app/personside/Personoversikt.tsx
+++ b/src/app/personside/Personoversikt.tsx
@@ -7,7 +7,7 @@ import { useHistory } from 'react-router';
 import { paths } from '../routes/routing';
 import { loggInfo } from '../../utils/logger/frontendLogger';
 import BegrensetTilgangSide from './BegrensetTilgangSide';
-import tilgangskontroll from '../../rest/resources/tilgangskontroll';
+import tilgangskontroll from '../../rest/resources/tilgangskontrollResource';
 import { DialogpanelStateProvider } from '../../context/dialogpanel-state';
 
 function Personoversikt() {

--- a/src/app/personside/dialogpanel/fortsettDialog/FortsettDialogContainer.tsx
+++ b/src/app/personside/dialogpanel/fortsettDialog/FortsettDialogContainer.tsx
@@ -11,7 +11,7 @@ import { SvarSendtKvittering } from './FortsettDialogKvittering';
 import useOpprettHenvendelse from './useOpprettHenvendelse';
 import { erJournalfort } from '../../infotabs/meldinger/utils/meldingerUtils';
 import { loggError } from '../../../../utils/logger/frontendLogger';
-import { post } from '../../../../api/api';
+import { FetchError, post } from '../../../../api/api';
 import { apiBaseUri } from '../../../../api/config';
 import {
     DialogPanelStatus,
@@ -28,11 +28,10 @@ import { Temagruppe } from '../../../../models/temagrupper';
 import useDraft, { Draft } from '../use-draft';
 import * as JournalforingUtils from '../../journalforings-use-fetch-utils';
 import { Oppgave } from '../../../../models/meldinger/oppgave';
-import tildelteoppgaver from '../../../../rest/resources/tildelteoppgaver';
-import { FetchResult, hasData } from '@nutgaard/use-fetch';
+import tildelteoppgaver from '../../../../rest/resources/tildelteoppgaverResource';
 import dialogResource from '../../../../rest/resources/dialogResource';
 import { useValgtenhet } from '../../../../context/valgtenhet-state';
-import { useQueryClient } from '@tanstack/react-query';
+import { useQueryClient, UseQueryResult } from '@tanstack/react-query';
 
 export type FortsettDialogType =
     | Meldingstype.SVAR_SKRIFTLIG
@@ -51,9 +50,9 @@ const StyledArticle = styled.article`
 
 export function finnPlukketOppgaveForTraad(
     traad: Traad,
-    resource: FetchResult<Oppgave[]>
+    resource: UseQueryResult<Oppgave[], FetchError>
 ): { oppgave: Oppgave | undefined; erSTOOppgave: boolean } {
-    if (!hasData(resource)) {
+    if (!resource.data) {
         return { oppgave: undefined, erSTOOppgave: false };
     } else {
         const oppgave: Oppgave | undefined = resource.data.find(
@@ -130,7 +129,7 @@ function FortsettDialogContainer(props: Props) {
         }
         const callback = () => {
             removeDraft();
-            tildelteOppgaverResource.rerun();
+            tildelteOppgaverResource.refetch();
             queryClient.invalidateQueries(dialogResource.queryKey(fnr, valgtEnhet));
         };
 

--- a/src/app/personside/dialogpanel/fortsettDialog/useOpprettHenvendelse.tsx
+++ b/src/app/personside/dialogpanel/fortsettDialog/useOpprettHenvendelse.tsx
@@ -9,7 +9,7 @@ import { apiBaseUri } from '../../../../api/config';
 import { postWithConflictVerification, RespectConflictError } from '../../../../api/api';
 import { useState } from 'react';
 import { setIngenValgtTraadDialogpanel } from '../../../../redux/oppgave/actions';
-import tildelteoppgaverResource from '../../../../rest/resources/tildelteoppgaver';
+import tildelteoppgaverResource from '../../../../rest/resources/tildelteoppgaverResource';
 import { useValgtenhet } from '../../../../context/valgtenhet-state';
 
 interface NotFinishedOpprettHenvendelse {
@@ -41,7 +41,7 @@ function useOpprettHenvendelse(traad: Traad): OpprettHenvendelseReturns {
             'Oppgaven tilknyttet denne meldingen er allerede tilordnet en saksbehandler. Vil du overstyre dette?'
         )
             .then((data) => setResponse(data as OpprettHenvendelseResponse))
-            .then(() => tildelteoppgaver.rerun())
+            .then(() => tildelteoppgaver.refetch())
             .catch((e) => {
                 if (e instanceof RespectConflictError) {
                     dispatch(setIngenValgtTraadDialogpanel());

--- a/src/app/personside/dialogpanel/sendMelding/Oppgaveliste.tsx
+++ b/src/app/personside/dialogpanel/sendMelding/Oppgaveliste.tsx
@@ -3,8 +3,7 @@ import Select from 'nav-frontend-skjema/lib/select';
 import { OppgavelisteValg } from './SendNyMelding';
 import styled from 'styled-components/macro';
 import theme from '../../../../styles/personOversiktTheme';
-import saksbehandlersEnheter from '../../../../rest/resources/saksbehandlersEnheter';
-import { hasData } from '@nutgaard/use-fetch';
+import saksbehandlersEnheter from '../../../../rest/resources/saksbehandlersEnheterResource';
 import { useValgtenhet } from '../../../../context/valgtenhet-state';
 
 interface Props {
@@ -21,7 +20,7 @@ const StyledSelect = styled(Select)`
 
 function Oppgaveliste(props: Props) {
     const enheterResource = saksbehandlersEnheter.useFetch();
-    const enheter = hasData(enheterResource) ? enheterResource.data.enhetliste : [];
+    const enheter = enheterResource.data ? enheterResource.data.enhetliste : [];
     const valgtEnhetId = useValgtenhet().enhetId;
 
     const valgtEnhet = enheter.find((enhet) => enhet.enhetId === valgtEnhetId);

--- a/src/app/personside/dialogpanel/sendMelding/autofullforUtils.ts
+++ b/src/app/personside/dialogpanel/sendMelding/autofullforUtils.ts
@@ -8,7 +8,7 @@ import { hentNavn } from '../../visittkort-v2/visittkort-utils';
 import innloggetSaksbehandler, {
     InnloggetSaksbehandler
 } from '../../../../rest/resources/innloggetSaksbehandlerResource';
-import saksbehandlersEnheter, { Enhet } from '../../../../rest/resources/saksbehandlersEnheter';
+import saksbehandlersEnheter, { Enhet } from '../../../../rest/resources/saksbehandlersEnheterResource';
 import { useValgtenhet } from '../../../../context/valgtenhet-state';
 
 export type AutofullforData = {
@@ -121,7 +121,7 @@ export function useAutoFullforData(): AutofullforData | undefined {
     const personResponse = useHentPersondata();
     const saksbehandler = innloggetSaksbehandler.useFetch();
     const enheterResource = saksbehandlersEnheter.useFetch();
-    const enheter = hasData(enheterResource) ? enheterResource.data.enhetliste : [];
+    const enheter = enheterResource.data ? enheterResource.data.enhetliste : [];
     const valgtEnhetId = useValgtenhet().enhetId;
     const valgtEnhet = enheter.find((enhet) => enhet.enhetId === valgtEnhetId);
 

--- a/src/app/personside/dialogpanel/sendMelding/standardTekster/StandardTekster.tsx
+++ b/src/app/personside/dialogpanel/sendMelding/standardTekster/StandardTekster.tsx
@@ -20,7 +20,7 @@ import LazySpinner from '../../../../../components/LazySpinner';
 import AriaNotification from '../../../../../components/AriaNotification';
 import { useHentPersondata, usePrevious } from '../../../../../utils/customHooks';
 import { AlertStripeAdvarsel } from 'nav-frontend-alertstriper';
-import saksbehandlersEnheter from '../../../../../rest/resources/saksbehandlersEnheter';
+import saksbehandlersEnheter from '../../../../../rest/resources/saksbehandlersEnheterResource';
 
 interface Props {
     sokefelt: FieldState;
@@ -183,9 +183,9 @@ function StandardTekster(props: Props) {
         );
     }
 
-    if (isPending(persondata) || isPending(enheterResource)) {
+    if (isPending(persondata) || enheterResource.isLoading) {
         return <LazySpinner type={'M'} />;
-    } else if (hasError(persondata) || hasError(enheterResource)) {
+    } else if (hasError(persondata) || enheterResource.isError) {
         return <AlertStripeAdvarsel>Feil ved lasting av data</AlertStripeAdvarsel>;
     }
 

--- a/src/app/personside/infotabs/dyplenkeTest/sakerDyplenker.test.tsx
+++ b/src/app/personside/infotabs/dyplenkeTest/sakerDyplenker.test.tsx
@@ -5,8 +5,10 @@ import InfoTabs from '../InfoTabs';
 import { BrowserRouter } from 'react-router-dom';
 import { INFOTABS } from '../InfoTabEnum';
 import { getAktivTab, sakerTest } from './utils-dyplenker-test';
+import { setupReactQueryMocks } from '../../../../test/testStore';
 
 test('bytter til riktig tab og setter riktig sakstema ved bruk av dyplenke fra oversikt', () => {
+    setupReactQueryMocks();
     const infoTabs = mount(
         <TestProvider>
             <BrowserRouter>

--- a/src/app/personside/infotabs/meldinger/traadvisning/verktoylinje/merk/MerkPanel.tsx
+++ b/src/app/personside/infotabs/meldinger/traadvisning/verktoylinje/merk/MerkPanel.tsx
@@ -19,7 +19,7 @@ import {
 import { Traad } from '../../../../../../../models/meldinger/meldinger';
 import { RadioPanelGruppe, RadioPanelProps } from 'nav-frontend-skjema';
 import { apiBaseUri } from '../../../../../../../api/config';
-import { post } from '../../../../../../../api/api';
+import { FetchError, post } from '../../../../../../../api/api';
 import {
     MerkLukkTraadRequest,
     MerkRequestMedBehandlingskjede,
@@ -30,14 +30,13 @@ import { Resultat } from '../utils/VisPostResultat';
 import { useFocusOnFirstFocusable } from '../../../../../../../utils/hooks/use-focus-on-first-focusable';
 import { setIngenValgtTraadDialogpanel } from '../../../../../../../redux/oppgave/actions';
 import { Oppgave } from '../../../../../../../models/meldinger/oppgave';
-import tildelteoppgaver from '../../../../../../../rest/resources/tildelteoppgaver';
-import { FetchResult, hasData } from '@nutgaard/use-fetch';
+import tildelteoppgaver from '../../../../../../../rest/resources/tildelteoppgaverResource';
 import { SladdeObjekt, velgMeldingerTilSladding } from './sladdevalg/Sladdevalg';
 import useFeatureToggle from '../../../../../../../components/featureToggle/useFeatureToggle';
 import { FeatureToggles } from '../../../../../../../components/featureToggle/toggleIDs';
 import dialogResource from '../../../../../../../rest/resources/dialogResource';
 import { useValgtenhet } from '../../../../../../../context/valgtenhet-state';
-import { useQueryClient } from '@tanstack/react-query';
+import { useQueryClient, UseQueryResult } from '@tanstack/react-query';
 
 interface Props {
     lukkPanel: () => void;
@@ -115,8 +114,11 @@ function getLukkTraadRequest(fnr: string, valgtEnhet: string, traad: Traad, oppg
     };
 }
 
-function finnOppgaveForTraad(traad: Traad, tildelteOppgaver: FetchResult<Oppgave[]>): Oppgave | undefined {
-    if (hasData(tildelteOppgaver)) {
+function finnOppgaveForTraad(
+    traad: Traad,
+    tildelteOppgaver: UseQueryResult<Oppgave[], FetchError>
+): Oppgave | undefined {
+    if (tildelteOppgaver.data) {
         return tildelteOppgaver.data.find((it) => it.traadId === traad.traadId);
     }
     return undefined;
@@ -178,7 +180,7 @@ function MerkPanel(props: Props) {
                 settResultat(Resultat.VELLYKKET);
                 setSubmitting(false);
                 queryClient.invalidateQueries(dialogResource.queryKey(valgtBrukersFnr, valgtEnhet));
-                tildelteOppgaverResource.rerun();
+                tildelteOppgaverResource.refetch();
                 dispatch(setIngenValgtTraadDialogpanel());
             })
             .catch(() => {
@@ -199,7 +201,7 @@ function MerkPanel(props: Props) {
                 break;
             case MerkOperasjon.SLADDING:
                 if (skalSendeArsak) {
-                    const sladdeObjekt: SladdeObjekt | null = await velgMeldingerTilSladding(valgtTraad);
+                    const sladdeObjekt: SladdeObjekt | null = await velgMeldingerTilSladding(valgtTraad, queryClient);
                     // If null, then modal was closed without "submitting form"
                     if (sladdeObjekt !== null) {
                         merkPost(

--- a/src/app/personside/infotabs/meldinger/traadvisning/verktoylinje/merk/sladdevalg/Sladdevalg.tsx
+++ b/src/app/personside/infotabs/meldinger/traadvisning/verktoylinje/merk/sladdevalg/Sladdevalg.tsx
@@ -12,6 +12,7 @@ import SladdTradMedArsak from './SladdTradMedArsak';
 import SladdMeldingerMedArsak from './SladdMeldingerMedArsak';
 import css from './Sladdvalg.module.css';
 import { useSladdeArsak } from './use-sladde-arsak';
+import { QueryClient } from '@tanstack/react-query';
 
 interface Props {
     traad: Traad;
@@ -19,8 +20,8 @@ interface Props {
 
 export type SladdeObjekt = ({ traadId: string } | { meldingId: Array<string> }) & { arsak?: string };
 
-export function velgMeldingerTilSladding(traad: Traad) {
-    return renderPopup(Sladdevalg, { traad });
+export function velgMeldingerTilSladding(traad: Traad, queryClient: QueryClient) {
+    return renderPopup(queryClient, Sladdevalg, { traad });
 }
 const ModalBase = styled(NavFrontendModal)`
     &.modal {

--- a/src/app/personside/infotabs/meldinger/traadvisning/verktoylinje/oppgave/AvsluttGosysOppgaveSkjema.tsx
+++ b/src/app/personside/infotabs/meldinger/traadvisning/verktoylinje/oppgave/AvsluttGosysOppgaveSkjema.tsx
@@ -10,8 +10,7 @@ import theme from '../../../../../../../styles/personOversiktTheme';
 import { AvsluttGosysOppgaveRequest } from '../../../../../../../models/meldinger/merk';
 import { Traad } from '../../../../../../../models/meldinger/meldinger';
 import Ekspanderbartpanel from 'nav-frontend-ekspanderbartpanel';
-import tildelteoppgaver from '../../../../../../../rest/resources/tildelteoppgaver';
-import { hasData } from '@nutgaard/use-fetch';
+import tildelteoppgaver from '../../../../../../../rest/resources/tildelteoppgaverResource';
 import { useValgtenhet } from '../../../../../../../context/valgtenhet-state';
 
 const StyledAlert = styled.div`
@@ -37,7 +36,7 @@ function AvsluttGosysOppgaveSkjema(props: Props) {
     const [avsluttOppgaveSuksess, setAvsluttOppgaveSuksess] = useState(false);
     const [error, setError] = useState(false);
     const harOppgaveTilknyttetTrad =
-        hasData(tildelteOppgaverResource) &&
+        tildelteOppgaverResource.data &&
         tildelteOppgaverResource.data.find((it) => it.traadId === props.valgtTraad.traadId);
 
     useFocusOnMount(ref);
@@ -57,7 +56,7 @@ function AvsluttGosysOppgaveSkjema(props: Props) {
             post(`${apiBaseUri}/dialogmerking/avsluttgosysoppgave`, request, 'Avslutt-Oppgave-Fra-Gosys')
                 .then(() => {
                     setAvsluttOppgaveSuksess(true);
-                    tildelteOppgaverResource.rerun();
+                    tildelteOppgaverResource.refetch();
                 })
                 .catch(() => {
                     setError(true);

--- a/src/app/personside/infotabs/oppfolging/OppfolgingDatoKomponent.tsx
+++ b/src/app/personside/infotabs/oppfolging/OppfolgingDatoKomponent.tsx
@@ -88,7 +88,7 @@ function getDatoFeilmelding(fra: string, til: string) {
 }
 
 function DatoInputs() {
-    const update = oppfolgingResource.useMutation();
+    const update = oppfolgingResource.useFetch();
 
     const valgtPeriode = useAppState((appState) => appState.oppfolging.valgtPeriode);
     const fra = valgtPeriode.fra;
@@ -107,7 +107,7 @@ function DatoInputs() {
             return;
         }
         loggEvent('SøkNyPeriode', 'Oppfølging');
-        update.mutate();
+        update.refetch();
     };
 
     return (

--- a/src/app/personside/infotabs/oversikt/SakerOversikt.tsx
+++ b/src/app/personside/infotabs/oversikt/SakerOversikt.tsx
@@ -9,7 +9,7 @@ import { ReactNode } from 'react';
 import { useOnMount } from '../../../../utils/customHooks';
 import { Normaltekst } from 'nav-frontend-typografi';
 import { filtrerSakstemaerUtenData } from '../saksoversikt/sakstemaliste/SakstemaListeUtils';
-import sakstemaResource from '../../../../rest/resources/sakstema';
+import sakstemaResource from '../../../../rest/resources/sakstemaResource';
 
 const ListStyle = styled.ol`
     > *:not(:first-child) {

--- a/src/app/personside/infotabs/saksoversikt/SaksoversiktContainer.tsx
+++ b/src/app/personside/infotabs/saksoversikt/SaksoversiktContainer.tsx
@@ -12,7 +12,7 @@ import JournalPoster from './saksdokumenter/JournalPoster';
 import { useKeepQueryParams } from '../../../../utils/hooks/useKeepQueryParams';
 import SakerFullscreenLenke from './SakerFullscreenLenke';
 import { useHentAlleSakstemaFraResource, useSakstemaURLState } from './useSakstemaURLState';
-import sakstema from '../../../../rest/resources/sakstema';
+import sakstema from '../../../../rest/resources/sakstemaResource';
 
 const saksoversiktMediaTreshold = '70rem';
 

--- a/src/app/personside/infotabs/saksoversikt/useSakstemaURLState.tsx
+++ b/src/app/personside/infotabs/saksoversikt/useSakstemaURLState.tsx
@@ -5,9 +5,8 @@ import { datoSynkende } from '../../../../utils/date-utils';
 import { hentDatoForSisteHendelse, sakstemakodeAlle, sakstemakodeIngen } from './utils/saksoversiktUtils';
 import { useQueryParams } from '../../../../utils/url-utils';
 import { Dokument, Journalpost } from '../../../../models/saksoversikt/journalpost';
-import sakstemaLoader from '../../../../rest/resources/sakstema';
+import sakstemaLoader from '../../../../rest/resources/sakstemaResource';
 import { filtrerSakstemaerUtenData } from './sakstemaliste/SakstemaListeUtils';
-import { hasData } from '@nutgaard/use-fetch';
 
 interface SakstemaURLState {
     valgteSakstemaer: Sakstema[];
@@ -93,7 +92,7 @@ export function useHentAlleSakstemaFraResource(): SakstemaResource {
     const resource = sakstemaLoader.useFetch();
 
     return useMemo(() => {
-        if (hasData(resource)) {
+        if (resource.data) {
             return {
                 alleSakstema: resource.data.resultat.sort(datoSynkende((it) => hentDatoForSisteHendelse(it))),
                 isLoading: false

--- a/src/components/person/BegrensetTilgangBegrunnelse.tsx
+++ b/src/components/person/BegrensetTilgangBegrunnelse.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import { assertUnreachable } from '../../utils/assertUnreachable';
-import { IkkeTilgangArsak } from '../../rest/resources/tilgangskontroll';
+import { IkkeTilgangArsak } from '../../rest/resources/tilgangskontrollResource';
 
 interface Props {
     begrunnelseType: IkkeTilgangArsak;

--- a/src/components/popup-boxes/popup-boxes.tsx
+++ b/src/components/popup-boxes/popup-boxes.tsx
@@ -11,6 +11,7 @@ import { ReactComponent as InfoIkon } from 'nav-frontend-ikoner-assets/assets/in
 import styled from 'styled-components/macro';
 import { focusOnFirstFocusable } from '../../utils/hooks/use-focus-on-first-focusable';
 import { Normaltekst, Systemtittel } from 'nav-frontend-typografi';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 
 type IconChoice = 'none' | 'ok' | 'warning' | 'error' | 'help' | 'info';
 type CommonPopupComponentProps = {
@@ -49,6 +50,7 @@ function getIcon(choice: IconChoice): React.ReactNode {
 }
 
 export function renderPopup<RESULT, PROPS>(
+    queryClient: QueryClient | null,
     componentType: PopupComponent<RESULT, PROPS>,
     props: PROPS
 ): Promise<RESULT> {
@@ -62,8 +64,11 @@ export function renderPopup<RESULT, PROPS>(
             resolve(result);
         };
         const component = createElement(componentType, { ...props, close });
-
-        render(component, tmp);
+        if (queryClient) {
+            render(<QueryClientProvider client={queryClient}>{component}</QueryClientProvider>, tmp);
+        } else {
+            render(component, tmp);
+        }
     });
 }
 
@@ -155,17 +160,17 @@ function Prompt(props: PopupComponentProps<string | null, PromptProps>) {
 }
 
 export function alert(props: CommonPopupComponentProps): Promise<void> {
-    return renderPopup(Alert, props);
+    return renderPopup(null, Alert, props);
 }
 
 export function confirm(props: CommonPopupComponentProps): Promise<boolean> {
-    return renderPopup(Confirm, props);
+    return renderPopup(null, Confirm, props);
 }
 
 export function prompt(props: CommonPopupComponentProps): Promise<string | null> {
-    return renderPopup(Prompt, { ...props, secret: false });
+    return renderPopup(null, Prompt, { ...props, secret: false });
 }
 
 export function promptSecret(props: CommonPopupComponentProps): Promise<string | null> {
-    return renderPopup(Prompt, { ...props, secret: true });
+    return renderPopup(null, Prompt, { ...props, secret: true });
 }

--- a/src/mock/getSaksBehandlersEnheterMock.ts
+++ b/src/mock/getSaksBehandlersEnheterMock.ts
@@ -1,5 +1,5 @@
 import { enheter } from './context-mock';
-import { SaksbehandlersEnheter } from '../rest/resources/saksbehandlersEnheter';
+import { SaksbehandlersEnheter } from '../rest/resources/saksbehandlersEnheterResource';
 
 export function getSaksBehandlersEnheterMock(): SaksbehandlersEnheter {
     return {

--- a/src/mock/tilgangskontroll-mock.ts
+++ b/src/mock/tilgangskontroll-mock.ts
@@ -1,6 +1,6 @@
 import navfaker from 'nav-faker';
 import { AuthIntropectionDTO } from '../utils/hooks/use-persistent-login';
-import { IkkeTilgangArsak, TilgangDTO } from '../rest/resources/tilgangskontroll';
+import { IkkeTilgangArsak, TilgangDTO } from '../rest/resources/tilgangskontrollResource';
 
 export function authMock(): AuthIntropectionDTO {
     return { expirationDate: new Date().getTime() + 2.5 * 60 * 1000 };

--- a/src/rest/resources/dialogResource.tsx
+++ b/src/rest/resources/dialogResource.tsx
@@ -24,17 +24,13 @@ function useReduxData(): [string, string | undefined] {
     return useAppState((appState) => [appState.gjeldendeBruker.fødselsnummer, valgtEnhet]);
 }
 
-function fetchDialog(fnr: string, enhet: string | undefined): Promise<Traad[]> {
-    return get<Traad[]>(url(fnr, enhet));
-}
-
 const resource = {
     queryKey(fnr: string, enhet: string | undefined) {
         return ['dialog', fnr, enhet];
     },
     useFetch(): UseQueryResult<Traad[], FetchError> {
         const [fnr, enhetId] = useReduxData();
-        return useQuery(this.queryKey(fnr, enhetId), () => fetchDialog(fnr, enhetId));
+        return useQuery(this.queryKey(fnr, enhetId), () => get(url(fnr, enhetId)));
     },
     useRenderer(renderer: RendererOrConfig<Traad[]>) {
         const response = this.useFetch();

--- a/src/rest/resources/oppfolgingResource.tsx
+++ b/src/rest/resources/oppfolgingResource.tsx
@@ -6,9 +6,8 @@ import * as React from 'react';
 import { apiBaseUri } from '../../api/config';
 import { VisOppfolgingFraTilDato } from '../../redux/oppfolging/types';
 import { useAppState } from '../../utils/customHooks';
-import { useMutation, useQuery, useQueryClient, UseQueryResult } from '@tanstack/react-query';
+import { useQuery, UseQueryResult } from '@tanstack/react-query';
 import { FetchError, get } from '../../api/api';
-import { UseMutationResult } from '@tanstack/react-query/src/types';
 
 function queryKey(fnr: string): [string, string] {
     return ['oppfolging', fnr];
@@ -31,15 +30,6 @@ const resource = {
     useFetch(): UseQueryResult<DetaljertOppfolging, FetchError> {
         const [fnr, periode] = useReduxData();
         return useQuery(queryKey(fnr), () => get(url(fnr, periode)));
-    },
-    useMutation(): UseMutationResult<DetaljertOppfolging, FetchError, void> {
-        const queryClient = useQueryClient();
-        const [fnr, periode] = useReduxData();
-        return useMutation(() => get(url(fnr, periode)), {
-            onSuccess(data: DetaljertOppfolging) {
-                queryClient.setQueryData(queryKey(fnr), data);
-            }
-        });
     },
     useRenderer(renderer: RendererOrConfig<DetaljertOppfolging>) {
         const response = this.useFetch();

--- a/src/rest/resources/saksbehandlersEnheterResource.tsx
+++ b/src/rest/resources/saksbehandlersEnheterResource.tsx
@@ -1,12 +1,15 @@
 import * as React from 'react';
 import { apiBaseUri } from '../../api/config';
-import { applyDefaults, DefaultConfig, RendererOrConfig, useFetch, useRest } from '../useRest';
+import { applyDefaults, DefaultConfig, RendererOrConfig, useRQRest } from '../useRest';
 import { CenteredLazySpinner } from '../../components/LazySpinner';
 import AlertStripe from 'nav-frontend-alertstriper';
+import { useQuery, UseQueryResult } from '@tanstack/react-query';
+import { FetchError, get } from '../../api/api';
 
 /**
  * Kan denne kanskje erstattes av kall til modiacontextholder, og bør den evt gjøre det?
  */
+const queryKey = ['saksbehandlersenheter'];
 const url = `${apiBaseUri}/hode/enheter`;
 const defaults: DefaultConfig = {
     ifPending: <CenteredLazySpinner />,
@@ -24,8 +27,13 @@ export interface SaksbehandlersEnheter {
 }
 
 const resource = {
-    useRenderer: (renderer: RendererOrConfig<SaksbehandlersEnheter>) => useRest(url, applyDefaults(defaults, renderer)),
-    useFetch: () => useFetch<SaksbehandlersEnheter>(url)
+    useFetch(): UseQueryResult<SaksbehandlersEnheter, FetchError> {
+        return useQuery(queryKey, () => get(url));
+    },
+    useRenderer(renderer: RendererOrConfig<SaksbehandlersEnheter>) {
+        const response = this.useFetch();
+        return useRQRest(response, applyDefaults(defaults, renderer));
+    }
 };
 
 export default resource;

--- a/src/rest/resources/sakstemaResource.tsx
+++ b/src/rest/resources/sakstemaResource.tsx
@@ -1,19 +1,22 @@
 import * as React from 'react';
-import { applyDefaults, DefaultConfig, RendererOrConfig, useRest, useFetch } from '../useRest';
+import { applyDefaults, DefaultConfig, RendererOrConfig, useRQRest } from '../useRest';
 import { CenteredLazySpinner } from '../../components/LazySpinner';
 import AlertStripe from 'nav-frontend-alertstriper';
 import { apiBaseUri } from '../../api/config';
-import { FetchResult } from '@nutgaard/use-fetch';
 import { SakstemaResponse } from '../../models/saksoversikt/sakstema';
 import { useSelector } from 'react-redux';
 import { AppState } from '../../redux/reducers';
 import { useValgtenhet } from '../../context/valgtenhet-state';
+import { useQuery, UseQueryResult } from '@tanstack/react-query';
+import { FetchError, get } from '../../api/api';
 
 const defaults: DefaultConfig = {
     ifPending: <CenteredLazySpinner />,
     ifError: <AlertStripe type="advarsel">Kunne ikke laste inn tema</AlertStripe>
 };
-
+function queryKey(fnr: string, enhet: string | undefined): [string, string, string | undefined] {
+    return ['sakstema', fnr, enhet];
+}
 function url(fnr: string, enhet: string | undefined) {
     const header = enhet ? `?enhet=${enhet}` : '';
     return `${apiBaseUri}/saker/${fnr}/sakstema${header}`;
@@ -26,13 +29,13 @@ function useFnrEnhet(): [string, string | undefined] {
 }
 
 const resource = {
-    useFetch(): FetchResult<SakstemaResponse> {
+    useFetch(): UseQueryResult<SakstemaResponse, FetchError> {
         const [fnr, enhet] = useFnrEnhet();
-        return useFetch(url(fnr, enhet));
+        return useQuery(queryKey(fnr, enhet), () => get(url(fnr, enhet)));
     },
     useRenderer(renderer: RendererOrConfig<SakstemaResponse>) {
-        const [fnr, enhet] = useFnrEnhet();
-        return useRest(url(fnr, enhet), applyDefaults(defaults, renderer));
+        const response = this.useFetch();
+        return useRQRest(response, applyDefaults(defaults, renderer));
     }
 };
 

--- a/src/rest/resources/tildelteoppgaverResource.tsx
+++ b/src/rest/resources/tildelteoppgaverResource.tsx
@@ -1,12 +1,16 @@
-import { FetchResult } from '@nutgaard/use-fetch';
 import { useFodselsnummer } from '../../utils/customHooks';
-import { applyDefaults, DefaultConfig, RendererOrConfig, useFetch, useRest } from '../useRest';
+import { applyDefaults, DefaultConfig, RendererOrConfig, useRQRest } from '../useRest';
 import { Oppgave } from '../../models/meldinger/oppgave';
 import { CenteredLazySpinner } from '../../components/LazySpinner';
 import AlertStripe from 'nav-frontend-alertstriper';
 import * as React from 'react';
 import { apiBaseUri } from '../../api/config';
+import { useQuery, UseQueryResult } from '@tanstack/react-query';
+import { FetchError, get } from '../../api/api';
 
+function queryKey(fnr: string): [string, string] {
+    return ['tildelteoppgaver', fnr];
+}
 function url(fnr: string): string {
     return `${apiBaseUri}/oppgaver/tildelt/${fnr}`;
 }
@@ -16,13 +20,13 @@ const defaults: DefaultConfig = {
 };
 
 const resource = {
-    useFetch(): FetchResult<Oppgave[]> {
+    useFetch(): UseQueryResult<Oppgave[], FetchError> {
         const fnr = useFodselsnummer();
-        return useFetch(url(fnr));
+        return useQuery(queryKey(fnr), () => get(url(fnr)));
     },
     useRenderer(renderer: RendererOrConfig<Oppgave[]>) {
-        const fnr = useFodselsnummer();
-        return useRest(url(fnr), applyDefaults(defaults, renderer));
+        const response = this.useFetch();
+        return useRQRest(response, applyDefaults(defaults, renderer));
     }
 };
 export default resource;

--- a/src/test/testStore.ts
+++ b/src/test/testStore.ts
@@ -26,6 +26,7 @@ import pleiepengerResource from '../rest/resources/pleiepengerResource';
 import sykepengerResource from '../rest/resources/sykepengerResource';
 import gsaktemaResource from '../rest/resources/gsaktemaResource';
 import oppfolgingResource from '../rest/resources/oppfolgingResource';
+import sakstemaResource from '../rest/resources/sakstemaResource';
 
 export function getTestStore(): Store<AppState> {
     const testStore = createStore(reducers, applyMiddleware(thunkMiddleware));
@@ -56,10 +57,6 @@ export function setupFetchCache() {
         createCacheKey(`${apiBaseUri}/v2/person/${aremark.personIdent}/aktorid`),
         `000${aremark.personIdent}000` as unknown as object
     );
-    cache.putResolved(
-        createCacheKey(`${apiBaseUri}/saker/${aremark.personIdent}/sakstema`),
-        getStaticMockSaksoversikt()
-    );
     cache.putResolved(createCacheKey(`${apiBaseUri}/baseurls`), mockBaseUrls());
     cache.putResolved(createCacheKey(`${apiBaseUri}/veileder/roller`), { roller: [SaksbehandlerRoller.HentOppgave] });
     cache.putResolved(createCacheKey(`${apiBaseUri}/hode/me`), getMockInnloggetSaksbehandler());
@@ -85,6 +82,7 @@ export function setupReactQueryMocks() {
     jest.spyOn(sykepengerResource, 'useFetch');
     jest.spyOn(gsaktemaResource, 'useFetch');
     jest.spyOn(oppfolgingResource, 'useFetch');
+    jest.spyOn(sakstemaResource, 'useFetch');
 
     mockReactQuery(innstillingerResource.useFetch, {
         sistLagret: new Date().toISOString(),
@@ -104,4 +102,5 @@ export function setupReactQueryMocks() {
         sykepenger: [statiskSykepengerMock]
     });
     mockReactQuery(oppfolgingResource.useFetch, statiskOppfolgingMock);
+    mockReactQuery(sakstemaResource.useFetch, getStaticMockSaksoversikt());
 }

--- a/src/utils/hooks/useTildelteOppgaver.ts
+++ b/src/utils/hooks/useTildelteOppgaver.ts
@@ -1,15 +1,14 @@
 import { useMemo } from 'react';
 import { useFodselsnummer } from '../customHooks';
 import { Oppgave } from '../../models/meldinger/oppgave';
-import tildelteoppgaver from '../../rest/resources/tildelteoppgaver';
-import { hasData } from '@nutgaard/use-fetch';
+import tildelteoppgaver from '../../rest/resources/tildelteoppgaverResource';
 
 const emptyList: any[] = [];
 function useTildelteOppgaver(): { paaBruker: Oppgave[] } {
     const tildelteOppgaverResource = tildelteoppgaver.useFetch();
     const fnr = useFodselsnummer();
 
-    const tildelteOppgaver = hasData(tildelteOppgaverResource) ? tildelteOppgaverResource.data : emptyList;
+    const tildelteOppgaver = tildelteOppgaverResource.data ? tildelteOppgaverResource.data : emptyList;
     return useMemo(() => {
         const alleTildelteOppgaverPaaBruker = tildelteOppgaver.filter((oppg) => oppg.fødselsnummer === fnr);
 


### PR DESCRIPTION
react-query er mer brukt, aktivt forvaltet og støtter refetching mye mer elegant.
