### PR TITLE
Fiks overflow problem i hoved konteiner

### DIFF
--- a/src/app/AppContainer.tsx
+++ b/src/app/AppContainer.tsx
@@ -55,11 +55,12 @@ const AppStyle = styled.div`
 `;
 
 const ContentStyle = styled.div`
+    height: 0px;
     @media print {
         height: auto;
     }
     display: flex;
-    flex-grow: 1;
+    flex: 1 1 auto;
 `;
 
 const store = createStore(reducers, composeWithDevTools(applyMiddleware(thunk)));


### PR DESCRIPTION
Fjernet `height: 0` etter vite oppgradering ettersom det ødela height i prod, men det ser ut til at
hacken gjorde at dynamisk height i containeren fungerte ordentlig.

Med denne fiksen er det mulig å scrolle i mye innhold igjen :)
