### PR TITLE
Umami: Fjern beacon og bruk nye sporingsendepunkter

### DIFF
--- a/index.html
+++ b/index.html
@@ -13,20 +13,17 @@
     
     <link rel="preload" href="https://cdn.nav.no/aksel/fonts/SourceSans3-normal.woff2" as="font" type="font/woff2" crossorigin/>
     <script>
-        window.sendViaBeacon = (event, payload) => {
+        window.sendWithEventData = (_event, payload) => {
+            const url = new URL(payload.url, location.href);
+            if(url.host.includes("localhost")) return null
+
+            url.search = '';
             const umamiEventData = window.__router?.state?.location?.state.umamiEvent;
-            const data = {
-                type: "event",
-                payload: {
-                    referrer: "",
-                    ...umamiEventData,
+
+            return {
                     ...payload,
-                }
-            }
-            if (navigator.sendBeacon) {
-                navigator.sendBeacon("https://umami.nav.no/api/send", JSON.stringify(data));
-            } else {
-                fetch("https://umami.nav.no/api/send", { method: "POST", body: JSON.stringify(data), keepalive: true });
+                    ...umamiEventData,
+                url: url.toString(),
             }
         };
     </script>
@@ -34,18 +31,16 @@
     <slot not-environment="prod">
         <script
             defer
-            data-before-send="sendViaBeacon"
-            src="https://cdn.nav.no/team-researchops/sporing/sporing.js"
-            data-host-url="https://umami.nav.no"
+            data-before-send="sendWithEventData"
+            src="https://cdn.nav.no/team-researchops/sporing/sporing-dev.js"
             data-website-id="bc5cfdcd-ecc1-402b-8cb0-c30913f0bd13"
         ></script>
     </slot>
     <slot environment="prod">
         <script
             defer
-            data-before-send="sendViaBeacon"
+            data-before-send="sendWithEventData"
             src="https://cdn.nav.no/team-researchops/sporing/sporing.js"
-            data-host-url="https://umami.nav.no"
             data-website-id="a8c2ec9c-2846-4154-8841-5db26494171a"
         ></script>
     </slot>

--- a/index.html
+++ b/index.html
@@ -15,16 +15,24 @@
     <script>
         window.sendWithEventData = (_event, payload) => {
             const url = new URL(payload.url, location.href);
-            if(url.host.includes("localhost")) return null
 
-            url.search = '';
+           if(url.host.includes("localhost")) return null
             const umamiEventData = window.__router?.state?.location?.state.umamiEvent;
 
-            return {
+            url.search = '';
+
+            const result = {
                     ...payload,
-                    ...umamiEventData,
+                data: umamiEventData?.data ?? payload?.data,
+                name: umamiEventData?.name ?? payload?.name,
                 url: url.toString(),
+            };
+
+            if (umamiEventData && window.__router?.state?.location?.state) {
+                window.__router.state.location.state.umamiEvent = undefined;
             }
+
+            return result;
         };
     </script>
 

--- a/proxy-config-dev.json
+++ b/proxy-config-dev.json
@@ -28,7 +28,7 @@
         "font-src": ["'self'", "data:", "https://cdn.nav.no"],
         "connect-src": [
             "'self'",
-            "umami.nav.no",
+            "reops-event-proxy.ekstern.dev.nav.no",
             "wss://modiaeventdistribution.intern.dev.nav.no",
             "wss://modiacontextholder.intern.dev.nav.no",
             "wss://modiapersonoversikt-draft.intern.dev.nav.no",

--- a/proxy-config-prod.json
+++ b/proxy-config-prod.json
@@ -28,7 +28,7 @@
         "font-src": ["'self'", "data:", "https://cdn.nav.no"],
         "connect-src": [
             "'self'",
-            "umami.nav.no",
+            "reops-event-proxy.nav.no",
             "wss://modiaeventdistribution.intern.nav.no",
             "wss://modiacontextholder.intern.nav.no",
             "wss://veilederflatehendelser.adeo.no",


### PR DESCRIPTION
- Lagt til nye endepunkter i proxy-config
- Renser urlen for query params
- Fjerner beacon og sender vanleg umami request
- Sende ingen request til umami ved lokal utvikling 
- reset umamiEvent etter etter at eventdataen er satt slik at ikkje det eventet overskriver default-eventet til umami sporingen