### PR TITLE
Send umami requests via beacon

### DIFF
--- a/index.html
+++ b/index.html
@@ -10,12 +10,29 @@
     <meta property="og:description"
           content="Intern arbeidsflate. Brukes som personoppslag og dialogverktøy av veiledere og saksbehandlere i Nav">
     <link rel="shortcut icon" href="./favicon.ico">
-
+    
     <link rel="preload" href="https://cdn.nav.no/aksel/fonts/SourceSans3-normal.woff2" as="font" type="font/woff2" crossorigin/>
+    <script>
+        window.sendViaBeacon = (event, payload) => {
+            const data = {
+                type: "event",
+                payload: {
+                    referrer: "",
+                    ...payload
+                }
+            };
+            if (navigator.sendBeacon) {
+                navigator.sendBeacon("https://umami.nav.no/api/send", JSON.stringify(data));
+            } else {
+                fetch("https://umami.nav.no/api/send", { method: "POST", body: JSON.stringify(data), keepalive: true });
+            }
+        };
+    </script>
 
     <slot not-environment="prod">
         <script
             defer
+            data-before-send="sendViaBeacon"
             src="https://cdn.nav.no/team-researchops/sporing/sporing.js"
             data-host-url="https://umami.nav.no"
             data-website-id="bc5cfdcd-ecc1-402b-8cb0-c30913f0bd13"
@@ -24,6 +41,7 @@
     <slot environment="prod">
         <script
             defer
+            data-before-send="sendViaBeacon"
             src="https://cdn.nav.no/team-researchops/sporing/sporing.js"
             data-host-url="https://umami.nav.no"
             data-website-id="a8c2ec9c-2846-4154-8841-5db26494171a"

--- a/src/app/internarbeidsflatedecorator/useDecoratorConfig.tsx
+++ b/src/app/internarbeidsflatedecorator/useDecoratorConfig.tsx
@@ -1,14 +1,14 @@
 import { useAtom, useAtomValue, useSetAtom } from 'jotai';
 import { useCallback } from 'react';
 import { aktivBrukerAtom, aktivBrukerLastetAtom, aktivEnhetAtom } from 'src/lib/state/context';
+import type { Enhet } from 'src/rest/resources/saksbehandlersEnheterResource';
+import { updateUserEnhet } from 'src/utils/analytics';
+import { useOnMount, useSettAktivBruker } from 'src/utils/customHooks';
+import { getDomainFromHost, getEnvFromHost } from 'src/utils/environment';
+import { loggEvent } from 'src/utils/logger/frontendLogger';
+import { parseQueryString, useQueryParams } from 'src/utils/url-utils';
 import config from '../../config';
-import type { Enhet } from '../../rest/resources/saksbehandlersEnheterResource';
 import bjelleIkon from '../../svg/bjelle.svg?raw';
-import { trackNavigation, updateUserEnhet } from '../../utils/analytics';
-import { useOnMount, useSettAktivBruker } from '../../utils/customHooks';
-import { getDomainFromHost, getEnvFromHost } from '../../utils/environment';
-import { loggEvent } from '../../utils/logger/frontendLogger';
-import { parseQueryString, useQueryParams } from '../../utils/url-utils';
 import { DecoratorButtonId as OppdateringsloggButtonId } from '../oppdateringslogg/OppdateringsloggContainer';
 import type { DecoratorPropsV3, Hotkey } from './decoratorprops';
 
@@ -35,15 +35,10 @@ export function useDecoratorConfig() {
         setAktivEnhet(enhet);
     };
 
-    const handleLinkClick = (link: { text: string; url: string }) => {
-        trackNavigation(link.text, link.url);
-    };
-
-    const configV3 = useCallback(lagConfigV3, [aktivEnhet, settAktivBruker, handleSetEnhet, handleLinkClick])(
+    const configV3 = useCallback(lagConfigV3, [aktivEnhet, settAktivBruker, handleSetEnhet])(
         aktivEnhet,
         settAktivBruker,
-        handleSetEnhet,
-        handleLinkClick
+        handleSetEnhet
     );
 
     return { configV3 };

--- a/src/utils/analytics.ts
+++ b/src/utils/analytics.ts
@@ -10,17 +10,6 @@ declare global {
     }
 }
 
-export const trackNavigation = (destination: string, linkText: string) => {
-    if (!window.umami) {
-        console.warn('Umami is not initialized. Ignoring');
-        return;
-    }
-    window.umami.track('lenke klikket', {
-        tekst: linkText,
-        destinasjon: destination
-    });
-};
-
 export const trackAccordionOpened = (name: string) => {
     if (!window.umami) {
         console.warn('Umami is not initialized. Ignoring');


### PR DESCRIPTION
Prøver på nytt med denne.

I dekoratøren tracker vi outbound (og innbound) links sånn her: https://umami.is/docs/track-outbound-links
Problemet med denne måten å tracke på er at nokon gongar så blocker requesten til Umami page navigation.
For å hindre dette sender me no request via Beacon API.
I tillegg hadde me satt opp eigen tracking på onLinkClick i dekoratøren som gjer at me har dobbelt tracking i dekoratøren, så har fjerna den.

Har lagt til tom referrer om den ikkje eksisterer i payloaden då dette gav ein feil sist.
