### PR TITLE
Landing page

### DIFF
--- a/.nais/prod.yaml
+++ b/.nais/prod.yaml
@@ -32,7 +32,7 @@ spec:
   ingresses:
     - https://app.adeo.no/modiapersonoversikt
     - https://modiapersonoversikt.intern.nav.no
-    - https://modiaflate.intern.nav.no
+    - https://modiaflate.intern.nav.no/landingpage
   replicas:
     min: 2
     max: 4

--- a/.nais/prod.yaml
+++ b/.nais/prod.yaml
@@ -32,6 +32,7 @@ spec:
   ingresses:
     - https://app.adeo.no/modiapersonoversikt
     - https://modiapersonoversikt.intern.nav.no
+    - https://modiaflate.intern.nav.no
   replicas:
     min: 2
     max: 4

--- a/.nais/qa-template.yaml
+++ b/.nais/qa-template.yaml
@@ -32,7 +32,7 @@ spec:
   ingresses:
     - https://app-{{ q_env }}.adeo.no/modiapersonoversikt
     - https://modiapersonoversikt-{{ q_env }}.intern.dev.nav.no
-    - https://modiaflate-{{ q_env }}.intern.dev.nav.no
+    - https://modiaflate-{{ q_env }}.intern.dev.nav.no/landingpage
   replicas:
     min: 2
     max: 4

--- a/.nais/qa-template.yaml
+++ b/.nais/qa-template.yaml
@@ -32,6 +32,7 @@ spec:
   ingresses:
     - https://app-{{ q_env }}.adeo.no/modiapersonoversikt
     - https://modiapersonoversikt-{{ q_env }}.intern.dev.nav.no
+    - https://modiaflate-{{ q_env }}.intern.dev.nav.no
   replicas:
     min: 2
     max: 4

--- a/src/app/AppContainer.tsx
+++ b/src/app/AppContainer.tsx
@@ -11,7 +11,7 @@ import { Provider } from 'react-redux';
 import LyttPaaFnrIURLOgSettIRedux from './PersonOppslagHandler/LyttPaaFnrIURLOgSettIRedux';
 import HentGlobaleVerdier from './FetchSessionInfoOgLeggIRedux';
 import GlobalStyling from './GlobalStyling';
-import Decorator, { LandingPage } from './internarbeidsflatedecorator/Decorator';
+import Decorator from './internarbeidsflatedecorator/Decorator';
 import Routing from './Routing';
 import styled from 'styled-components';
 import { useOnMount } from '../utils/customHooks';
@@ -46,6 +46,7 @@ import 'nav-frontend-etiketter-style';
 import { SentryRoute } from '../sentry-route';
 import { paths } from './routes/routing';
 import { Switch } from 'react-router';
+import { LandingPage } from './internarbeidsflatedecorator/LandingPage';
 
 const AppStyle = styled.div`
     height: 100vh;

--- a/src/app/AppContainer.tsx
+++ b/src/app/AppContainer.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import { applyMiddleware, createStore } from 'redux';
 import thunk from 'redux-thunk';
-import { BrowserRouter, HashRouter } from 'react-router-dom';
+import { BrowserRouter, HashRouter, Route } from 'react-router-dom';
 import reducers from '../redux/reducers';
 import ModalWrapper from 'nav-frontend-modal';
 import { composeWithDevTools } from 'redux-devtools-extension';
@@ -11,7 +11,7 @@ import { Provider } from 'react-redux';
 import LyttPaaFnrIURLOgSettIRedux from './PersonOppslagHandler/LyttPaaFnrIURLOgSettIRedux';
 import HentGlobaleVerdier from './FetchSessionInfoOgLeggIRedux';
 import GlobalStyling from './GlobalStyling';
-import Decorator from './internarbeidsflatedecorator/Decorator';
+import Decorator, { LandingPage } from './internarbeidsflatedecorator/Decorator';
 import Routing from './Routing';
 import styled from 'styled-components';
 import { useOnMount } from '../utils/customHooks';
@@ -27,7 +27,6 @@ import { initAmplitude } from '../utils/amplitude';
 
 import 'nav-frontend-lukknapp-style';
 import 'nav-frontend-lenker-style';
-import 'nav-frontend-lukknapp-style';
 import 'nav-frontend-popover-style';
 import 'nav-frontend-alertstriper-style';
 import 'nav-frontend-snakkeboble-style';
@@ -44,6 +43,9 @@ import 'nav-frontend-tabs-style';
 import 'nav-frontend-skjema-style';
 import 'nav-frontend-ekspanderbartpanel-style';
 import 'nav-frontend-etiketter-style';
+import { SentryRoute } from '../sentry-route';
+import { paths } from './routes/routing';
+import { Switch } from 'react-router';
 
 const AppStyle = styled.div`
     height: 100vh;
