### PR TITLE
[KAIZEN-0] fikse evig render-løkke for standardtekster

### DIFF
--- a/src/app/personside/dialogpanel/sendMelding/standardTekster/StandardTekster.tsx
+++ b/src/app/personside/dialogpanel/sendMelding/standardTekster/StandardTekster.tsx
@@ -116,9 +116,10 @@ function velgTekst(
 function StandardTekster(props: Props) {
     const sokRef = React.useRef<HTMLElement>(null);
     const standardTekster = skrivestotteResource.useFetch();
+    const standardTeksterData = standardTekster.data;
     const debouncedSokefelt = useDebounce(props.sokefelt.input.value, 250);
     const [filtrerteTekster, settFiltrerteTekster] = useState(() =>
-        sokEtterTekster(standardTekster, debouncedSokefelt)
+        sokEtterTekster(standardTeksterData, debouncedSokefelt)
     );
     const valgt = useFieldState('');
     const valgtLocale = useFieldState('');
@@ -134,8 +135,8 @@ function StandardTekster(props: Props) {
     useDefaultValgtTekst(filtrerteTekster, valgt);
 
     useEffect(() => {
-        settFiltrerteTekster(sokEtterTekster(standardTekster, debouncedSokefelt));
-    }, [settFiltrerteTekster, standardTekster, debouncedSokefelt]);
+        settFiltrerteTekster(sokEtterTekster(standardTeksterData, debouncedSokefelt));
+    }, [settFiltrerteTekster, standardTeksterData, debouncedSokefelt]);
 
     const prevFiltreteTekster = usePrevious(filtrerteTekster);
     useEffect(() => {
@@ -169,7 +170,7 @@ function StandardTekster(props: Props) {
         content = <Spinner type="XL" />;
     } else if (standardTekster.isError) {
         content = <SkjemaelementFeilmelding>Kunne ikke laste inn standardtekster</SkjemaelementFeilmelding>;
-    } else if (standardTekster.data) {
+    } else if (standardTeksterData) {
         content = (
             <StandardTekstValg
                 tekster={filtrerteTekster}

--- a/src/app/personside/dialogpanel/sendMelding/standardTekster/sokUtils.tsx
+++ b/src/app/personside/dialogpanel/sendMelding/standardTekster/sokUtils.tsx
@@ -1,18 +1,13 @@
 import { parseTekst } from '@navikt/tag-input';
 import * as StandardTekster from './domain';
-import { UseQueryResult } from '@tanstack/react-query';
 import { Tekster } from './domain';
-import { FetchError } from '../../../../../api/api';
 
 export function rapporterBruk(tekst: StandardTekster.Tekst): void {
     fetch(`/modiapersonoversikt/proxy/modia-skrivestotte/skrivestotte/statistikk/${tekst.id}`, { method: 'POST' });
 }
 
-export function sokEtterTekster(
-    data: UseQueryResult<Tekster, FetchError>,
-    query: string
-): Array<StandardTekster.Tekst> {
-    const tekster: Array<StandardTekster.Tekst> = data.data ? Object.values(data.data) : [];
+export function sokEtterTekster(data: Tekster | undefined, query: string): Array<StandardTekster.Tekst> {
+    const tekster: Array<StandardTekster.Tekst> = data ? Object.values(data) : [];
     if (query === '' || tekster.length === 0) {
         return tekster;
     }


### PR DESCRIPTION
`UseQueryResult<T>` bør ikke brukes som en avhengighet til `useEffect` da objektet ikke er stabil over tid.

Ved å endre `useEffect` til å synkronisere mot dataene blir det derimot stabil, og man slipper unna en evig-løkke
