### PR TITLE
Fjerne overflødige loadere

### DIFF
--- a/src/app/internarbeidsflatedecorator/Decorator.tsx
+++ b/src/app/internarbeidsflatedecorator/Decorator.tsx
@@ -20,10 +20,10 @@ function Decorator() {
     return (
         <StyledNav>
             <InternflateDecoratorV3 {...configV3} />
-            <IfFeatureToggleOn toggleID={FeatureToggles.NyAvansertSok}>
+            <IfFeatureToggleOn loader={<div />} toggleID={FeatureToggles.NyAvansertSok}>
                 <Personsok />
             </IfFeatureToggleOn>
-            <IfFeatureToggleOff toggleID={FeatureToggles.NyAvansertSok}>
+            <IfFeatureToggleOff loader={<div />} toggleID={FeatureToggles.NyAvansertSok}>
                 <PersonsokContainer />
             </IfFeatureToggleOff>
             <OppdateringsloggContainer />

--- a/src/components/featureToggle/FeatureToggle.tsx
+++ b/src/components/featureToggle/FeatureToggle.tsx
@@ -1,4 +1,4 @@
-import type { ReactNode } from 'react';
+import type { JSX, ReactNode } from 'react';
 import featuretoggles from '../../rest/resources/featuretogglesResource';
 import LazySpinner from '../LazySpinner';
 import type { FeatureToggles } from './toggleIDs';
@@ -12,6 +12,7 @@ interface Props {
     children: ReactNode;
     toggleID: FeatureToggles;
     mode: DisplayWhenToggleIs;
+    loader?: JSX.Element;
 }
 
 function shouldDisplay(mode: DisplayWhenToggleIs, featureToggleIsOn: boolean): boolean {
@@ -25,7 +26,7 @@ function shouldDisplay(mode: DisplayWhenToggleIs, featureToggleIsOn: boolean): b
 
 function FeatureToggle(props: Props) {
     return featuretoggles.useRenderer({
-        ifPending: <LazySpinner type="S" delay={1000} />,
+        ifPending: props.loader ?? <LazySpinner type="S" delay={1000} />,
         ifData: (toggles) => {
             if (shouldDisplay(props.mode, toggles[props.toggleID])) {
                 return <>{props.children}</>;

--- a/src/components/featureToggle/IfFeatureToggleOff.tsx
+++ b/src/components/featureToggle/IfFeatureToggleOff.tsx
@@ -1,10 +1,11 @@
-import type { ReactNode } from 'react';
+import type { JSX, ReactNode } from 'react';
 import FeatureToggle, { DisplayWhenToggleIs } from './FeatureToggle';
 import type { FeatureToggles } from './toggleIDs';
 
 interface Props {
     children: ReactNode;
     toggleID: FeatureToggles;
+    loader?: JSX.Element;
 }
 
 function IfFeatureToggleOff(props: Props) {

--- a/src/components/featureToggle/IfFeatureToggleOn.tsx
+++ b/src/components/featureToggle/IfFeatureToggleOn.tsx
@@ -1,10 +1,11 @@
-import type { ReactNode } from 'react';
+import type { JSX, ReactNode } from 'react';
 import FeatureToggle, { DisplayWhenToggleIs } from './FeatureToggle';
 import type { FeatureToggles } from './toggleIDs';
 
 interface Props {
     children: ReactNode;
     toggleID: FeatureToggles;
+    loader?: JSX.Element;
 }
 
 function IfFeatureToggleOn(props: Props) {

--- a/src/routes/__root.tsx
+++ b/src/routes/__root.tsx
@@ -17,7 +17,6 @@ import { ThemeProvider } from 'src/lib/state/theme';
 import { usePersistentWWLogin } from 'src/login/use-persistent-ww-login';
 import HandleLegacyUrls from 'src/utils/HandleLegacyUrls';
 import useTimeout from 'src/utils/hooks/use-timeout';
-import styled from 'styled-components';
 
 export const Route = createRootRoute({
     component: RootLayout,
@@ -93,14 +92,9 @@ const TanStackRouterDevtools = import.meta.env.DEV
       )
     : () => null;
 
-const AppStyle = styled.div`
-  height: 100vh;
-  @media print {
-    height: auto;
-  }
-  display: flex;
-  flex-flow: column nowrap;
-`;
+const AppWrapper = ({ children }: PropsWithChildren) => (
+    <div className="h-svh print:h-auto flex flex-col flex-nowrap">{children}</div>
+);
 
 function RootLayout() {
     const matchRoute = useMatchRoute();
@@ -113,7 +107,7 @@ function RootLayout() {
                 {isLanding ? (
                     <Outlet />
                 ) : (
-                    <AppStyle>
+                    <AppWrapper>
                         <HandleLegacyUrls>
                             <DemoBanner />
                             <NyModia />
@@ -124,7 +118,7 @@ function RootLayout() {
                                 </App>
                             </ErrorBoundary>
                         </HandleLegacyUrls>
-                    </AppStyle>
+                    </AppWrapper>
                 )}
                 <TanStackRouterDevtools position="bottom-right" />
             </ValgtEnhetProvider>

--- a/src/utils/HandleLegacyUrls.tsx
+++ b/src/utils/HandleLegacyUrls.tsx
@@ -86,7 +86,7 @@ function HandleLegacyUrls({ children }: PropsWithChildren) {
         return urlObj.toString();
     };
 
-    return delayRender ? <Loader /> : children;
+    return delayRender ? <Loader size="3xlarge" /> : children;
 }
 
 export default HandleLegacyUrls;


### PR DESCRIPTION
FeatureToggle komponentene viser loadere når man venter på data. Men de tar ikke hensyn til at det
som vises ikke er vanlige block komponenter. Dette fjerner to loadere som dukker opp i et halvt
sekund pga. feature toggling på avansert søk.

