### PR TITLE
Skaler ned ressursbruk

### DIFF
--- a/.nais/dev.yaml
+++ b/.nais/dev.yaml
@@ -27,19 +27,18 @@ spec:
     enabled: true
   resources:
     requests:
-      cpu: 200m
-      memory: 512Mi
+      cpu: 5m
+      memory: 200Mi
     limits:
-      cpu: 3000m
-      memory: 1536Mi
+      memory: 2048Mi
   ingresses:
     - https://modiapersonoversikt.intern.dev.nav.no
     - https://modiapersonoversikt.ansatt.dev.nav.no
     - https://modiaflate.intern.dev.nav.no
   replicas:
-    min: 2
-    max: 4
-    cpuThresholdPercentage: 60
+    min: 1
+    max: 2
+    cpuThresholdPercentage: 200
   azure:
     application:
       enabled: true

--- a/.nais/prod.yaml
+++ b/.nais/prod.yaml
@@ -28,9 +28,9 @@ spec:
   resources:
     requests:
       cpu: 100m
-      memory: 4096Mi
+      memory: 400Mi
     limits:
-      memory: 6144Mi
+      memory: 2048Mi
   ingresses:
     - https://modiapersonoversikt.intern.nav.no
     - https://modiaflate.intern.nav.no
@@ -39,7 +39,7 @@ spec:
     max: 6
     scalingStrategy:
       cpu:
-        thresholdPercentage: 50
+        thresholdPercentage: 100
   azure:
     application:
       enabled: true


### PR DESCRIPTION
Personoversikt i prod er veldig CPU-bound og varierer fra 5m CPU til 300m CPU i peak business hours, så beholder litt juice på den så den blir prioritert under load.