### PR TITLE
Fikse accordion tracking på første render

### DIFF
--- a/src/app/personside/visittkort-v2/VisittkortVisning.tsx
+++ b/src/app/personside/visittkort-v2/VisittkortVisning.tsx
@@ -22,9 +22,15 @@ function VisittkortVisning(props: Props) {
     const toggleApen = visittkortState.toggle;
     const lenkeNyBrukerprofil = useUrlNyPersonforvalter();
 
+    const isMount = React.useRef(true);
+
     React.useEffect(() => {
+        if (isMount.current) {
+            isMount.current = false;
+            return;
+        }
         erApen ? trackAccordionOpened('Visittkort') : trackAccordionClosed('Visittkort');
-    }, [erApen]);
+    }, [erApen, isMount]);
 
     useHotkey({ char: 'n', altKey: true }, () => toggleApen(), [toggleApen], 'Visittkort');
     useHotkey(


### PR DESCRIPTION
Siden useEffecten kjører på første render logger vi "Accordion lukket" selv når brukeren ikke har interagert med komponenten. Dette skal være fikset ved å ignorere "mount" effecten.