### PR TITLE
[PROD] [KAIZEN-0] gå direkte mot backend

### DIFF
--- a/src/api/config.ts
+++ b/src/api/config.ts
@@ -14,5 +14,6 @@ export function postConfig(body?: object | string) {
 
 export const includeCredentials: RequestInit = { credentials: 'include' };
 
-const useAzureAd = window.location.search.includes('azuread');
-export const apiBaseUri = useAzureAd ? '/modiapersonoversikt/proxy/azure-api' : '/modiapersonoversikt/proxy/api';
+// const useAzureAd = window.location.search.includes('azuread');
+// export const apiBaseUri = useAzureAd ? '/modiapersonoversikt/proxy/azure-api' : '/modiapersonoversikt/proxy/api';
+export const apiBaseUri = '/modiapersonoversikt-api/rest';


### PR DESCRIPTION
Klargjøring for azureAd aktivering.

Ved aktiverting av AzureAd vil frontend-containeren begynne å kreve azureAd token.
For veiledere som allerede er inne i løsningen vil dette føre til at de i effekt blir logget ut, og alle kall vil feile frem til de laster siden på nytt og blir logget inn med azuread.

For å minimere konsekvensen av dette kjører vi majoriteten av api-kall direkte mot backend i en overgangsfase