### PR TITLE
Fjerne /rest fra proxy url til API

### DIFF
--- a/proxy-config-dev.json
+++ b/proxy-config-dev.json
@@ -1,23 +1,23 @@
 {
     "proxy": {
         "modia-skrivestotte": {
-            "url": "http://modiapersonoversikt-skrivestotte.personoversikt.svc.cluster.local",
+            "url": "http://modiapersonoversikt-skrivestotte",
             "scope": "api://dev-gcp.personoversikt.modiapersonoversikt-skrivestotte/.default"
         },
         "modia-draft": {
-            "url": "http://modiapersonoversikt-draft.personoversikt.svc.cluster.local",
+            "url": "http://modiapersonoversikt-draft",
             "scope": "api://dev-gcp.personoversikt.modiapersonoversikt-draft/.default"
         },
         "modia-innstillinger": {
-            "url": "http://modiapersonoversikt-innstillinger.personoversikt.svc.cluster.local",
+            "url": "http://modiapersonoversikt-innstillinger",
             "scope": "api://dev-gcp.personoversikt.modiapersonoversikt-innstillinger/.default"
         },
         "modiacontextholder": {
-            "url": "http://modiacontextholder.personoversikt.svc.cluster.local",
+            "url": "http://modiacontextholder",
             "scope": "api://dev-gcp.personoversikt.modiacontextholder/.default"
         },
         "azure-api": {
-            "url": "http://modiapersonoversikt-api.personoversikt.svc.cluster.local/modiapersonoversikt-api/rest",
+            "url": "http://modiapersonoversikt-api/modiapersonoversikt-api",
             "scope": "api://dev-gcp.personoversikt.modiapersonoversikt-api/.default"
         }
     },

--- a/proxy-config-prod.json
+++ b/proxy-config-prod.json
@@ -1,23 +1,23 @@
 {
     "proxy": {
         "modia-skrivestotte": {
-            "url": "http://modiapersonoversikt-skrivestotte.personoversikt.svc.cluster.local",
+            "url": "http://modiapersonoversikt-skrivestotte",
             "scope": "api://prod-gcp.personoversikt.modiapersonoversikt-skrivestotte/.default"
         },
         "modia-draft": {
-            "url": "http://modiapersonoversikt-draft.personoversikt.svc.cluster.local",
+            "url": "http://modiapersonoversikt-draft",
             "scope": "api://prod-gcp.personoversikt.modiapersonoversikt-draft/.default"
         },
         "modia-innstillinger": {
-            "url": "http://modiapersonoversikt-innstillinger.personoversikt.svc.cluster.local",
+            "url": "http://modiapersonoversikt-innstillinger",
             "scope": "api://prod-gcp.personoversikt.modiapersonoversikt-innstillinger/.default"
         },
         "modiacontextholder": {
-            "url": "http://modiacontextholder.personoversikt.svc.cluster.local",
+            "url": "http://modiacontextholder",
             "scope": "api://prod-gcp.personoversikt.modiacontextholder/.default"
         },
         "azure-api": {
-            "url": "http://modiapersonoversikt-api.personoversikt.svc.cluster.local/modiapersonoversikt-api/rest",
+            "url": "http://modiapersonoversikt-api/modiapersonoversikt-api",
             "scope": "api://prod-gcp.personoversikt.modiapersonoversikt-api/.default"
         }
     },

--- a/src/api/config.ts
+++ b/src/api/config.ts
@@ -14,5 +14,5 @@ export function postConfig(body?: object | string) {
 
 export const includeCredentials: RequestInit = { credentials: 'include' };
 
-export const apiBaseUri = `${import.meta.env.BASE_URL}proxy/azure-api`;
+export const apiBaseUri = `${import.meta.env.BASE_URL}proxy/azure-api/rest`;
 export const contextHolderBaseUri = `${import.meta.env.BASE_URL}proxy/modiacontextholder/api`;


### PR DESCRIPTION
Når vi bruker autogenerert klient fra openAPI schema så er /rest med i
URLene og det er litt styr å fjerne den. Vi normaliserer og fjerner
/rest fra proxy urlen isteden.
