### PR TITLE
[PROD][OPP-1441] teste ut azure-ad-proxy vha queryparam

### DIFF
--- a/src/api/config.ts
+++ b/src/api/config.ts
@@ -14,4 +14,5 @@ export function postConfig(body?: object | string) {
 
 export const includeCredentials: RequestInit = { credentials: 'include' };
 
-export const apiBaseUri = '/modiapersonoversikt/proxy/api';
+const useAzureAd = window.location.search.includes('azuread');
+export const apiBaseUri = useAzureAd ? '/modiapersonoversikt/proxy/azure-api' : '/modiapersonoversikt/proxy/api';

--- a/src/app/personside/infotabs/meldinger/MeldingerContainer.tsx
+++ b/src/app/personside/infotabs/meldinger/MeldingerContainer.tsx
@@ -6,7 +6,7 @@ import { pxToRem } from '../../../../styles/personOversiktTheme';
 import TraadListe from './traadliste/TraadListe';
 import { useInfotabsDyplenker } from '../dyplenker';
 import { useHistory } from 'react-router';
-import { AlertStripeFeil, AlertStripeInfo } from 'nav-frontend-alertstriper';
+import AlertStripe, { AlertStripeFeil, AlertStripeInfo } from 'nav-frontend-alertstriper';
 import { ScrollBar, scrollBarContainerStyle } from '../utils/InfoTabsScrollBar';
 import { useSokEtterMeldinger } from './utils/meldingerUtils';
 import { useValgtTraadIUrl } from './utils/useValgtTraadIUrl';
@@ -62,6 +62,8 @@ function MeldingerContainer() {
 
     if (traaderResource.isLoading) {
         return <LazySpinner type="M" />;
+    } else if (traaderResource.isError) {
+        return <AlertStripe type="advarsel">Kunne ikke laste inn brukers meldinger</AlertStripe>;
     }
 
     if (traaderForSok.length === 0) {


### PR DESCRIPTION
ved å slenge på queryparam `azuread` ved lasting av modiapersonoversikt vil alle kall til backend gjøres med azure-ad token og obo-flyt.

etter azure-ad blir skrudd på i produksjon kan vi også bruke dette for å verifisere funksjonaliteten uten at det påvirker veiledere ellers
