### PR TITLE
Fikse gosys URL handler & tab routing med fnr

### DIFF
--- a/src/app/internarbeidsflatedecorator/useDecoratorConfig.tsx
+++ b/src/app/internarbeidsflatedecorator/useDecoratorConfig.tsx
@@ -76,7 +76,7 @@ function lagConfig(
 ): DecoratorProps {
     const { sokFnr } = getFnrFraUrl();
     const fnr = useGjeldendeBruker();
-    const onsketFnr = fnr ?? sokFnr;
+    const onsketFnr = sokFnr ?? fnr;
     const fnrValue = onsketFnr === '0' ? RESET_VALUE : onsketFnr;
     return {
         appname: 'Modia personoversikt',

--- a/src/app/internarbeidsflatedecorator/useHandleGosysUrl.ts
+++ b/src/app/internarbeidsflatedecorator/useHandleGosysUrl.ts
@@ -1,28 +1,32 @@
 import { useQueryParams } from '../../utils/url-utils';
-import { useOnMount } from '../../utils/customHooks';
+import { useOnMount, useSettAktivBruker } from '../../utils/customHooks';
 import { loggEvent } from '../../utils/logger/frontendLogger';
-import { useHistory } from 'react-router';
 import { INFOTABS } from '../personside/infotabs/InfoTabEnum';
 import { paths } from '../routes/routing';
 import { Oppgave } from '../../models/meldinger/oppgave';
 import { apiBaseUri } from '../../api/config';
 import { fetchToJson, hasData } from '../../utils/fetchToJson';
+import { useDispatch } from 'react-redux';
+import { replace } from 'connected-react-router';
 
 function useHandleGosysUrl() {
     const queryParams = useQueryParams<{ sokFnr?: string; oppgaveid?: string; behandlingsid?: string }>();
-    const history = useHistory();
+    const dispatch = useDispatch();
+    const settGjeldendeBruker = useSettAktivBruker();
 
     useOnMount(() => {
-        const linkTilValgtHenvendelse = `${paths.personUri}/${queryParams.sokFnr}/${INFOTABS.MELDINGER.path}?traadId=${queryParams.behandlingsid}`;
+        const linkTilValgtHenvendelse = `${paths.personUri}/${INFOTABS.MELDINGER.path}?traadId=${queryParams.behandlingsid}`;
 
         if (queryParams.oppgaveid && queryParams.behandlingsid && queryParams.sokFnr) {
             fetchToJson<Oppgave>(`${apiBaseUri}/v2/oppgaver/oppgavedata/${queryParams.oppgaveid}`).then((response) => {
                 loggEvent('Oppgave', 'FraGosys', { success: hasData(response) });
-                history.replace(linkTilValgtHenvendelse);
+                settGjeldendeBruker(queryParams.sokFnr as string);
+                dispatch(replace(linkTilValgtHenvendelse));
             });
         } else if (queryParams.sokFnr && queryParams.behandlingsid) {
             loggEvent('Henvendelse', 'FraGosys');
-            history.replace(linkTilValgtHenvendelse);
+            settGjeldendeBruker(queryParams.sokFnr as string);
+            dispatch(replace(linkTilValgtHenvendelse));
         }
     });
 }

--- a/src/redux/gjeldendeBruker/reducer.ts
+++ b/src/redux/gjeldendeBruker/reducer.ts
@@ -9,7 +9,8 @@ function gjeldendeBrukerReducer(state: GjeldendeBrukerState = initialState, acti
         case SetNyGjeldendeBrukerActionTypes.SetNyPerson:
             return {
                 ...state,
-                fødselsnummer: action.fnr
+                fødselsnummer: action.fnr,
+                hasLoaded: true
             };
         default:
             return state;

--- a/src/redux/gjeldendeBruker/types.ts
+++ b/src/redux/gjeldendeBruker/types.ts
@@ -4,6 +4,7 @@ import { useSelector } from 'react-redux';
 
 export interface GjeldendeBrukerState {
     fødselsnummer: string;
+    hasLoaded?: boolean;
 }
 
 export enum SetNyGjeldendeBrukerActionTypes {
@@ -18,4 +19,8 @@ export type GjeldendeBrukerActions = SetNyGjeldendeBrukerAction;
 
 export function useGjeldendeBruker(): string {
     return useSelector((state: AppState) => state.gjeldendeBruker.fødselsnummer);
+}
+
+export function useGjeldendeBrukerLastet(): boolean {
+    return useSelector((state: AppState) => !!state.gjeldendeBruker.hasLoaded);
 }


### PR DESCRIPTION
Et par ting som skjer her:


### Fikse tab routing med fnr i path

Hvis man lenket til f.eks `/person/:fnr/saker`, så ville ikke fnr være i redux med en gang, og
`useEffect`en i Personoversikt komponenten ville route tilbake til hovedsiden, før redux er
oppdatert og man sendes tilbake med et gyldig fnr. Altså mister man `/sake` urlEn. Nå setter vi en
state på om fnr er "klart" i redux, med en timeout, slik at vi venter med å kjøre validation til fnr
er satt i redux.


### Fikse gosys URL handler

Denne ble glemt i routing/fnr-i-url endringene og gjorde at ting ikke skjedde i riktig rekkefølge,
ettersom den redirectet til "riktig" url en render-sykel for sent, og da hadde contexten lastet inn
forrige person og satt denne i redux før gosys-url handleren rakk å gjøre det.

Nå setter vi fnr i redux, dispatcher route replacement med en gang slik at ting skjer i riktig
rekkefølge og redux staten er oppdatert med riktig fnr før dekoratøren og contexten laster inn.

