### PR TITLE
Behold melding når man bytter meldingstype

### DIFF
--- a/src/components/melding/NyMelding.tsx
+++ b/src/components/melding/NyMelding.tsx
@@ -101,6 +101,7 @@ function NyMelding() {
                             setMeldingsType={(meldingsType) => {
                                 form.reset({
                                     ...defaultFormOptions,
+                                    melding: form.getFieldValue('melding'),
                                     sak: meldingsType !== MeldingsType.Referat ? form.getFieldValue('sak') : undefined
                                 });
                                 field.handleChange(meldingsType);


### PR DESCRIPTION
Tenkte det var nok å fylle inn fra draftcontext, men det var gammel context. På denne måten har me sikra at melding alltid er med uavhengig om draft har blitt lagret.