### PR TITLE
Fikse rar styling på avansert søk knapp

### DIFF
--- a/src/app/internarbeidsflatedecorator/personsokKnapp.less
+++ b/src/app/internarbeidsflatedecorator/personsokKnapp.less
@@ -9,6 +9,7 @@
     font-size: 1.2em;
     padding: 0;
     margin-right: 0.5em;
+    background-color: white;
 
     span {
         color: @navMorkGra;
@@ -17,16 +18,17 @@
         border-radius: 40px;
         text-align: center;
         vertical-align: middle;
-        background-color: #fff;
         display: inline-block;
-        padding-top: 9px;
+        padding-top: 6px;
         pointer-events: none;
     }
-    &:hover span {
+    &:hover {
         background-color: @navBlaDarken20;
         outline: none;
-        color: white;
         cursor: pointer;
+        span {
+            color: white;
+        }
     }
 
     &:focus {
@@ -34,21 +36,5 @@
         box-shadow: 0 0 0 3px #ffbd66;
     }
     &:active {
-        .personsok-pil {
-            border-top: none;
-            border-left: 7px solid transparent;
-            border-right: 7px solid transparent;
-            border-bottom: 7px solid currentColor;
-        }
-    }
-    .personsok-pil {
-        display: block;
-        width: 0;
-        height: 0;
-        padding: 0;
-        margin: 0 auto;
-        border-left: 7px solid transparent;
-        border-right: 7px solid transparent;
-        border-top: 7px solid currentColor;
     }
 }

--- a/src/app/internarbeidsflatedecorator/useDecoratorConfig.tsx
+++ b/src/app/internarbeidsflatedecorator/useDecoratorConfig.tsx
@@ -52,7 +52,7 @@ export function useDecoratorConfig() {
 const etterSokefelt = `
         <div class="knapper_container">
           <button class="personsok-button" id="toggle-personsok" aria-label="Åpne avansert søk" title="Åpne avansert søk">
-            <span> A <span class="personsok-pil"></span></span>
+            <span> A </span>
           </button>
           <button class="${OppdateringsloggButtonId}" id="${OppdateringsloggButtonId}" title="Åpne oppdateringslogg">
             <div class="oppdateringslogg__ikon">


### PR DESCRIPTION
Noe rart som har skjedd med stylingen til pilen under avansert søk knappen i dekoratøren. Jeg tenkte det var like greit å bare fjerne den ettersom den så litt out of place ut.

Før:
![image](https://github.com/navikt/modiapersonoversikt/assets/42850232/bcce280b-f217-4d66-9a13-eb9aef127b9e)

Etter:
![image](https://github.com/navikt/modiapersonoversikt/assets/42850232/571ea8e7-bc65-430f-bdef-f7a3bcaab592)
