### PR TITLE
Et ferdigstilt varsel er ikke lenger aktivt

### DIFF
--- a/src/components/varsler/List/index.tsx
+++ b/src/components/varsler/List/index.tsx
@@ -129,7 +129,7 @@ export const VarslerListe = () => {
                                 <Table.DataCell>
                                     {varsel.revarslingstidspunkt ? formaterDato(varsel.revarslingstidspunkt) : ENDASH}
                                 </Table.DataCell>
-                                <Table.DataCell>{varsel.aktiv ? 'Ja' : 'Nei'}</Table.DataCell>
+                                <Table.DataCell>{varsel.aktiv ? 'Nei' : 'Ja'}</Table.DataCell>
                                 <Table.DataCell>{emptyReplacement(varsel.kanaler?.join(', '), ENDASH)}</Table.DataCell>
                                 <Table.DataCell>
                                     <Status varsel={varsel} />


### PR DESCRIPTION
Vi har hatt motsatt visning på ferdigstilt-kolonnen i varseltabellen. Et aktivt varsel er ikke ferdigstillt, men motsatt.