### PR TITLE
Sikre at personnummer er lastet inn før bruk

### DIFF
--- a/src/app/personside/Personoversikt.tsx
+++ b/src/app/personside/Personoversikt.tsx
@@ -12,6 +12,7 @@ import NyIdentModal from './NyIdentModal';
 import { useGjeldendeBrukerLastet } from '../../redux/gjeldendeBruker/types';
 import { CenteredLazySpinner } from '../../components/LazySpinner';
 import useTimeout from '../../utils/hooks/use-timeout';
+import VentPaaPersonLastet from '../../components/VentPaaPersonLastet';
 
 function Personoversikt({ fnr }: { fnr: string }) {
     const [loadTimeout, setLoadTimeout] = useState(false);
@@ -48,4 +49,10 @@ function Personoversikt({ fnr }: { fnr: string }) {
     });
 }
 
-export default Personoversikt;
+const PersonoversiktWrapper = ({ fnr }: { fnr: string }) => (
+    <VentPaaPersonLastet fnr={fnr}>
+        <Personoversikt fnr={fnr} />
+    </VentPaaPersonLastet>
+);
+
+export default PersonoversiktWrapper;

--- a/src/app/personside/infotabs/saksoversikt/SaksDokumentIEgetVindu.tsx
+++ b/src/app/personside/infotabs/saksoversikt/SaksDokumentIEgetVindu.tsx
@@ -5,8 +5,8 @@ import DokumentVisning from './dokumentvisning/SaksDokumentVisning';
 import { useQueryParams } from '../../../../utils/url-utils';
 import { AlertStripeFeil } from 'nav-frontend-alertstriper';
 import styled from 'styled-components';
-import SetFnrIRedux from '../../../PersonOppslagHandler/SetFnrIRedux';
 import { getSaksdokumentUrl } from './dokumentvisning/getSaksdokumentUrl';
+import VentPaaPersonLastet from '../../../../components/VentPaaPersonLastet';
 
 interface Props {
     fnr: string;
@@ -37,11 +37,12 @@ function SaksDokumentEgetVindu(props: Props) {
     }
     return (
         <>
-            <SetFnrIRedux fnr={props.fnr} />
-            <DokumentVisning
-                fnr={props.fnr}
-                url={getSaksdokumentUrl(props.fnr, queryParams.journalpost ?? null, queryParams.dokument)}
-            />
+            <VentPaaPersonLastet fnr={props.fnr}>
+                <DokumentVisning
+                    fnr={props.fnr}
+                    url={getSaksdokumentUrl(props.fnr, queryParams.journalpost ?? null, queryParams.dokument)}
+                />
+            </VentPaaPersonLastet>
         </>
     );
 }

--- a/src/components/VentPaaPersonLastet.tsx
+++ b/src/components/VentPaaPersonLastet.tsx
@@ -1,0 +1,37 @@
+import React, { PropsWithChildren, useEffect, useState } from 'react';
+import { useHistory } from 'react-router';
+import { useGjeldendeBrukerLastet } from '../redux/gjeldendeBruker/types';
+import useTimeout from '../utils/hooks/use-timeout';
+import { erGyldigishFnr } from '../utils/fnr-utils';
+import { loggInfo } from '../utils/logger/frontendLogger';
+import { paths } from '../app/routes/routing';
+import { CenteredLazySpinner } from './LazySpinner';
+
+type Props = {
+    fnr: string;
+};
+
+// Timeout 1 sekund for å laste fra context
+const TIMEOUT_MILLIS = 1000;
+
+const VentPaaPersonLastet = ({ fnr, children }: PropsWithChildren<Props>) => {
+    const [loadTimeout, setLoadTimeout] = useState(false);
+    const history = useHistory();
+    const gjeldendeBrukerHasLoaded = useGjeldendeBrukerLastet();
+    useTimeout(() => setLoadTimeout(true), TIMEOUT_MILLIS);
+
+    useEffect(() => {
+        if (!erGyldigishFnr(fnr) && (gjeldendeBrukerHasLoaded || loadTimeout)) {
+            loggInfo('Ugyldig fnr, redirecter til startside');
+            history.push(`${paths.basePath}`);
+        }
+    }, [fnr, gjeldendeBrukerHasLoaded, loadTimeout]);
+
+    if (!gjeldendeBrukerHasLoaded) {
+        return <CenteredLazySpinner />;
+    }
+
+    return <>{children}</>;
+};
+
+export default VentPaaPersonLastet;


### PR DESCRIPTION
Fikser en bug der åpning av dokumentsiden prøvde å laste inn dokumenter
for bruker før fnr var satt, noe som propagerer dårlige requests rundt
omkring i verdikjeden.
