### PR TITLE
Aktiver proxy til dev-miljø ved lokal utvikling

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -7,8 +7,13 @@ import { setupTimeSpentMetrics } from './utils/timeSpentMetrics';
 import './window-variabler';
 setupTimeSpentMetrics();
 
+if (import.meta.env.DEV) {
+    window.applicationFeatureToggles = {
+        useNewDecorator: true
+    };
+}
+
 if (import.meta.env.VITE_MOCK_ENABLED === 'true') {
     await import('./mock');
 }
-
 ReactDOM.render(<AppContainer />, document.getElementById('root') as HTMLElement);

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -19,9 +19,18 @@ const fixNavFrontendStyleNoCss = (packages: string[]) =>
     }));
 
 export default defineConfig({
-    base: '/modiapersonoversikt/',
+    base: process.env.LOCAL_TOKEN ? '/' : '/modiapersonoversikt/',
     server: {
-        port: 3000
+        port: 3000,
+        proxy: {
+            '/proxy': {
+                target: 'https://modiapersonoversikt.intern.dev.nav.no',
+                changeOrigin: true,
+                headers: {
+                    Authorization: `Bearer ${process.env.LOCAL_TOKEN}`
+                }
+            }
+        }
     },
     plugins: [
         react(),


### PR DESCRIPTION
Dette gjør det mulig å sette en token fra [token generator](https://docs.nais.io/security/auth/azure-ad/usage/#token-generator) i env variablen `LOCAL_TOKEN`. Da vil requests til `/proxy` sendes til vite og proxies videre til proxien som kjører i dev (Q2) med tokenen. 

TLDR så vil man nå kunne utvikle frontenden lokalt mot hele dev-miljøet som kjører i gcp :)

