### PR TITLE
[KAIZEN-0] bytte ut useFetch for react-query for tilgangskontroll

### DIFF
--- a/src/app/personside/BegrensetTilgangSide.tsx
+++ b/src/app/personside/BegrensetTilgangSide.tsx
@@ -7,7 +7,7 @@ import styled from 'styled-components/macro';
 import Ekspanderbartpanel from 'nav-frontend-ekspanderbartpanel';
 import { useState, useCallback } from 'react';
 import gsaktemaResource from '../../rest/resources/gsaktemaResource';
-import { HarIkkeTilgang } from '../../rest/resources/tilgangskontroll';
+import { HarIkkeTilgang } from '../../rest/resources/tilgangskontrollResource';
 
 interface BegrensetTilgangProps {
     tilgangsData: HarIkkeTilgang;

--- a/src/app/personside/Personoversikt.tsx
+++ b/src/app/personside/Personoversikt.tsx
@@ -7,7 +7,7 @@ import { useHistory } from 'react-router';
 import { paths } from '../routes/routing';
 import { loggInfo } from '../../utils/logger/frontendLogger';
 import BegrensetTilgangSide from './BegrensetTilgangSide';
-import tilgangskontroll from '../../rest/resources/tilgangskontroll';
+import tilgangskontroll from '../../rest/resources/tilgangskontrollResource';
 import { DialogpanelStateProvider } from '../../context/dialogpanel-state';
 
 function Personoversikt() {

--- a/src/components/person/BegrensetTilgangBegrunnelse.tsx
+++ b/src/components/person/BegrensetTilgangBegrunnelse.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import { assertUnreachable } from '../../utils/assertUnreachable';
-import { IkkeTilgangArsak } from '../../rest/resources/tilgangskontroll';
+import { IkkeTilgangArsak } from '../../rest/resources/tilgangskontrollResource';
 
 interface Props {
     begrunnelseType: IkkeTilgangArsak;

--- a/src/mock/tilgangskontroll-mock.ts
+++ b/src/mock/tilgangskontroll-mock.ts
@@ -1,6 +1,6 @@
 import navfaker from 'nav-faker';
 import { AuthIntropectionDTO } from '../utils/hooks/use-persistent-login';
-import { IkkeTilgangArsak, TilgangDTO } from '../rest/resources/tilgangskontroll';
+import { IkkeTilgangArsak, TilgangDTO } from '../rest/resources/tilgangskontrollResource';
 
 export function authMock(): AuthIntropectionDTO {
     return { expirationDate: new Date().getTime() + 2.5 * 60 * 1000 };


### PR DESCRIPTION
react-query er mer brukt, aktivt forvaltet og støtter refetching mye mer elegant.
