### PR TITLE
[KAIZEN-0] Oppdatere telefonnummerformat

### DIFF
--- a/src/app/personside/visittkort-v2/body/__snapshots__/VisittkortBody.test.tsx.snap
+++ b/src/app/personside/visittkort-v2/body/__snapshots__/VisittkortBody.test.tsx.snap
@@ -617,7 +617,7 @@ exports[`viser info om bruker i visittkortbody 1`] = `
         <p
           className="typo-normal"
         >
-          +47 990 09 900
+          +47 99 00 99 00
         </p>
         <div
           className="c7"
@@ -811,7 +811,7 @@ exports[`viser info om bruker i visittkortbody 1`] = `
           className="typo-normal"
         >
           Telefon: 
-          909 09 090
+          90 90 90 90
         </p>
         <div
           className="c9"

--- a/src/app/personside/visittkort-v2/body/__snapshots__/VisittkortBodyFeilendeSystemer.test.tsx.snap
+++ b/src/app/personside/visittkort-v2/body/__snapshots__/VisittkortBodyFeilendeSystemer.test.tsx.snap
@@ -721,7 +721,7 @@ exports[`viser info om bruker i visittkortbody 1`] = `
           className="typo-normal"
         >
           Telefon: 
-          909 09 090
+          90 90 90 90
         </p>
         <div
           className="c8"

--- a/src/app/personside/visittkort-v2/body/fullmakt/__snapshots__/Fullmakt.test.tsx.snap
+++ b/src/app/personside/visittkort-v2/body/fullmakt/__snapshots__/Fullmakt.test.tsx.snap
@@ -135,7 +135,7 @@ exports[`viser fullmakt 1`] = `
       className="typo-normal"
     >
       Telefon: 
-      909 09 090
+      90 90 90 90
     </p>
     <div
       className="c4"

--- a/src/utils/telefon-utils.ts
+++ b/src/utils/telefon-utils.ts
@@ -3,9 +3,9 @@ import { formatNumber } from './string-utils';
 
 export function formaterMobiltelefonnummer(telefonnummer: string) {
     if (telefonnummer.startsWith('+') && telefonnummer.length === 11) {
-        return formatNumber('### ### ## ###', telefonnummer);
+        return formatNumber('### ## ## ## ##', telefonnummer);
     } else if (telefonnummer.length === 8) {
-        return formatNumber('### ## ###', telefonnummer);
+        return formatNumber('## ## ## ##', telefonnummer);
     } else {
         return telefonnummer;
     }

--- a/src/utils/telefon-utils.ts
+++ b/src/utils/telefon-utils.ts
@@ -23,7 +23,7 @@ export function formaterTelefonnummer(telefonnummer: string) {
     const utenSpace = removeWhitespace(telefonnummer);
     if (utenSpace.length !== 8) {
         return telefonnummer;
-    } else if ('489'.includes(utenSpace[0])) {
+    } else if (utenSpace.startsWith('800')) {
         return formatNumber('### ## ###', utenSpace);
     } else {
         return formatNumber('## ## ## ##', utenSpace);

--- a/src/utils/telefonUtils.test.ts
+++ b/src/utils/telefonUtils.test.ts
@@ -5,7 +5,7 @@ it('returnerer formatert mobiltelefon', () => {
 
     const formatertTelefonnummer = formaterMobiltelefonnummer(telefonnummer);
 
-    expect(formatertTelefonnummer).toEqual('900 00 000');
+    expect(formatertTelefonnummer).toEqual('90 00 00 00');
 });
 
 it('returnerer formatert mobiltelefon med retningskode', () => {
@@ -13,15 +13,15 @@ it('returnerer formatert mobiltelefon med retningskode', () => {
 
     const formatertTelefonnummer = formaterMobiltelefonnummer(telefonnummer);
 
-    expect(formatertTelefonnummer).toEqual('+47 900 00 000');
+    expect(formatertTelefonnummer).toEqual('+47 90 00 00 00');
 });
 
-it('returnerer formatert mobiltelefon basert på første siffer', () => {
-    const telefonnummer = '90000000';
+it('returnerer formatert 800-telefonnummer basert på tre første siffer', () => {
+    const telefonnummer = '80000000';
 
     const formatertTelefonnummer = formaterTelefonnummer(telefonnummer);
 
-    expect(formatertTelefonnummer).toEqual('900 00 000');
+    expect(formatertTelefonnummer).toEqual('800 00 000');
 });
 
 it('returnerer formatert hustelefon basert på første siffer', () => {


### PR DESCRIPTION
Hei!

Vi får rett som det er inn endringsønsker om å endre telefonnummerformatet vi bruker (2+2+2+2) i Modia arbeidsrettet oppfølging og gjøre så det er likt som i personoversikten. Men det viser seg at Modia personoversikt bruker det gamle formatet med 3+2+3. Se [NAVs anbefaling](https://navno.sharepoint.com/sites/intranett-kommunikasjon/SitePages/Datoer,-symboler,-tall-og-valuta.aspx) som igjen er basert på [Språkrådets regler](https://www.sprakradet.no/sprakhjelp/Skriveregler/Dato/#tlf) som ble oppdatert etter [nummerforskriften i 2019](https://lovdata.no/forskrift/2004-02-16-426/§16)

Så tenkte vi nå at å oppdatere formatet hos dere, kanskje kan løse veiledernes behov for å melde inn endringsønsker til oss 🙏 

Si ifra hvis det skulle være noe! 😃 

NB! iPhone formaterer av en eller annen grunn alt som 3+2+3 og det er nok også en årsak til forvirring 🤷 