### PR TITLE
[KAIZEN-0] bytte ut useFetch for react-query for tildelte oppgaver

### DIFF
--- a/src/app/PersonOppslagHandler/LyttPåNyttFnrIReduxOgHentAllPersoninfo.tsx
+++ b/src/app/PersonOppslagHandler/LyttPåNyttFnrIReduxOgHentAllPersoninfo.tsx
@@ -3,7 +3,7 @@ import { useDispatch } from 'react-redux';
 import { useGjeldendeBruker } from '../../redux/gjeldendeBruker/types';
 import { useFetchFeatureTogglesOnNewFnr } from './FetchFeatureToggles';
 import { loggEvent } from '../../utils/logger/frontendLogger';
-import tildelteoppgaver from '../../rest/resources/tildelteoppgaver';
+import tildelteoppgaver from '../../rest/resources/tildelteoppgaverResource';
 
 function LyttPåNyttFnrIReduxOgHentAllPersoninfo() {
     const dispatch = useDispatch();

--- a/src/app/personside/BegrensetTilgangSide.tsx
+++ b/src/app/personside/BegrensetTilgangSide.tsx
@@ -7,7 +7,7 @@ import styled from 'styled-components/macro';
 import Ekspanderbartpanel from 'nav-frontend-ekspanderbartpanel';
 import { useState, useCallback } from 'react';
 import gsaktemaResource from '../../rest/resources/gsaktemaResource';
-import { HarIkkeTilgang } from '../../rest/resources/tilgangskontroll';
+import { HarIkkeTilgang } from '../../rest/resources/tilgangskontrollResource';
 
 interface BegrensetTilgangProps {
     tilgangsData: HarIkkeTilgang;

--- a/src/app/personside/Personoversikt.tsx
+++ b/src/app/personside/Personoversikt.tsx
@@ -7,7 +7,7 @@ import { useHistory } from 'react-router';
 import { paths } from '../routes/routing';
 import { loggInfo } from '../../utils/logger/frontendLogger';
 import BegrensetTilgangSide from './BegrensetTilgangSide';
-import tilgangskontroll from '../../rest/resources/tilgangskontroll';
+import tilgangskontroll from '../../rest/resources/tilgangskontrollResource';
 import { DialogpanelStateProvider } from '../../context/dialogpanel-state';
 
 function Personoversikt() {

--- a/src/app/personside/dialogpanel/fortsettDialog/FortsettDialogContainer.tsx
+++ b/src/app/personside/dialogpanel/fortsettDialog/FortsettDialogContainer.tsx
@@ -11,7 +11,7 @@ import { SvarSendtKvittering } from './FortsettDialogKvittering';
 import useOpprettHenvendelse from './useOpprettHenvendelse';
 import { erJournalfort } from '../../infotabs/meldinger/utils/meldingerUtils';
 import { loggError } from '../../../../utils/logger/frontendLogger';
-import { post } from '../../../../api/api';
+import { FetchError, post } from '../../../../api/api';
 import { apiBaseUri } from '../../../../api/config';
 import {
     DialogPanelStatus,
@@ -28,11 +28,10 @@ import { Temagruppe } from '../../../../models/temagrupper';
 import useDraft, { Draft } from '../use-draft';
 import * as JournalforingUtils from '../../journalforings-use-fetch-utils';
 import { Oppgave } from '../../../../models/meldinger/oppgave';
-import tildelteoppgaver from '../../../../rest/resources/tildelteoppgaver';
-import { FetchResult, hasData } from '@nutgaard/use-fetch';
+import tildelteoppgaver from '../../../../rest/resources/tildelteoppgaverResource';
 import dialogResource from '../../../../rest/resources/dialogResource';
 import { useValgtenhet } from '../../../../context/valgtenhet-state';
-import { useQueryClient } from '@tanstack/react-query';
+import { useQueryClient, UseQueryResult } from '@tanstack/react-query';
 
 export type FortsettDialogType =
     | Meldingstype.SVAR_SKRIFTLIG
@@ -51,9 +50,9 @@ const StyledArticle = styled.article`
 
 export function finnPlukketOppgaveForTraad(
     traad: Traad,
-    resource: FetchResult<Oppgave[]>
+    resource: UseQueryResult<Oppgave[], FetchError>
 ): { oppgave: Oppgave | undefined; erSTOOppgave: boolean } {
-    if (!hasData(resource)) {
+    if (!resource.data) {
         return { oppgave: undefined, erSTOOppgave: false };
     } else {
         const oppgave: Oppgave | undefined = resource.data.find(
@@ -130,7 +129,7 @@ function FortsettDialogContainer(props: Props) {
         }
         const callback = () => {
             removeDraft();
-            tildelteOppgaverResource.rerun();
+            tildelteOppgaverResource.refetch();
             queryClient.invalidateQueries(dialogResource.queryKey(fnr, valgtEnhet));
         };
 

--- a/src/app/personside/dialogpanel/fortsettDialog/useOpprettHenvendelse.tsx
+++ b/src/app/personside/dialogpanel/fortsettDialog/useOpprettHenvendelse.tsx
@@ -9,7 +9,7 @@ import { apiBaseUri } from '../../../../api/config';
 import { postWithConflictVerification, RespectConflictError } from '../../../../api/api';
 import { useState } from 'react';
 import { setIngenValgtTraadDialogpanel } from '../../../../redux/oppgave/actions';
-import tildelteoppgaverResource from '../../../../rest/resources/tildelteoppgaver';
+import tildelteoppgaverResource from '../../../../rest/resources/tildelteoppgaverResource';
 import { useValgtenhet } from '../../../../context/valgtenhet-state';
 
 interface NotFinishedOpprettHenvendelse {
@@ -41,7 +41,7 @@ function useOpprettHenvendelse(traad: Traad): OpprettHenvendelseReturns {
             'Oppgaven tilknyttet denne meldingen er allerede tilordnet en saksbehandler. Vil du overstyre dette?'
         )
             .then((data) => setResponse(data as OpprettHenvendelseResponse))
-            .then(() => tildelteoppgaver.rerun())
+            .then(() => tildelteoppgaver.refetch())
             .catch((e) => {
                 if (e instanceof RespectConflictError) {
                     dispatch(setIngenValgtTraadDialogpanel());

--- a/src/app/personside/infotabs/meldinger/traadvisning/verktoylinje/merk/MerkPanel.tsx
+++ b/src/app/personside/infotabs/meldinger/traadvisning/verktoylinje/merk/MerkPanel.tsx
@@ -19,7 +19,7 @@ import {
 import { Traad } from '../../../../../../../models/meldinger/meldinger';
 import { RadioPanelGruppe, RadioPanelProps } from 'nav-frontend-skjema';
 import { apiBaseUri } from '../../../../../../../api/config';
-import { post } from '../../../../../../../api/api';
+import { FetchError, post } from '../../../../../../../api/api';
 import {
     MerkLukkTraadRequest,
     MerkRequestMedBehandlingskjede,
@@ -30,14 +30,13 @@ import { Resultat } from '../utils/VisPostResultat';
 import { useFocusOnFirstFocusable } from '../../../../../../../utils/hooks/use-focus-on-first-focusable';
 import { setIngenValgtTraadDialogpanel } from '../../../../../../../redux/oppgave/actions';
 import { Oppgave } from '../../../../../../../models/meldinger/oppgave';
-import tildelteoppgaver from '../../../../../../../rest/resources/tildelteoppgaver';
-import { FetchResult, hasData } from '@nutgaard/use-fetch';
+import tildelteoppgaver from '../../../../../../../rest/resources/tildelteoppgaverResource';
 import { SladdeObjekt, velgMeldingerTilSladding } from './sladdevalg/Sladdevalg';
 import useFeatureToggle from '../../../../../../../components/featureToggle/useFeatureToggle';
 import { FeatureToggles } from '../../../../../../../components/featureToggle/toggleIDs';
 import dialogResource from '../../../../../../../rest/resources/dialogResource';
 import { useValgtenhet } from '../../../../../../../context/valgtenhet-state';
-import { useQueryClient } from '@tanstack/react-query';
+import { useQueryClient, UseQueryResult } from '@tanstack/react-query';
 
 interface Props {
     lukkPanel: () => void;
@@ -115,8 +114,11 @@ function getLukkTraadRequest(fnr: string, valgtEnhet: string, traad: Traad, oppg
     };
 }
 
-function finnOppgaveForTraad(traad: Traad, tildelteOppgaver: FetchResult<Oppgave[]>): Oppgave | undefined {
-    if (hasData(tildelteOppgaver)) {
+function finnOppgaveForTraad(
+    traad: Traad,
+    tildelteOppgaver: UseQueryResult<Oppgave[], FetchError>
+): Oppgave | undefined {
+    if (tildelteOppgaver.data) {
         return tildelteOppgaver.data.find((it) => it.traadId === traad.traadId);
     }
     return undefined;
@@ -178,7 +180,7 @@ function MerkPanel(props: Props) {
                 settResultat(Resultat.VELLYKKET);
                 setSubmitting(false);
                 queryClient.invalidateQueries(dialogResource.queryKey(valgtBrukersFnr, valgtEnhet));
-                tildelteOppgaverResource.rerun();
+                tildelteOppgaverResource.refetch();
                 dispatch(setIngenValgtTraadDialogpanel());
             })
             .catch(() => {
@@ -199,7 +201,7 @@ function MerkPanel(props: Props) {
                 break;
             case MerkOperasjon.SLADDING:
                 if (skalSendeArsak) {
-                    const sladdeObjekt: SladdeObjekt | null = await velgMeldingerTilSladding(valgtTraad);
+                    const sladdeObjekt: SladdeObjekt | null = await velgMeldingerTilSladding(valgtTraad, queryClient);
                     // If null, then modal was closed without "submitting form"
                     if (sladdeObjekt !== null) {
                         merkPost(

--- a/src/app/personside/infotabs/meldinger/traadvisning/verktoylinje/merk/sladdevalg/Sladdevalg.tsx
+++ b/src/app/personside/infotabs/meldinger/traadvisning/verktoylinje/merk/sladdevalg/Sladdevalg.tsx
@@ -12,6 +12,7 @@ import SladdTradMedArsak from './SladdTradMedArsak';
 import SladdMeldingerMedArsak from './SladdMeldingerMedArsak';
 import css from './Sladdvalg.module.css';
 import { useSladdeArsak } from './use-sladde-arsak';
+import { QueryClient } from '@tanstack/react-query';
 
 interface Props {
     traad: Traad;
@@ -19,8 +20,8 @@ interface Props {
 
 export type SladdeObjekt = ({ traadId: string } | { meldingId: Array<string> }) & { arsak?: string };
 
-export function velgMeldingerTilSladding(traad: Traad) {
-    return renderPopup(Sladdevalg, { traad });
+export function velgMeldingerTilSladding(traad: Traad, queryClient: QueryClient) {
+    return renderPopup(queryClient, Sladdevalg, { traad });
 }
 const ModalBase = styled(NavFrontendModal)`
     &.modal {

--- a/src/app/personside/infotabs/meldinger/traadvisning/verktoylinje/oppgave/AvsluttGosysOppgaveSkjema.tsx
+++ b/src/app/personside/infotabs/meldinger/traadvisning/verktoylinje/oppgave/AvsluttGosysOppgaveSkjema.tsx
@@ -10,8 +10,7 @@ import theme from '../../../../../../../styles/personOversiktTheme';
 import { AvsluttGosysOppgaveRequest } from '../../../../../../../models/meldinger/merk';
 import { Traad } from '../../../../../../../models/meldinger/meldinger';
 import Ekspanderbartpanel from 'nav-frontend-ekspanderbartpanel';
-import tildelteoppgaver from '../../../../../../../rest/resources/tildelteoppgaver';
-import { hasData } from '@nutgaard/use-fetch';
+import tildelteoppgaver from '../../../../../../../rest/resources/tildelteoppgaverResource';
 import { useValgtenhet } from '../../../../../../../context/valgtenhet-state';
 
 const StyledAlert = styled.div`
@@ -37,7 +36,7 @@ function AvsluttGosysOppgaveSkjema(props: Props) {
     const [avsluttOppgaveSuksess, setAvsluttOppgaveSuksess] = useState(false);
     const [error, setError] = useState(false);
     const harOppgaveTilknyttetTrad =
-        hasData(tildelteOppgaverResource) &&
+        tildelteOppgaverResource.data &&
         tildelteOppgaverResource.data.find((it) => it.traadId === props.valgtTraad.traadId);
 
     useFocusOnMount(ref);
@@ -57,7 +56,7 @@ function AvsluttGosysOppgaveSkjema(props: Props) {
             post(`${apiBaseUri}/dialogmerking/avsluttgosysoppgave`, request, 'Avslutt-Oppgave-Fra-Gosys')
                 .then(() => {
                     setAvsluttOppgaveSuksess(true);
-                    tildelteOppgaverResource.rerun();
+                    tildelteOppgaverResource.refetch();
                 })
                 .catch(() => {
                     setError(true);

--- a/src/app/personside/infotabs/oppfolging/OppfolgingDatoKomponent.tsx
+++ b/src/app/personside/infotabs/oppfolging/OppfolgingDatoKomponent.tsx
@@ -88,7 +88,7 @@ function getDatoFeilmelding(fra: string, til: string) {
 }
 
 function DatoInputs() {
-    const update = oppfolgingResource.useMutation();
+    const update = oppfolgingResource.useFetch();
 
     const valgtPeriode = useAppState((appState) => appState.oppfolging.valgtPeriode);
     const fra = valgtPeriode.fra;
@@ -107,7 +107,7 @@ function DatoInputs() {
             return;
         }
         loggEvent('SøkNyPeriode', 'Oppfølging');
-        update.mutate();
+        update.refetch();
     };
 
     return (

--- a/src/components/person/BegrensetTilgangBegrunnelse.tsx
+++ b/src/components/person/BegrensetTilgangBegrunnelse.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import { assertUnreachable } from '../../utils/assertUnreachable';
-import { IkkeTilgangArsak } from '../../rest/resources/tilgangskontroll';
+import { IkkeTilgangArsak } from '../../rest/resources/tilgangskontrollResource';
 
 interface Props {
     begrunnelseType: IkkeTilgangArsak;

--- a/src/components/popup-boxes/popup-boxes.tsx
+++ b/src/components/popup-boxes/popup-boxes.tsx
@@ -11,6 +11,7 @@ import { ReactComponent as InfoIkon } from 'nav-frontend-ikoner-assets/assets/in
 import styled from 'styled-components/macro';
 import { focusOnFirstFocusable } from '../../utils/hooks/use-focus-on-first-focusable';
 import { Normaltekst, Systemtittel } from 'nav-frontend-typografi';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 
 type IconChoice = 'none' | 'ok' | 'warning' | 'error' | 'help' | 'info';
 type CommonPopupComponentProps = {
@@ -49,6 +50,7 @@ function getIcon(choice: IconChoice): React.ReactNode {
 }
 
 export function renderPopup<RESULT, PROPS>(
+    queryClient: QueryClient | null,
     componentType: PopupComponent<RESULT, PROPS>,
     props: PROPS
 ): Promise<RESULT> {
@@ -62,8 +64,11 @@ export function renderPopup<RESULT, PROPS>(
             resolve(result);
         };
         const component = createElement(componentType, { ...props, close });
-
-        render(component, tmp);
+        if (queryClient) {
+            render(<QueryClientProvider client={queryClient}>{component}</QueryClientProvider>, tmp);
+        } else {
+            render(component, tmp);
+        }
     });
 }
 
@@ -155,17 +160,17 @@ function Prompt(props: PopupComponentProps<string | null, PromptProps>) {
 }
 
 export function alert(props: CommonPopupComponentProps): Promise<void> {
-    return renderPopup(Alert, props);
+    return renderPopup(null, Alert, props);
 }
 
 export function confirm(props: CommonPopupComponentProps): Promise<boolean> {
-    return renderPopup(Confirm, props);
+    return renderPopup(null, Confirm, props);
 }
 
 export function prompt(props: CommonPopupComponentProps): Promise<string | null> {
-    return renderPopup(Prompt, { ...props, secret: false });
+    return renderPopup(null, Prompt, { ...props, secret: false });
 }
 
 export function promptSecret(props: CommonPopupComponentProps): Promise<string | null> {
-    return renderPopup(Prompt, { ...props, secret: true });
+    return renderPopup(null, Prompt, { ...props, secret: true });
 }

--- a/src/mock/tilgangskontroll-mock.ts
+++ b/src/mock/tilgangskontroll-mock.ts
@@ -1,6 +1,6 @@
 import navfaker from 'nav-faker';
 import { AuthIntropectionDTO } from '../utils/hooks/use-persistent-login';
-import { IkkeTilgangArsak, TilgangDTO } from '../rest/resources/tilgangskontroll';
+import { IkkeTilgangArsak, TilgangDTO } from '../rest/resources/tilgangskontrollResource';
 
 export function authMock(): AuthIntropectionDTO {
     return { expirationDate: new Date().getTime() + 2.5 * 60 * 1000 };

--- a/src/rest/resources/dialogResource.tsx
+++ b/src/rest/resources/dialogResource.tsx
@@ -24,17 +24,13 @@ function useReduxData(): [string, string | undefined] {
     return useAppState((appState) => [appState.gjeldendeBruker.fødselsnummer, valgtEnhet]);
 }
 
-function fetchDialog(fnr: string, enhet: string | undefined): Promise<Traad[]> {
-    return get<Traad[]>(url(fnr, enhet));
-}
-
 const resource = {
     queryKey(fnr: string, enhet: string | undefined) {
         return ['dialog', fnr, enhet];
     },
     useFetch(): UseQueryResult<Traad[], FetchError> {
         const [fnr, enhetId] = useReduxData();
-        return useQuery(this.queryKey(fnr, enhetId), () => fetchDialog(fnr, enhetId));
+        return useQuery(this.queryKey(fnr, enhetId), () => get(url(fnr, enhetId)));
     },
     useRenderer(renderer: RendererOrConfig<Traad[]>) {
         const response = this.useFetch();

--- a/src/rest/resources/oppfolgingResource.tsx
+++ b/src/rest/resources/oppfolgingResource.tsx
@@ -6,9 +6,8 @@ import * as React from 'react';
 import { apiBaseUri } from '../../api/config';
 import { VisOppfolgingFraTilDato } from '../../redux/oppfolging/types';
 import { useAppState } from '../../utils/customHooks';
-import { useMutation, useQuery, useQueryClient, UseQueryResult } from '@tanstack/react-query';
+import { useQuery, UseQueryResult } from '@tanstack/react-query';
 import { FetchError, get } from '../../api/api';
-import { UseMutationResult } from '@tanstack/react-query/src/types';
 
 function queryKey(fnr: string): [string, string] {
     return ['oppfolging', fnr];
@@ -31,15 +30,6 @@ const resource = {
     useFetch(): UseQueryResult<DetaljertOppfolging, FetchError> {
         const [fnr, periode] = useReduxData();
         return useQuery(queryKey(fnr), () => get(url(fnr, periode)));
-    },
-    useMutation(): UseMutationResult<DetaljertOppfolging, FetchError, void> {
-        const queryClient = useQueryClient();
-        const [fnr, periode] = useReduxData();
-        return useMutation(() => get(url(fnr, periode)), {
-            onSuccess(data: DetaljertOppfolging) {
-                queryClient.setQueryData(queryKey(fnr), data);
-            }
-        });
     },
     useRenderer(renderer: RendererOrConfig<DetaljertOppfolging>) {
         const response = this.useFetch();

--- a/src/rest/resources/tildelteoppgaverResource.tsx
+++ b/src/rest/resources/tildelteoppgaverResource.tsx
@@ -1,12 +1,16 @@
-import { FetchResult } from '@nutgaard/use-fetch';
 import { useFodselsnummer } from '../../utils/customHooks';
-import { applyDefaults, DefaultConfig, RendererOrConfig, useFetch, useRest } from '../useRest';
+import { applyDefaults, DefaultConfig, RendererOrConfig, useRQRest } from '../useRest';
 import { Oppgave } from '../../models/meldinger/oppgave';
 import { CenteredLazySpinner } from '../../components/LazySpinner';
 import AlertStripe from 'nav-frontend-alertstriper';
 import * as React from 'react';
 import { apiBaseUri } from '../../api/config';
+import { useQuery, UseQueryResult } from '@tanstack/react-query';
+import { FetchError, get } from '../../api/api';
 
+function queryKey(fnr: string): [string, string] {
+    return ['tildelteoppgaver', fnr];
+}
 function url(fnr: string): string {
     return `${apiBaseUri}/oppgaver/tildelt/${fnr}`;
 }
@@ -16,13 +20,13 @@ const defaults: DefaultConfig = {
 };
 
 const resource = {
-    useFetch(): FetchResult<Oppgave[]> {
+    useFetch(): UseQueryResult<Oppgave[], FetchError> {
         const fnr = useFodselsnummer();
-        return useFetch(url(fnr));
+        return useQuery(queryKey(fnr), () => get(url(fnr)));
     },
     useRenderer(renderer: RendererOrConfig<Oppgave[]>) {
-        const fnr = useFodselsnummer();
-        return useRest(url(fnr), applyDefaults(defaults, renderer));
+        const response = this.useFetch();
+        return useRQRest(response, applyDefaults(defaults, renderer));
     }
 };
 export default resource;

--- a/src/utils/hooks/useTildelteOppgaver.ts
+++ b/src/utils/hooks/useTildelteOppgaver.ts
@@ -1,15 +1,14 @@
 import { useMemo } from 'react';
 import { useFodselsnummer } from '../customHooks';
 import { Oppgave } from '../../models/meldinger/oppgave';
-import tildelteoppgaver from '../../rest/resources/tildelteoppgaver';
-import { hasData } from '@nutgaard/use-fetch';
+import tildelteoppgaver from '../../rest/resources/tildelteoppgaverResource';
 
 const emptyList: any[] = [];
 function useTildelteOppgaver(): { paaBruker: Oppgave[] } {
     const tildelteOppgaverResource = tildelteoppgaver.useFetch();
     const fnr = useFodselsnummer();
 
-    const tildelteOppgaver = hasData(tildelteOppgaverResource) ? tildelteOppgaverResource.data : emptyList;
+    const tildelteOppgaver = tildelteOppgaverResource.data ? tildelteOppgaverResource.data : emptyList;
     return useMemo(() => {
         const alleTildelteOppgaverPaaBruker = tildelteOppgaver.filter((oppg) => oppg.fødselsnummer === fnr);
 


### PR DESCRIPTION
react-query er mer brukt, aktivt forvaltet og støtter refetching mye mer elegant.
