### PR TITLE
Submit melding bugfix

### DIFF
--- a/src/components/melding/NyMelding.tsx
+++ b/src/components/melding/NyMelding.tsx
@@ -98,7 +98,10 @@ function NyMelding() {
                     {(field) => (
                         <VelgMeldingsType
                             meldingsType={field.state.value}
-                            setMeldingsType={(meldingsType) => field.handleChange(meldingsType)}
+                            setMeldingsType={(meldingsType) => {
+                                form.reset();
+                                field.handleChange(meldingsType);
+                            }}
                         />
                     )}
                 </form.Field>

--- a/src/components/sakVelger/VelgSak.tsx
+++ b/src/components/sakVelger/VelgSak.tsx
@@ -51,13 +51,10 @@ export default function VelgSak({ setSak, valgtSak, error }: VelgSakProps) {
                 <Modal.Body className="overflow-y-hidden">
                     <SakVelger.Root
                         setSak={(sak) => {
-                            setSak({
-                                ...sak,
-                                fnr: undefined,
-                                saksId: sak.saksId ?? undefined,
-                                fagsystemSaksId: sak.fagsystemSaksId ?? undefined,
-                                opprettetDato: sak.opprettetDato ?? undefined
-                            });
+                            const normalized = Object.fromEntries(
+                                Object.entries(sak).map(([k, v]) => [k, v ?? undefined])
+                            ) as JournalforingSak;
+                            setSak({ ...normalized, fnr: undefined });
                             setVelgSakModalOpen(false);
                         }}
                     >


### PR DESCRIPTION
Det har kome inn fleire henvendelsar om at det ikkje er muleg å klikke på send-knappen, men så går det plutseleg etterkvart. Eg har ikkje sett problemet når det har oppstått, og me får ikkje sett frontendfeil i loggane. Desse fiksane er derfor berre eit håp om at skal fjerne problemet.

Tidlegare når det ikkje har fungert å klikke på knappen så har det vore ein valideringsfeil i zod-schema i formet, men feilmeldinga har ikkje vore synleg. Dette har i alle tilfellene vore knytta til journalføringssaker som har null-felter. Eg trudde dette problemet var borte, men kanskje ikkje. Løysinga er derfor kanskje litt "hacky", men har normalisert alle nullverdier til å bli undefined for ein sak for sikkerhetsskyld.

Den neste fiksen er at når ein bytter meldingstype så blir formet tilbakestillt. Då fjernar me alle valideringsfeil og startar på nytt.