### PR TITLE
Vedleggsvisning fikser

### DIFF
--- a/src/components/Dokumenter/DokumentVisningExpandable.tsx
+++ b/src/components/Dokumenter/DokumentVisningExpandable.tsx
@@ -56,9 +56,7 @@ const DokumentTab = ({
             value={value ?? `${index}-${dokument.dokumentreferanse}`}
             label={
                 <HStack wrap={false}>
-                    <BodyShort className="whitespace-nowrap">
-                        {value ? capitalize(value) : `Vedlegg ${index + 1}`}
-                    </BodyShort>
+                    <BodyShort className="whitespace-nowrap">{value ? capitalize(value) : dokument.tittel}</BodyShort>
                     <Link
                         to="/new/dokument"
                         target="_blank"

--- a/src/components/Dokumenter/DokumenterTabell.tsx
+++ b/src/components/Dokumenter/DokumenterTabell.tsx
@@ -35,6 +35,11 @@ const avsenderMottaker = (
     }
 };
 
+const countVedleggMedReferanse = (journalpost: Dokumentmetadata) => {
+    if (!journalpost.vedlegg.length) return 1;
+    return journalpost.vedlegg.filter((vedlegg) => vedlegg.dokumentreferanse).length + 1;
+};
+
 export const DokumenterTabell = () => {
     const [openMap, setOpenMap] = useState<{ [key: string]: boolean }>({});
 
@@ -155,7 +160,7 @@ export const DokumenterTabell = () => {
                                         title="Antall vedlegg"
                                         icon={<FilesIcon aria-hidden />}
                                     >
-                                        {journalpost.vedlegg.length ? journalpost.vedlegg.length + 1 : 1}
+                                        {countVedleggMedReferanse(journalpost)}
                                     </Tag>
                                 </Table.DataCell>
                             </Table.ExpandableRow>


### PR DESCRIPTION
- Counten på vedlegg var feil om vedleggene var uten referanse. Dei uten referanse er kun eit notat til hoveddokumentet, dvs at det ikkje er eit faktisk vedlegg.
- Vedleggstittel vistes før som. "vedlegg x" og du måtte aktivt klikke inn på vedlegget for å sjå tittel. No er det tittel som vises i tabben.
- 
https://trello.com/c/TqDOiKgS/275-legg-til-navn-p%C3%A5-vedlegg-i-dokumenterfanen-og-ikke-tell-med-dokumenter-uten-referanse