### PR TITLE
[PROD][OPP-1441] legge til azure-ad-group

### DIFF
--- a/src/api/api.ts
+++ b/src/api/api.ts
@@ -1,5 +1,5 @@
 import { includeCredentials, postConfig } from './config';
-import { loggError, loggEvent } from '../utils/logger/frontendLogger';
+import { loggError, loggEvent, loggWarning } from '../utils/logger/frontendLogger';
 import { confirm } from '../components/popup-boxes/popup-boxes';
 
 const CONFLICT = 409;
@@ -65,7 +65,8 @@ function parseResponse<TYPE>(response: Response): Promise<TYPE> {
     } else if (contentType && contentType.indexOf('text/plain') !== -1) {
         return response.text() as Promise<TYPE>;
     } else {
-        return Promise.reject(`Unknown Content-Type: ${contentType}. Not sure what to do with response.`);
+        loggWarning(new Error(`Unknown Content-Type: ${contentType}. Not sure what to do with response.`));
+        return Promise.resolve({} as TYPE);
     }
 }
 

--- a/src/api/api.ts
+++ b/src/api/api.ts
@@ -58,12 +58,14 @@ function handleResponse<TYPE extends object = object>(
     return parseResponse<TYPE>(response);
 }
 
-function parseResponse<TYPE extends object = object>(response: Response): Promise<TYPE> {
+function parseResponse<TYPE>(response: Response): Promise<TYPE> {
     const contentType = response.headers.get('content-type');
     if (contentType && contentType.indexOf('application/json') !== -1) {
         return response.json();
+    } else if (contentType && contentType.indexOf('text/plain') !== -1) {
+        return response.text() as Promise<TYPE>;
     } else {
-        return Promise.resolve({} as TYPE);
+        return Promise.reject(`Unknown Content-Type: ${contentType}. Not sure what to do with response.`);
     }
 }
 

--- a/src/app/FetchSessionInfoOgLeggIRedux.tsx
+++ b/src/app/FetchSessionInfoOgLeggIRedux.tsx
@@ -3,6 +3,7 @@ import gsaktemaResource from '../rest/resources/gsaktemaResource';
 import baseurls from '../rest/resources/baseurlsResource';
 import innloggetSaksbehandler from '../rest/resources/innloggetSaksbehandlerResource';
 import saksbehandlersEnheter from '../rest/resources/saksbehandlersEnheterResource';
+import oppgaveBehandlerResource from '../rest/resources/oppgaveBehandlerResource';
 
 function FetchSessionInfoOgLeggIRedux() {
     useInitializeLogger();
@@ -10,6 +11,7 @@ function FetchSessionInfoOgLeggIRedux() {
     innloggetSaksbehandler.usePrefetch();
     saksbehandlersEnheter.usePrefetch();
     gsaktemaResource.usePrefetch();
+    oppgaveBehandlerResource.usePrefetch();
     baseurls.usePrefetch();
 
     return null;

--- a/src/app/personside/infotabs/saksoversikt/dokumentvisning/SaksDokumentVisning.tsx
+++ b/src/app/personside/infotabs/saksoversikt/dokumentvisning/SaksDokumentVisning.tsx
@@ -68,4 +68,4 @@ function feilmelding(statusKode: number) {
     }
 }
 
-export default DokumentVisning;
+export default React.memo(DokumentVisning);

--- a/src/rest/resources/oppgaveBehandlerResource.tsx
+++ b/src/rest/resources/oppgaveBehandlerResource.tsx
@@ -1,5 +1,5 @@
 import { apiBaseUri } from '../../api/config';
-import { useQuery, UseQueryResult } from '@tanstack/react-query';
+import { useQuery, useQueryClient, UseQueryResult } from '@tanstack/react-query';
 import { FetchError, get } from '../../api/api';
 import { Enhet } from '../../models/meldinger/oppgave';
 
@@ -7,8 +7,12 @@ const queryKey = ['oppgavebehandlere'];
 const url = `${apiBaseUri}/enheter/oppgavebehandlere/alle`;
 
 const resource = {
+    usePrefetch() {
+        const queryClient = useQueryClient();
+        queryClient.prefetchQuery(queryKey, () => get(url));
+    },
     useFetch(): UseQueryResult<Array<Enhet>, FetchError> {
-        return useQuery(queryKey, () => get(url), { initialData: [] });
+        return useQuery(queryKey, () => get(url));
     }
 };
 export default resource;


### PR DESCRIPTION
`allowAllUsers: true` (som er default uten `groups`) er en hack fra nais-plattformen, og impliserer egentlig gruppe-tilhørighet til office365-lisens-gruppen.

Ved å spesifisere modiaGenerellTilgang-gruppen (uuid hentet fra azure portal) endrer vi gruppe tilhørigheten til å passe bedre med vårt bruk.
