### PR TITLE
[OPP-1441] teste ut azure-ad-proxy vha queryparam

### DIFF
--- a/src/api/config.ts
+++ b/src/api/config.ts
@@ -14,4 +14,5 @@ export function postConfig(body?: object | string) {
 
 export const includeCredentials: RequestInit = { credentials: 'include' };
 
-export const apiBaseUri = '/modiapersonoversikt/proxy/api';
+const useAzureAd = window.location.search.includes('azuread');
+export const apiBaseUri = useAzureAd ? '/modiapersonoversikt/proxy/azure-api' : '/modiapersonoversikt/proxy/api';


### PR DESCRIPTION
ved å slenge på queryparam `azuread` ved lasting av modiapersonoversikt vil alle kall til backend gjøres med azure-ad token og obo-flyt.

etter azure-ad blir skrudd på i produksjon kan vi også bruke dette for å verifisere funksjonaliteten uten at det påvirker veiledere ellers
