### PR TITLE
Fjern trailing slash fra API url

### DIFF
--- a/src/rest/resources/sakstemaResource.tsx
+++ b/src/rest/resources/sakstemaResource.tsx
@@ -21,7 +21,7 @@ function queryKeyV2(fnr: string, enhet: string | undefined): [string, string, st
 
 function urlUtenFnrIPathV2(enhet?: string) {
     const header = enhet ? `?enhet=${enhet}` : '';
-    return `${apiBaseUri}/v2/saker/v2/sakstema/${header}`;
+    return `${apiBaseUri}/v2/saker/v2/sakstema${header}`;
 }
 
 function useFnrEnhet(): [string, string | undefined] {


### PR DESCRIPTION
Spring 3 fjernet implisitt match av trailing slash.
