### PR TITLE
[OPP-1441] legge til azure-ad-group

### DIFF
--- a/.nais/prod.yaml
+++ b/.nais/prod.yaml
@@ -41,6 +41,10 @@ spec:
     application:
       enabled: true
       tenant: nav.no
+      allowAllUsers: false
+      claims:
+        groups:
+          - id: "ea34edea-1e80-4759-a1d2-fbe696cf1709" # 0000-GA-BD06_ModiaGenerellTilgang
   env:
     - name: APP_NAME
       value: "modiapersonoversikt"

--- a/.nais/qa-template.yaml
+++ b/.nais/qa-template.yaml
@@ -41,6 +41,10 @@ spec:
     application:
       enabled: true
       tenant: trygdeetaten.no
+      allowAllUsers: false
+      claims:
+        groups:
+          - id: "67a06857-0028-4a90-bf4c-9c9a92c7d733" # 0000-GA-BD06_ModiaGenerellTilgang
   env:
     - name: APP_NAME
       value: "modiapersonoversikt"

--- a/src/app/personside/infotabs/saksoversikt/SaksDokumentIEgetVindu.tsx
+++ b/src/app/personside/infotabs/saksoversikt/SaksDokumentIEgetVindu.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { useFodselsnummer, useOnMount } from '../../../../utils/customHooks';
+import { useOnMount } from '../../../../utils/customHooks';
 import { loggEvent } from '../../../../utils/logger/frontendLogger';
 import DokumentVisning from './dokumentvisning/SaksDokumentVisning';
 import { useQueryParams } from '../../../../utils/url-utils';
@@ -22,7 +22,6 @@ const Sentring = styled.div`
 
 function SaksDokumentEgetVindu(props: Props) {
     const queryParams = useQueryParams<{ dokument?: string; journalpost?: string }>();
-    const fodselsnummer = useFodselsnummer();
 
     useOnMount(() => {
         loggEvent('Sidevisning', 'SaksDokumentEgetVindu');
@@ -36,11 +35,12 @@ function SaksDokumentEgetVindu(props: Props) {
             </Sentring>
         );
     }
+    console.log('fnr', props.fnr);
     return (
         <>
             <SetFnrIRedux fnr={props.fnr} />
             <DokumentVisning
-                url={getSaksdokumentUrl(fodselsnummer, queryParams.journalpost ?? null, queryParams.dokument)}
+                url={getSaksdokumentUrl(props.fnr, queryParams.journalpost ?? null, queryParams.dokument)}
             />
         </>
     );


### PR DESCRIPTION
`allowAllUsers: true` (som er default uten `groups`) er en hack fra nais-plattformen, og impliserer egentlig gruppe-tilhørighet til office365-lisens-gruppen.

Ved å spesifisere modiaGenerellTilgang-gruppen (uuid hentet fra azure portal) endrer vi gruppe tilhørigheten til å passe bedre med vårt bruk.
