### PR TITLE
Ikke resett ytelsefilter ved endring i periode

### DIFF
--- a/src/app/personside/infotabs/utbetalinger/Utbetalinger.test.tsx
+++ b/src/app/personside/infotabs/utbetalinger/Utbetalinger.test.tsx
@@ -12,13 +12,13 @@ const filterState: UtbetalingFilterState = {
         }
     },
     utbetaltTil: ['Bruker'],
-    ytelser: ['Sykepenger']
+    ytelser: { Sykepenger: true }
 };
 
 test('filtrerer bort ytelser i utbetalinger som ikke er valgt i filter', () => {
     const filter: UtbetalingFilterState = {
         ...filterState,
-        ytelser: ['Dagpenger']
+        ytelser: { Dagpenger: true }
     };
 
     const utbetalinger: Utbetaling[] = [
@@ -58,7 +58,7 @@ test('filtrerer bort ytelser i utbetalinger som ikke er valgt i filter', () => {
 test('filtrerer bort utbetalinger som ikke er utbetalt til valgt mottaker i filter', () => {
     const filter: UtbetalingFilterState = {
         ...filterState,
-        ytelser: ['Dagpenger'],
+        ytelser: { Dagpenger: true },
         utbetaltTil: ['Berit AS']
     };
 

--- a/src/app/personside/infotabs/utbetalinger/Utbetalinger.tsx
+++ b/src/app/personside/infotabs/utbetalinger/Utbetalinger.tsx
@@ -20,31 +20,31 @@ import {
 } from './utils/utbetalinger-utils';
 
 const UtbetalingerPanel = styled(Panel)`
-    padding: 0rem;
-    margin-top: ${theme.margin.layout};
-    margin-bottom: ${theme.margin.layout};
-    > *:first-child {
-        padding: ${pxToRem(15)};
-    }
+  padding: 0rem;
+  margin-top: ${theme.margin.layout};
+  margin-bottom: ${theme.margin.layout};
+  > *:first-child {
+    padding: ${pxToRem(15)};
+  }
 `;
 
 const UtbetalingerListe = styled.ol`
-    padding: 0;
-    margin: 0;
+  padding: 0;
+  margin: 0;
 `;
 
 const Wrapper = styled.div`
-    ol {
-        list-style: none;
-    }
+  ol {
+    list-style: none;
+  }
 `;
 
 const OnOneLine = styled.div`
-    display: inline-flex;
-    align-items: center;
-    > *:last-child {
-        margin-left: 1rem;
-    }
+  display: inline-flex;
+  align-items: center;
+  > *:last-child {
+    margin-left: 1rem;
+  }
 `;
 
 export function getFiltrerteUtbetalinger(utbetalinger: Utbetaling[], filter: UtbetalingFilterState) {
@@ -59,7 +59,7 @@ function filtrerPaUtbetaltTilValg(utbetaling: Utbetaling, filter: UtbetalingFilt
 
 function filtrerBortYtelserSomIkkeErValgt(utbetaling: Utbetaling, filter: UtbetalingFilterState): Utbetaling {
     const ytelser = reduceUtbetlingerTilYtelser([utbetaling]);
-    const filtrerteYtelser = ytelser.filter((ytelse) => filter.ytelser.includes(getTypeFromYtelse(ytelse)));
+    const filtrerteYtelser = ytelser.filter((ytelse) => filter.ytelser[getTypeFromYtelse(ytelse)] === true);
     if (filtrerteYtelser.length === ytelser.length) {
         return utbetaling;
     }

--- a/src/app/personside/infotabs/utbetalinger/filter/UtbetalingFilter.tsx
+++ b/src/app/personside/infotabs/utbetalinger/filter/UtbetalingFilter.tsx
@@ -17,36 +17,36 @@ import UtbetaltTilValg from './UtbetaltTilValg';
 import YtelseValg from './YtelseValg';
 
 const FiltreringsPanel = styled(Panel)`
-    padding: ${pxToRem(15)};
+  padding: ${pxToRem(15)};
 `;
 
 const InputPanel = styled.form`
-    display: flex;
-    flex-direction: column;
-    margin-top: 1.5rem;
-    > *:first-child {
-        margin-bottom: 0.5rem;
-    }
-    > * {
-        margin-top: 0.5rem;
-    }
-    .skjemaelement--horisontal {
-        margin-bottom: 0.4rem;
-    }
+  display: flex;
+  flex-direction: column;
+  margin-top: 1.5rem;
+  > *:first-child {
+    margin-bottom: 0.5rem;
+  }
+  > * {
+    margin-top: 0.5rem;
+  }
+  .skjemaelement--horisontal {
+    margin-bottom: 0.4rem;
+  }
 `;
 
 const WrapOnSmallScreen = styled.div`
-    @media (max-width: ${theme.media.utbetalinger.maxWidth}) {
-        display: flex;
-        flex-wrap: wrap;
-        > * {
-            flex-grow: 1;
-            flex-basis: 30%;
-        }
-        > *:not(:last-child) {
-            margin-right: 1rem;
-        }
+  @media (max-width: ${theme.media.utbetalinger.maxWidth}) {
+    display: flex;
+    flex-wrap: wrap;
+    > * {
+      flex-grow: 1;
+      flex-basis: 30%;
     }
+    > *:not(:last-child) {
+      margin-right: 1rem;
+    }
+  }
 `;
 
 function visCheckbokser(utbetalingerResponse: UtbetalingerResponse): boolean {

--- a/src/app/personside/infotabs/utbetalinger/utils/utbetalinger-utils.test.tsx
+++ b/src/app/personside/infotabs/utbetalinger/utils/utbetalinger-utils.test.tsx
@@ -229,7 +229,7 @@ const mockFilter: UtbetalingFilterState = {
             til: dayjs().format(ISO_DATE_FORMAT)
         }
     },
-    ytelser: [],
+    ytelser: {},
     utbetaltTil: []
 };
 

--- a/src/mock/utbetalinger/utbetalinger-mock.ts
+++ b/src/mock/utbetalinger/utbetalinger-mock.ts
@@ -25,7 +25,9 @@ export function getMockUtbetalinger(fodselsnummer: string, startDato: string, sl
     navfaker.seed(`${fodselsnummer}utbetaling`);
 
     return {
-        utbetalinger: getUtbetalinger(fodselsnummer),
+        utbetalinger: getUtbetalinger(fodselsnummer).filter(
+            (u) => dayjs(u.posteringsdato).isAfter(startDato) && dayjs(u.posteringsdato).isBefore(sluttDato)
+        ),
         periode: {
             startDato: startDato,
             sluttDato: sluttDato

--- a/src/redux/utbetalinger/types.ts
+++ b/src/redux/utbetalinger/types.ts
@@ -9,7 +9,7 @@ export interface UtbetalingerState {
 export interface UtbetalingFilterState {
     periode: PeriodeOptions;
     utbetaltTil: Array<string>;
-    ytelser: Array<string>;
+    ytelser: Record<string, boolean>;
 }
 
 export interface PeriodeOptions {

--- a/src/redux/utbetalinger/utbetalingerReducer.ts
+++ b/src/redux/utbetalinger/utbetalingerReducer.ts
@@ -17,7 +17,7 @@ const initialState: UtbetalingerState = {
             }
         },
         utbetaltTil: [],
-        ytelser: []
+        ytelser: {}
     }
 };
 


### PR DESCRIPTION
I utbetalinger var det logikk for å legge til ytelser som default true i
filteret når det kom inn nye utbetalinger. Dette funket ikke da
komponenten remountet og onComponentUpdate ikke lenger fungerer for å se
hvilke ytelser som er nye. Vi endrer det til at filteret kan holde styr
på både hilke som er valgt og hvilke valgmuligheter som _finnes_ ved å
gjøre den om til et objekt.
