### PR TITLE
Default form options blir satt når form blir resatt pa meldingstype

### DIFF
--- a/src/components/melding/NyMelding.tsx
+++ b/src/components/melding/NyMelding.tsx
@@ -99,7 +99,10 @@ function NyMelding() {
                         <VelgMeldingsType
                             meldingsType={field.state.value}
                             setMeldingsType={(meldingsType) => {
-                                form.reset();
+                                form.reset({
+                                    ...defaultFormOptions,
+                                    sak: meldingsType !== MeldingsType.Referat ? form.getFieldValue('sak') : undefined
+                                });
                                 field.handleChange(meldingsType);
                             }}
                         />


### PR DESCRIPTION
Sak meldt inn om at draft forsvinner ved form.reset:
https://trello.com/c/9DUf5Ifc/282-ikke-tilbakestill-tekst-ved-bytte-av-meldingstype

Ved å sette defaultformoptions på reset så vil defaultverdier bli satt, dette gjelder draften også. Legger i tillegg til saken om det byttes mellom samtale og infomelding.