@@ -121,6 +123,7 @@ const queryClient = new QueryClient({
         }
     }
 });
+
 function AppContainer() {
     useOnMount(() => {
         ModalWrapper.setAppElement('#root');
@@ -133,10 +136,18 @@ function AppContainer() {
             <ValgtEnhetProvider>
                 <Provider store={store}>
                     <Router>
-                        <AppStyle>
-                            {!window.erChatvisning && <Decorator />}
-                            <App />
-                        </AppStyle>
+                        <Switch>
+                            <SentryRoute path={paths.landingPage}>
+                                <LandingPage />
+                            </SentryRoute>
+                            <Route>
+                                <AppStyle>
+                                    Hello
+                                    {!window.erChatvisning && <Decorator />}
+                                    <App />
+                                </AppStyle>
+                            </Route>
+                        </Switch>
                     </Router>
                 </Provider>
             </ValgtEnhetProvider>

--- a/src/app/internarbeidsflatedecorator/Decorator.tsx
+++ b/src/app/internarbeidsflatedecorator/Decorator.tsx
@@ -1,34 +1,16 @@
 import * as React from 'react';
-import { useCallback } from 'react';
 import NAVSPA from '@navikt/navspa';
-import { History } from 'history';
 import styled from 'styled-components/macro';
-import { DecoratorProps, DecoratorPropsV3, EnhetDisplay, FnrDisplay, Hotkey, RESET_VALUE } from './decoratorprops';
-import { fjernBrukerFraPath, paths, setNyBrukerIPath } from '../routes/routing';
-import { matchPath, useHistory } from 'react-router';
-import { useOnMount } from '../../utils/customHooks';
+import { DecoratorProps, DecoratorPropsV3 } from './decoratorprops';
 import PersonsokContainer from '../personsok/Personsok';
 import DecoratorEasterEgg from './EasterEggs/DecoratorEasterEgg';
-import { parseQueryString, useQueryParams } from '../../utils/url-utils';
-import useHandleGosysUrl from './useHandleGosysUrl';
-import { loggEvent } from '../../utils/logger/frontendLogger';
-import { removePrefix } from '../../utils/string-utils';
-import OppdateringsloggContainer, {
-    DecoratorButtonId as OppdateringsloggButtonId
-} from '../oppdateringslogg/OppdateringsloggContainer';
+import OppdateringsloggContainer from '../oppdateringslogg/OppdateringsloggContainer';
 import './personsokKnapp.less';
 import './decorator.less';
-import { useValgtenhet } from '../../context/valgtenhet-state';
-import { trackNavigation, updateUserEnhet } from '../../utils/amplitude';
-import { Enhet } from '../../rest/resources/saksbehandlersEnheterResource';
-
-import bjelleIkon from '../../svg/bjelle.svg?raw';
+import { useDecoratorConfig } from './useDecoratorConfig';
 
 const InternflateDecoratorV2 = NAVSPA.importer<DecoratorProps>('internarbeidsflatefs');
 const InternflateDecoratorV3 = NAVSPA.importer<DecoratorPropsV3>('internarbeidsflate-decorator-v3');
-const InternflateDecoratorV3LandingPage = NAVSPA.importer<DecoratorPropsV3>(
-    'internarbeidsflate-decorator-v3-fullscreen'
-);
 
 function Decorator() {
     const { configV2, configV3 } = useDecoratorConfig();
@@ -43,209 +25,6 @@ function Decorator() {
     );
 }
 
-export function LandingPage() {
-    const { configV3 } = useDecoratorConfig();
-
-    return <InternflateDecoratorV3LandingPage {...configV3} />;
-}
-
-function useDecoratorConfig() {
-    const valgtEnhet = useValgtenhet();
-    const valgtEnhetId = valgtEnhet.enhetId;
-    const setEnhetId = valgtEnhet.setEnhetId;
-
-    const history = useHistory();
-    const queryParams = useQueryParams<{ sokFnr?: string }>();
-
-    useHandleGosysUrl();
-
-    useOnMount(() => {
-        if (queryParams.sokFnr) {
-            loggEvent('Oppslag', 'Puzzle');
-        }
-    });
-
-    const handleSetEnhet = (enhet: string, enhetValue?: Enhet) => {
-        if (enhetValue) {
-            updateUserEnhet(enhetValue.navn);
-        }
-        setEnhetId(enhet);
-    };
-
-    const handleLinkClick = (link: { text: string; url: string }) => {
-        trackNavigation(link.text, link.url);
-    };
-
-    const configV2 = useCallback(lagConfig, [valgtEnhetId, history, handleSetEnhet])(
-        valgtEnhetId,
-        history,
-        handleSetEnhet
-    );
-
-    const configV3 = useCallback(lagConfigV3, [valgtEnhetId, history, handleSetEnhet, handleLinkClick])(
-        valgtEnhetId,
-        history,
-        handleSetEnhet,
-        handleLinkClick
-    );
-
-    return { configV2, configV3 };
-}
-
-const etterSokefelt = `
-        <div class="knapper_container">
-          <button class="personsok-button" id="toggle-personsok" aria-label="Åpne avansert søk" title="Åpne avansert søk">
-            <span> A <span class="personsok-pil"></span></span>
-          </button>
-          <button class="${OppdateringsloggButtonId}" id="${OppdateringsloggButtonId}" title="Åpne oppdateringslogg">
-            <div class="oppdateringslogg__ikon">
-              ${bjelleIkon}
-            </div>
-            <span class="oppdateringslogg__beskrivelse" aria-label="Åpne oppdateringslogg"></span>
-            <span class="oppdateringslogg__ulestindikator" aria-label="(Uleste)"></span>
-          </button>
-        </div>
-    `;
-
-const StyledNav = styled.nav`
-    .dekorator .dekorator__container {
-        max-width: initial;
-    }
-`;
-
-function lagConfig(
-    enhet: string | undefined | null,
-    history: History,
-    settEnhet: (enhet: string) => void
-): DecoratorProps {
-    const { sokFnr, pathFnr } = getFnrFraUrl();
-    const onsketFnr = sokFnr || pathFnr;
-    const fnrValue = onsketFnr === '0' ? RESET_VALUE : onsketFnr;
-    return {
-        appname: 'Modia personoversikt',
-        fnr: {
-            value: fnrValue,
-            display: FnrDisplay.SOKEFELT,
-            onChange(fnr: string | null): void {
-                if (fnr === getFnrFraUrl().pathFnr) {
-                    return;
-                }
-                if (fnr && fnr.length > 0) {
-                    setNyBrukerIPath(history, fnr);
-                } else {
-                    fjernBrukerFraPath(history);
-                }
-            }
-        },
-        enhet: {
-            initialValue: enhet || null,
-            display: EnhetDisplay.ENHET_VALG,
-            onChange(enhet: string | null): void {
-                if (enhet) {
-                    settEnhet(enhet);
-                }
-            }
-        },
-        toggles: {
-            visVeileder: true,
-            visHotkeys: true
-        },
-        markup: {
-            etterSokefelt: etterSokefelt
-        },
-        hotkeys: getHotkeys(),
-        // modiacontextholder kjører på samme domene som modiapersonoversikt.
-        // Som default brukes app.adeo.no, så her tvinger vi dekoratøren over på nytt domene
-        useProxy: `https://${window.location.host}${import.meta.env.BASE_URL}proxy`
-    };
-}
-
-function lagConfigV3(
-    enhet: string | undefined | null,
-    history: History,
-    settEnhet: (enhet: string, enhetValue?: Enhet) => void,
-    onLinkClick?: (link: { text: string; url: string }) => void
-): DecoratorPropsV3 {
-    const { sokFnr, pathFnr, userKey } = getFnrFraUrl();
-    const onsketFnr = sokFnr || pathFnr;
-    const getEnvFromHost = () => {
-        switch (window.location.host) {
-            case 'app.adeo.no':
-            case 'modiapersonoversikt.intern.nav.no':
-                return 'prod';
-            case 'app-q1.adeo.no':
-                return 'q1';
-            case 'app-q0.adeo.no':
-                return 'q0';
-            case 'modiapersonoversikt.intern.dev.nav.no':
-                return 'q2';
-        }
-        return 'mock';
-    };
-
-    const environment = import.meta.env.PROD ? getEnvFromHost() : 'mock';
-
-    return {
-        appName: 'Modia personoversikt',
-        fnr: onsketFnr ?? undefined,
-        userKey: userKey ?? pathFnr ?? undefined,
-        onFnrChanged: (fnr) => {
-            if (fnr === getFnrFraUrl().pathFnr) {
-                return;
-            }
-            if (fnr && fnr.length > 0) {
-                setNyBrukerIPath(history, fnr);
-            } else {
-                fjernBrukerFraPath(history);
-            }
-        },
-        enhet: enhet ?? undefined,
-        onEnhetChanged: (enhet, enhetValue) => {
-            if (enhet) {
-                settEnhet(enhet, enhetValue);
-            }
-        },
-        onLinkClick: onLinkClick ?? undefined,
-        showHotkeys: true,
-        markup: {
-            etterSokefelt: etterSokefelt
-        },
-        hotkeys: getHotkeys(),
-        // modiacontextholder kjører på samme domene som modiapersonoversikt.
-        // Som default brukes app.adeo.no, så her tvinger vi dekoratøren over på nytt domene
-        proxy: import.meta.env.PROD
-            ? `https://${window.location.host}${import.meta.env.BASE_URL}proxy`
-            : import.meta.env.VITE_CONTEXTHOLDER_URL ?? `${import.meta.env.BASE_URL}proxy`,
-        environment,
-        urlFormat: import.meta.env.PROD ? (window.location.host.includes('adeo.no') ? 'ADEO' : 'NAV_NO') : 'LOCAL',
-        showEnheter: true,
-        showSearchArea: true,
-        fetchActiveUserOnMount: true,
-        fetchActiveEnhetOnMount: true
-    };
-}
-
-function getPathnameFromUrl(): string {
-    const { pathname, hash } = window.location;
-    return removePrefix(pathname + hash, import.meta.env.BASE_URL, '/#', '#');
-}
-
-function getFnrFraUrl(): { sokFnr: string | null; pathFnr: string | null; userKey: string | null } {
-    const location = window.location;
-    const pathname = getPathnameFromUrl();
-
-    const queryParams = parseQueryString<{ sokFnr?: string; userKey?: string }>(location.search);
-    const sakerUriMatch = matchPath<{ fnr: string }>(pathname, `${paths.sakerFullscreen}/:fnr`);
-    const saksdokumentUriMatch = matchPath<{ fnr: string }>(pathname, `${paths.saksdokumentEgetVindu}/:fnr`);
-    const personUriMatch = matchPath<{ fnr: string }>(pathname, `${paths.personUri}/:fnr`);
-
-    return {
-        sokFnr: queryParams.sokFnr ?? null,
-        userKey: queryParams.userKey ?? null,
-        pathFnr: sakerUriMatch?.params.fnr ?? saksdokumentUriMatch?.params.fnr ?? personUriMatch?.params.fnr ?? null
-    };
-}
-
 const DecoratorToggle = ({ configV2, configV3 }: { configV2: DecoratorProps; configV3: DecoratorPropsV3 }) => {
     if (
         (typeof window.applicationFeatureToggles?.useNewDecorator === 'boolean' &&
@@ -257,75 +36,10 @@ const DecoratorToggle = ({ configV2, configV3 }: { configV2: DecoratorProps; con
     return <InternflateDecoratorV2 {...configV2} />;
 };
 
-function getHotkeys(): Hotkey[] {
-    /**
-     * TODO ønskelig å fjerne dobbelt-bokføring her og ved bruken av useHook
-     * hurtigtastene kan definere actions her om det er enkelt (litt avhengig av funksjon)
-     * Evt kan bruken av `useHotkey` hooken føre til at dette blir registrert i en global context som kan brukes her
-     */
-    const isProd = window.location.host === 'app.adeo.no';
-    const naisInternNavDomain = isProd ? '.intern.nav.no' : '.intern.dev.nav.no';
-    return [
-        {
-            key: { char: 'O', altKey: true },
-            description: 'Vis oversikt',
-            documentationOnly: true
-        },
-        {
-            key: { char: 'T', altKey: true },
-            description: 'Vis oppfølging',
-            documentationOnly: true
-        },
-        {
-            key: { char: 'M', altKey: true },
-            description: 'Vis meldinger',
-            documentationOnly: true
-        },
-        {
-            key: { char: 'U', altKey: true },
-            description: 'Vis utbetalinger',
-            documentationOnly: true
-        },
-        {
-            key: { char: 'S', altKey: true },
-            description: 'Vis saker',
-            documentationOnly: true
-        },
-        {
-            key: { char: 'Y', altKey: true },
-            description: 'Vis ytelser',
-            documentationOnly: true
-        },
-        {
-            key: { char: 'V', altKey: true },
-            description: 'Vis varsler',
-            documentationOnly: true
-        },
-        {
-            key: { char: 'N', altKey: true },
-            description: 'Åpne/lukke visitkort',
-            documentationOnly: true
-        },
-        {
-            key: { char: 'B', altKey: true },
-            description: 'Gå til personforvalter',
-            documentationOnly: true
-        },
-        {
-            key: { char: 'C', altKey: true },
-            description: 'Åpne samtalemaler',
-            documentationOnly: true
-        },
-        {
-            key: { char: 'D', altKey: true },
-            description: 'Gå til modia sosialhjelp',
-            action(event: KeyboardEvent) {
-                event.preventDefault();
-                const url = `https://sosialhjelp-modia${naisInternNavDomain}/sosialhjelp/modia/`;
-                window.open(url, '_blank');
-            }
-        }
-    ];
-}
+const StyledNav = styled.nav`
+    .dekorator .dekorator__container {
+        max-width: initial;
+    }
+`;
 
 export default Decorator;

--- a/src/app/internarbeidsflatedecorator/Decorator.tsx
+++ b/src/app/internarbeidsflatedecorator/Decorator.tsx
@@ -26,6 +26,71 @@ import bjelleIkon from '../../svg/bjelle.svg?raw';
 
 const InternflateDecoratorV2 = NAVSPA.importer<DecoratorProps>('internarbeidsflatefs');
 const InternflateDecoratorV3 = NAVSPA.importer<DecoratorPropsV3>('internarbeidsflate-decorator-v3');
+const InternflateDecoratorV3LandingPage = NAVSPA.importer<DecoratorPropsV3>(
+    'internarbeidsflate-decorator-v3-fullscreen'
+);
+
+function Decorator() {
+    const { configV2, configV3 } = useDecoratorConfig();
+
+    return (
+        <StyledNav>
+            <DecoratorToggle configV2={configV2} configV3={configV3} />
+            <PersonsokContainer />
+            <OppdateringsloggContainer />
+            <DecoratorEasterEgg />
+        </StyledNav>
+    );
+}
+
+export function LandingPage() {
+    const { configV3 } = useDecoratorConfig();
+
+    return <InternflateDecoratorV3LandingPage {...configV3} />;
+}
+
+function useDecoratorConfig() {
+    const valgtEnhet = useValgtenhet();
+    const valgtEnhetId = valgtEnhet.enhetId;
+    const setEnhetId = valgtEnhet.setEnhetId;
+
+    const history = useHistory();
+    const queryParams = useQueryParams<{ sokFnr?: string }>();
+
+    useHandleGosysUrl();
+
+    useOnMount(() => {
+        if (queryParams.sokFnr) {
+            loggEvent('Oppslag', 'Puzzle');
+        }
+    });
+
+    const handleSetEnhet = (enhet: string, enhetValue?: Enhet) => {
+        if (enhetValue) {
+            updateUserEnhet(enhetValue.navn);
+        }
+        setEnhetId(enhet);
+    };
+
+    const handleLinkClick = (link: { text: string; url: string }) => {
+        trackNavigation(link.text, link.url);
+    };
+
+    const configV2 = useCallback(lagConfig, [valgtEnhetId, history, handleSetEnhet])(
+        valgtEnhetId,
+        history,
+        handleSetEnhet
+    );
+
+    const configV3 = useCallback(lagConfigV3, [valgtEnhetId, history, handleSetEnhet, handleLinkClick])(
+        valgtEnhetId,
+        history,
+        handleSetEnhet,
+        handleLinkClick
+    );
+
+    return { configV2, configV3 };
+}
 
 const etterSokefelt = `
         <div class="knapper_container">
@@ -261,56 +326,6 @@ function getHotkeys(): Hotkey[] {
             }
         }
     ];
-}
-
-function Decorator() {
-    const valgtEnhet = useValgtenhet();
-    const valgtEnhetId = valgtEnhet.enhetId;
-    const setEnhetId = valgtEnhet.setEnhetId;
-
-    const history = useHistory();
-    const queryParams = useQueryParams<{ sokFnr?: string }>();
-
-    useHandleGosysUrl();
-
-    useOnMount(() => {
-        if (queryParams.sokFnr) {
-            loggEvent('Oppslag', 'Puzzle');
-        }
-    });
-
-    const handleSetEnhet = (enhet: string, enhetValue?: Enhet) => {
-        if (enhetValue) {
-            updateUserEnhet(enhetValue.navn);
-        }
-        setEnhetId(enhet);
-    };
-
-    const handleLinkClick = (link: { text: string; url: string }) => {
-        trackNavigation(link.text, link.url);
-    };
-
-    const configV2 = useCallback(lagConfig, [valgtEnhetId, history, handleSetEnhet])(
-        valgtEnhetId,
-        history,
-        handleSetEnhet
-    );
-
-    const configV3 = useCallback(lagConfigV3, [valgtEnhetId, history, handleSetEnhet, handleLinkClick])(
-        valgtEnhetId,
-        history,
-        handleSetEnhet,
-        handleLinkClick
-    );
-
-    return (
-        <StyledNav>
-            <DecoratorToggle configV2={configV2} configV3={configV3} />
-            <PersonsokContainer />
-            <OppdateringsloggContainer />
-            <DecoratorEasterEgg />
-        </StyledNav>
-    );
 }
 
 export default Decorator;

--- a/src/app/internarbeidsflatedecorator/LandingPage.tsx
+++ b/src/app/internarbeidsflatedecorator/LandingPage.tsx
@@ -1,0 +1,15 @@
+import NAVSPA from '@navikt/navspa';
+import { DecoratorPropsV3 } from './decoratorprops';
+import * as React from 'react';
+
+import { useDecoratorConfig } from './useDecoratorConfig';
+
+const InternflateDecoratorV3LandingPage = NAVSPA.importer<DecoratorPropsV3>(
+    'internarbeidsflate-decorator-v3-fullscreen'
+);
+
+export function LandingPage() {
+    const { configV3 } = useDecoratorConfig();
+
+    return <InternflateDecoratorV3LandingPage {...configV3} />;
+}

--- a/src/app/internarbeidsflatedecorator/useDecoratorConfig.tsx
+++ b/src/app/internarbeidsflatedecorator/useDecoratorConfig.tsx
@@ -1,0 +1,277 @@
+import { DecoratorButtonId as OppdateringsloggButtonId } from '../oppdateringslogg/OppdateringsloggContainer';
+import bjelleIkon from '../../svg/bjelle.svg';
+import { parseQueryString, useQueryParams } from '../../utils/url-utils';
+import { matchPath, useHistory } from 'react-router';
+import { fjernBrukerFraPath, paths, setNyBrukerIPath } from '../routes/routing';
+import { useValgtenhet } from '../../context/valgtenhet-state';
+import useHandleGosysUrl from './useHandleGosysUrl';
+import { useOnMount } from '../../utils/customHooks';
+import { loggEvent } from '../../utils/logger/frontendLogger';
+import { Enhet } from '../../rest/resources/saksbehandlersEnheterResource';
+import { trackNavigation, updateUserEnhet } from '../../utils/amplitude';
+import { useCallback } from 'react';
+import { History } from 'history';
+import { DecoratorProps, DecoratorPropsV3, EnhetDisplay, FnrDisplay, Hotkey, RESET_VALUE } from './decoratorprops';
+import { removePrefix } from '../../utils/string-utils';
+
+export function useDecoratorConfig() {
+    const valgtEnhet = useValgtenhet();
+    const valgtEnhetId = valgtEnhet.enhetId;
+    const setEnhetId = valgtEnhet.setEnhetId;
+
+    const history = useHistory();
+    const queryParams = useQueryParams<{ sokFnr?: string }>();
+
+    useHandleGosysUrl();
+
+    useOnMount(() => {
+        if (queryParams.sokFnr) {
+            loggEvent('Oppslag', 'Puzzle');
+        }
+    });
+
+    const handleSetEnhet = (enhet: string, enhetValue?: Enhet) => {
+        if (enhetValue) {
+            updateUserEnhet(enhetValue.navn);
+        }
+        setEnhetId(enhet);
+    };
+
+    const handleLinkClick = (link: { text: string; url: string }) => {
+        trackNavigation(link.text, link.url);
+    };
+
+    const configV2 = useCallback(lagConfig, [valgtEnhetId, history, handleSetEnhet])(
+        valgtEnhetId,
+        history,
+        handleSetEnhet
+    );
+
+    const configV3 = useCallback(lagConfigV3, [valgtEnhetId, history, handleSetEnhet, handleLinkClick])(
+        valgtEnhetId,
+        history,
+        handleSetEnhet,
+        handleLinkClick
+    );
+
+    return { configV2, configV3 };
+}
+
+const etterSokefelt = `
+        <div class="knapper_container">
+          <button class="personsok-button" id="toggle-personsok" aria-label="Åpne avansert søk" title="Åpne avansert søk">
+            <span> A <span class="personsok-pil"></span></span>
+          </button>
+          <button class="${OppdateringsloggButtonId}" id="${OppdateringsloggButtonId}" title="Åpne oppdateringslogg">
+            <div class="oppdateringslogg__ikon">
+              ${bjelleIkon}
+            </div>
+            <span class="oppdateringslogg__beskrivelse" aria-label="Åpne oppdateringslogg"></span>
+            <span class="oppdateringslogg__ulestindikator" aria-label="(Uleste)"></span>
+          </button>
+        </div>
+    `;
+
+function lagConfig(
+    enhet: string | undefined | null,
+    history: History,
+    settEnhet: (enhet: string) => void
+): DecoratorProps {
+    const { sokFnr, pathFnr } = getFnrFraUrl();
+    const onsketFnr = sokFnr || pathFnr;
+    const fnrValue = onsketFnr === '0' ? RESET_VALUE : onsketFnr;
+    return {
+        appname: 'Modia personoversikt',
+        fnr: {
+            value: fnrValue,
+            display: FnrDisplay.SOKEFELT,
+            onChange(fnr: string | null): void {
+                if (fnr === getFnrFraUrl().pathFnr) {
+                    return;
+                }
+                if (fnr && fnr.length > 0) {
+                    setNyBrukerIPath(history, fnr);
+                } else {
+                    fjernBrukerFraPath(history);
+                }
+            }
+        },
+        enhet: {
+            initialValue: enhet || null,
+            display: EnhetDisplay.ENHET_VALG,
+            onChange(enhet: string | null): void {
+                if (enhet) {
+                    settEnhet(enhet);
+                }
+            }
+        },
+        toggles: {
+            visVeileder: true,
+            visHotkeys: true
+        },
+        markup: {
+            etterSokefelt: etterSokefelt
+        },
+        hotkeys: getHotkeys(),
+        // modiacontextholder kjører på samme domene som modiapersonoversikt.
+        // Som default brukes app.adeo.no, så her tvinger vi dekoratøren over på nytt domene
+        useProxy: `https://${window.location.host}${import.meta.env.BASE_URL}proxy`
+    };
+}
+
+function lagConfigV3(
+    enhet: string | undefined | null,
+    history: History,
+    settEnhet: (enhet: string, enhetValue?: Enhet) => void,
+    onLinkClick?: (link: { text: string; url: string }) => void
+): DecoratorPropsV3 {
+    const { sokFnr, pathFnr, userKey } = getFnrFraUrl();
+    const onsketFnr = sokFnr || pathFnr;
+    const getEnvFromHost = () => {
+        switch (window.location.host) {
+            case 'app.adeo.no':
+            case 'modiapersonoversikt.intern.nav.no':
+                return 'prod';
+            case 'app-q1.adeo.no':
+                return 'q1';
+            case 'app-q0.adeo.no':
+                return 'q0';
+            case 'modiapersonoversikt.intern.dev.nav.no':
+                return 'q2';
+        }
+        return 'mock';
+    };
+
+    const environment = import.meta.env.PROD ? getEnvFromHost() : 'mock';
+
+    return {
+        appName: 'Modia personoversikt',
+        fnr: onsketFnr ?? undefined,
+        userKey: userKey ?? pathFnr ?? undefined,
+        onFnrChanged: (fnr) => {
+            if (fnr === getFnrFraUrl().pathFnr) {
+                return;
+            }
+            if (fnr && fnr.length > 0) {
+                setNyBrukerIPath(history, fnr);
+            } else {
+                fjernBrukerFraPath(history);
+            }
+        },
+        enhet: enhet ?? undefined,
+        onEnhetChanged: (enhet, enhetValue) => {
+            if (enhet) {
+                settEnhet(enhet, enhetValue);
+            }
+        },
+        onLinkClick: onLinkClick ?? undefined,
+        showHotkeys: true,
+        markup: {
+            etterSokefelt: etterSokefelt
+        },
+        hotkeys: getHotkeys(),
+        // modiacontextholder kjører på samme domene som modiapersonoversikt.
+        // Som default brukes app.adeo.no, så her tvinger vi dekoratøren over på nytt domene
+        proxy: import.meta.env.PROD
+            ? `https://${window.location.host}${import.meta.env.BASE_URL}proxy`
+            : import.meta.env.VITE_CONTEXTHOLDER_URL ?? `${import.meta.env.BASE_URL}proxy`,
+        environment,
+        urlFormat: import.meta.env.PROD ? (window.location.host.includes('adeo.no') ? 'ADEO' : 'NAV_NO') : 'LOCAL',
+        showEnheter: true,
+        showSearchArea: true,
+        fetchActiveUserOnMount: true,
+        fetchActiveEnhetOnMount: true
+    };
+}
+
+function getPathnameFromUrl(): string {
+    const { pathname, hash } = window.location;
+    return removePrefix(pathname + hash, import.meta.env.BASE_URL, '/#', '#');
+}
+
+function getFnrFraUrl(): { sokFnr: string | null; pathFnr: string | null; userKey: string | null } {
+    const location = window.location;
+    const pathname = getPathnameFromUrl();
+
+    const queryParams = parseQueryString<{ sokFnr?: string; userKey?: string }>(location.search);
+    const sakerUriMatch = matchPath<{ fnr: string }>(pathname, `${paths.sakerFullscreen}/:fnr`);
+    const saksdokumentUriMatch = matchPath<{ fnr: string }>(pathname, `${paths.saksdokumentEgetVindu}/:fnr`);
+    const personUriMatch = matchPath<{ fnr: string }>(pathname, `${paths.personUri}/:fnr`);
+
+    return {
+        sokFnr: queryParams.sokFnr ?? null,
+        userKey: queryParams.userKey ?? null,
+        pathFnr: sakerUriMatch?.params.fnr ?? saksdokumentUriMatch?.params.fnr ?? personUriMatch?.params.fnr ?? null
+    };
+}
+
+function getHotkeys(): Hotkey[] {
+    /**
+     * TODO ønskelig å fjerne dobbelt-bokføring her og ved bruken av useHook
+     * hurtigtastene kan definere actions her om det er enkelt (litt avhengig av funksjon)
+     * Evt kan bruken av `useHotkey` hooken føre til at dette blir registrert i en global context som kan brukes her
+     */
+    const isProd = window.location.host === 'app.adeo.no';
+    const naisInternNavDomain = isProd ? '.intern.nav.no' : '.intern.dev.nav.no';
+    return [
+        {
+            key: { char: 'O', altKey: true },
+            description: 'Vis oversikt',
+            documentationOnly: true
+        },
+        {
+            key: { char: 'T', altKey: true },
+            description: 'Vis oppfølging',
+            documentationOnly: true
+        },
+        {
+            key: { char: 'M', altKey: true },
+            description: 'Vis meldinger',
+            documentationOnly: true
+        },
+        {
+            key: { char: 'U', altKey: true },
+            description: 'Vis utbetalinger',
+            documentationOnly: true
+        },
+        {
+            key: { char: 'S', altKey: true },
+            description: 'Vis saker',
+            documentationOnly: true
+        },
+        {
+            key: { char: 'Y', altKey: true },
+            description: 'Vis ytelser',
+            documentationOnly: true
+        },
+        {
+            key: { char: 'V', altKey: true },
+            description: 'Vis varsler',
+            documentationOnly: true
+        },
+        {
+            key: { char: 'N', altKey: true },
+            description: 'Åpne/lukke visitkort',
+            documentationOnly: true
+        },
+        {
+            key: { char: 'B', altKey: true },
+            description: 'Gå til personforvalter',
+            documentationOnly: true
+        },
+        {
+            key: { char: 'C', altKey: true },
+            description: 'Åpne samtalemaler',
+            documentationOnly: true
+        },
+        {
+            key: { char: 'D', altKey: true },
+            description: 'Gå til modia sosialhjelp',
+            action(event: KeyboardEvent) {
+                event.preventDefault();
+                const url = `https://sosialhjelp-modia${naisInternNavDomain}/sosialhjelp/modia/`;
+                window.open(url, '_blank');
+            }
+        }
+    ];
+}

--- a/src/app/routes/routing.tsx
+++ b/src/app/routes/routing.tsx
@@ -9,7 +9,8 @@ export const paths = {
     saksdokumentEgetVindu: `/dokument`,
     brukerprofil: '/brukerprofil',
     basePath: '',
-    standaloneKomponenter: '/components'
+    standaloneKomponenter: '/components',
+    landingPage: '/landingpage'
 };
 
 export function usePaths() {


### PR DESCRIPTION
Tanken her er at vi kan endre URLen som Modia-ikonet i Applikasjonsportalen peker på til den nye ingressen `https://modiaflate.intern.nav.no/landingpage`.

Vi kan også putte en redirect på den gamle URLen om det er slik at folk bruker den gamle URLen direkte.

Har ikke prøvd å opprette Ingress med en spesifikk path før, men det skal vist [være mulig](https://doc.nav.cloud.nais.io/workloads/application/how-to/expose/).

Stopp meg om jeg er på bærtur 🙏 