### PR TITLE
Enabler bruk av piltaster i paginert resultatliste

### DIFF
--- a/src/components/Meldinger/List/TraadItem.tsx
+++ b/src/components/Meldinger/List/TraadItem.tsx
@@ -176,7 +176,8 @@ export const TraadItem = ({ traad }: { traad: TraadDto }) => {
                 e.preventDefault();
                 onClick();
             }}
-            tabIndex={0}
+            tabIndex={aktivTraad === traad.traadId ? 0 : -1}
+            aria-current={aktivTraad === traad.traadId ? true : undefined}
             role="link"
             onKeyDown={(e) => {
                 if (e.key !== 'Enter' && e.key !== ' ' && e.key !== 'Spacebar') return;

--- a/src/components/Meldinger/List/index.tsx
+++ b/src/components/Meldinger/List/index.tsx
@@ -1,4 +1,4 @@
-import { useSearch } from '@tanstack/react-router';
+import { getRouteApi, useSearch } from '@tanstack/react-router';
 import ErrorBoundary from 'src/components/ErrorBoundary';
 import { PaginatedList } from 'src/components/PaginatedList';
 import { useAntallListeElementeBasertPaaSkjermStorrelse } from 'src/utils/customHooks';
@@ -12,15 +12,20 @@ export const TraadList = () => (
     </ErrorBoundary>
 );
 
+const routeApi = getRouteApi('/new/person/meldinger');
+
 const Traader = () => {
     const { isLoading } = useTraader();
     const filteredMeldinger = useFilterMeldinger();
     const antallListeElementer = useAntallListeElementeBasertPaaSkjermStorrelse();
+    const navigate = routeApi.useNavigate();
 
     const traadId = useSearch({
         from: '/new/person/meldinger',
         select: (p) => p.traadId
     });
+
+    const selectedItem = filteredMeldinger.find((t) => t.traadId === traadId);
 
     return (
         <PaginatedList
@@ -37,6 +42,8 @@ const Traader = () => {
             items={filteredMeldinger}
             keyExtractor={(item) => item.traadId}
             renderItem={({ item }) => <TraadItem traad={item} />}
+            onSelectItem={(traad) => navigate({ search: { traadId: traad.traadId } })}
+            selectedItem={selectedItem}
         />
     );
 };

--- a/src/components/PaginatedList/index.tsx
+++ b/src/components/PaginatedList/index.tsx
@@ -4,12 +4,13 @@ import {
     type ComponentProps,
     type ComponentPropsWithRef,
     type JSX,
-    type KeyboardEvent,
     type ReactNode,
     useEffect,
     useMemo,
+    useRef,
     useState
 } from 'react';
+import { usePiltasterIListe } from 'src/components/sakVelger/keyboardHooks';
 
 type Props<T, KeyType> = Omit<ComponentPropsWithRef<typeof VStack>, 'as'> & {
     items: T[];
@@ -21,6 +22,8 @@ type Props<T, KeyType> = Omit<ComponentPropsWithRef<typeof VStack>, 'as'> & {
     paginationSrHeading?: ComponentProps<typeof Pagination>['srHeading'];
     filterCard?: ReactNode;
     isLoading?: boolean;
+    onSelectItem?: (item: T) => void;
+    selectedItem?: T;
 };
 
 export const PaginatedList = <T, KeyType extends string | number>({
@@ -33,12 +36,23 @@ export const PaginatedList = <T, KeyType extends string | number>({
     paginationSrHeading,
     filterCard,
     isLoading,
+    onSelectItem,
+    selectedItem,
     ...rest
 }: Props<T, KeyType>) => {
     const [page, setPage] = useState(0);
     const pages = useMemo(() => chunk(items, pageSize), [items, pageSize]);
     const pageCount = useMemo(() => pages.length, [pages]);
     const renderItems = useMemo(() => pages[page > pageCount - 1 ? pageCount - 1 : page], [pages, page, pageCount]);
+    const listRef = useRef<HTMLDivElement>(null);
+
+    usePiltasterIListe(
+        listRef,
+        [renderItems, selectedItem],
+        renderItems ?? [],
+        onSelectItem ?? (() => {}),
+        selectedItem
+    );
 
     useEffect(() => {
         if (selectedKey) {
@@ -50,22 +64,6 @@ export const PaginatedList = <T, KeyType extends string | number>({
         }
         setPage(0);
     }, [selectedKey, pages, keyExtractor]);
-
-    const handleListKeyDown = (e: KeyboardEvent<HTMLElement>) => {
-        if (e.key !== 'ArrowDown' && e.key !== 'ArrowUp') return;
-
-        const focusableItems = Array.from(e.currentTarget.querySelectorAll<HTMLElement>('[tabindex="0"]'));
-        const focusedIndex = focusableItems.indexOf(document.activeElement as HTMLElement);
-
-        if (focusedIndex === -1) return;
-
-        e.preventDefault();
-
-        const lastIndex = focusableItems.length - 1;
-        const nextIndex = e.key === 'ArrowDown' ? Math.min(focusedIndex + 1, lastIndex) : Math.max(focusedIndex - 1, 0);
-
-        focusableItems[nextIndex].focus();
-    };
 
     return (
         <VStack as={as ?? 'div'} gap="space-4" justify="space-between" height="100%" overflow="auto" {...rest}>
@@ -84,11 +82,13 @@ export const PaginatedList = <T, KeyType extends string | number>({
                         Ingen resultat
                     </InlineMessage>
                 ) : (
-                    <VStack as="ul" gap="space-4" onKeyDown={handleListKeyDown}>
-                        {renderItems?.map((item, i) => (
-                            <RenderComp item={item} key={`${i}-${keyExtractor(item)}`} />
-                        ))}
-                    </VStack>
+                    <div ref={listRef}>
+                        <VStack as="ul" gap="space-4">
+                            {renderItems?.map((item, i) => (
+                                <RenderComp item={item} key={`${i}-${keyExtractor(item)}`} />
+                            ))}
+                        </VStack>
+                    </div>
                 )}
             </VStack>
             {pages.length > 1 && (

--- a/src/components/PaginatedList/index.tsx
+++ b/src/components/PaginatedList/index.tsx
@@ -44,15 +44,6 @@ export const PaginatedList = <T, KeyType extends string | number>({
     const pages = useMemo(() => chunk(items, pageSize), [items, pageSize]);
     const pageCount = useMemo(() => pages.length, [pages]);
     const renderItems = useMemo(() => pages[page > pageCount - 1 ? pageCount - 1 : page], [pages, page, pageCount]);
-    const listRef = useRef<HTMLDivElement>(null);
-
-    usePiltasterIListe(
-        listRef,
-        [renderItems, selectedItem],
-        renderItems ?? [],
-        onSelectItem ?? (() => {}),
-        selectedItem
-    );
 
     useEffect(() => {
         if (selectedKey) {
@@ -64,6 +55,9 @@ export const PaginatedList = <T, KeyType extends string | number>({
         }
         setPage(0);
     }, [selectedKey, pages, keyExtractor]);
+
+    const listRef = useRef<HTMLDivElement>(null);
+    usePiltasterIListe(listRef, [selectedItem, items], items, (item) => onSelectItem?.(item), selectedItem);
 
     return (
         <VStack as={as ?? 'div'} gap="space-4" justify="space-between" height="100%" overflow="auto" {...rest}>
@@ -82,7 +76,7 @@ export const PaginatedList = <T, KeyType extends string | number>({
                         Ingen resultat
                     </InlineMessage>
                 ) : (
-                    <div ref={listRef}>
+                    <div ref={listRef} tabIndex={!selectedItem && !!onSelectItem ? 0 : -1}>
                         <VStack as="ul" gap="space-4">
                             {renderItems?.map((item, i) => (
                                 <RenderComp item={item} key={`${i}-${keyExtractor(item)}`} />

--- a/src/components/PaginatedList/index.tsx
+++ b/src/components/PaginatedList/index.tsx
@@ -4,6 +4,7 @@ import {
     type ComponentProps,
     type ComponentPropsWithRef,
     type JSX,
+    type KeyboardEvent,
     type ReactNode,
     useEffect,
     useMemo,
@@ -50,6 +51,22 @@ export const PaginatedList = <T, KeyType extends string | number>({
         setPage(0);
     }, [selectedKey, pages, keyExtractor]);
 
+    const handleListKeyDown = (e: KeyboardEvent<HTMLElement>) => {
+        if (e.key !== 'ArrowDown' && e.key !== 'ArrowUp') return;
+
+        const focusableItems = Array.from(e.currentTarget.querySelectorAll<HTMLElement>('[tabindex="0"]'));
+        const focusedIndex = focusableItems.indexOf(document.activeElement as HTMLElement);
+
+        if (focusedIndex === -1) return;
+
+        e.preventDefault();
+
+        const lastIndex = focusableItems.length - 1;
+        const nextIndex = e.key === 'ArrowDown' ? Math.min(focusedIndex + 1, lastIndex) : Math.max(focusedIndex - 1, 0);
+
+        focusableItems[nextIndex].focus();
+    };
+
     return (
         <VStack as={as ?? 'div'} gap="space-4" justify="space-between" height="100%" overflow="auto" {...rest}>
             <VStack gap="space-4">
@@ -67,7 +84,7 @@ export const PaginatedList = <T, KeyType extends string | number>({
                         Ingen resultat
                     </InlineMessage>
                 ) : (
-                    <VStack as="ul" gap="space-4">
+                    <VStack as="ul" gap="space-4" onKeyDown={handleListKeyDown}>
                         {renderItems?.map((item, i) => (
                             <RenderComp item={item} key={`${i}-${keyExtractor(item)}`} />
                         ))}

--- a/src/components/PersonSidebar.tsx
+++ b/src/components/PersonSidebar.tsx
@@ -12,7 +12,7 @@ import {
 } from '@navikt/aksel-icons';
 import { Bleed, Box, Button, Heading, Tooltip, VStack } from '@navikt/ds-react';
 import { Link } from '@tanstack/react-router';
-import { type ComponentProps, type ReactElement, useState } from 'react';
+import { type ComponentProps, type KeyboardEvent, type ReactElement, useRef, useState } from 'react';
 import { getOpenTabFromRouterPath, useOpenTab } from 'src/app/personside/infotabs/utils/useOpenTab';
 import { erUbesvartHenvendelseFraBruker, useTraader } from 'src/components/Meldinger/List/utils';
 import { usePersonSideBarKotkeys } from 'src/components/usePersonSidebarHotkeys';
@@ -89,10 +89,22 @@ export const PersonSidebarMenu = () => {
     const { data: oppgaver = [] } = usePersonOppgaver();
     const harOppgaverPaaEnTraad = oppgaver.some((oppgave) => oppgave.traadId !== null);
     const harUbesvarteTraader = traader.some((traad) => erUbesvartHenvendelseFraBruker(traad));
+    const navRef = useRef<HTMLElement>(null);
 
     const visNotifikasjon = (tab: string) => {
         if (tab !== 'Kommunikasjon') return false;
         return harOppgaverPaaEnTraad || harUbesvarteTraader;
+    };
+
+    const handleNavKeyDown = (e: KeyboardEvent<HTMLElement>) => {
+        if (e.key !== 'ArrowDown' && e.key !== 'ArrowUp') return;
+        const links = Array.from(navRef.current?.querySelectorAll<HTMLElement>('a') ?? []);
+        const currentIndex = links.indexOf(document.activeElement as HTMLElement);
+        if (currentIndex === -1) return;
+        e.preventDefault();
+        const lastIndex = links.length - 1;
+        const nextIndex = e.key === 'ArrowDown' ? Math.min(currentIndex + 1, lastIndex) : Math.max(currentIndex - 1, 0);
+        links[nextIndex].focus();
     };
 
     return (
@@ -124,9 +136,11 @@ export const PersonSidebarMenu = () => {
                     <VStack
                         as="nav"
                         id="sidebar-person"
+                        ref={navRef}
                         aria-label="Person"
                         padding="space-8"
                         className="divide-y divide-ax-border-neutral-subtle "
+                        onKeyDown={handleNavKeyDown}
                     >
                         <Heading visuallyHidden size="small" level="2">
                             Faner
@@ -145,6 +159,8 @@ export const PersonSidebarMenu = () => {
                                         }
                                     }}
                                     aria-label={title}
+                                    activeProps={{ tabIndex: 0 }}
+                                    inactiveProps={{ tabIndex: -1 }}
                                 >
                                     {({ isActive }) => (
                                         <>

--- a/src/components/PersonSidebar.tsx
+++ b/src/components/PersonSidebar.tsx
@@ -89,7 +89,7 @@ export const PersonSidebarMenu = () => {
     const { data: oppgaver = [] } = usePersonOppgaver();
     const harOppgaverPaaEnTraad = oppgaver.some((oppgave) => oppgave.traadId !== null);
     const harUbesvarteTraader = traader.some((traad) => erUbesvartHenvendelseFraBruker(traad));
-    const navRef = useRef<HTMLElement>(null);
+    const navRef = useRef<HTMLDivElement>(null);
 
     const visNotifikasjon = (tab: string) => {
         if (tab !== 'Kommunikasjon') return false;
@@ -137,6 +137,7 @@ export const PersonSidebarMenu = () => {
                         as="nav"
                         id="sidebar-person"
                         ref={navRef}
+                        role="menu"
                         aria-label="Person"
                         padding="space-8"
                         className="divide-y divide-ax-border-neutral-subtle "
@@ -159,6 +160,7 @@ export const PersonSidebarMenu = () => {
                                         }
                                     }}
                                     aria-label={title}
+                                    role="menuitem"
                                     activeProps={{ tabIndex: 0 }}
                                     inactiveProps={{ tabIndex: -1 }}
                                 >

--- a/src/components/sakVelger/keyboardHooks.ts
+++ b/src/components/sakVelger/keyboardHooks.ts
@@ -1,4 +1,4 @@
-import type { DependencyList } from 'react';
+import { type DependencyList, useEffect, useState } from 'react';
 import { useHotkey } from 'src/utils/hooks/use-hotkey';
 import { modulo } from 'src/utils/math';
 
@@ -9,17 +9,30 @@ export function usePiltasterIListe<T>(
     velgElement: (element: T) => void,
     valgtElement?: T
 ) {
+    const [element, setElement] = useState<HTMLDivElement | null>(null);
+    useEffect(() => {
+        if (listeRef.current !== element) {
+            setElement(listeRef.current);
+        }
+    });
+
     const velg = (offset: number) => () => {
-        const index = listeElementer.findIndex((element) => element === valgtElement);
+        if (!listeElementer.length) return;
+
+        if (!valgtElement) {
+            velgElement(offset > 0 ? listeElementer[0] : listeElementer[listeElementer.length - 1]);
+            return;
+        }
+
+        const index = listeElementer.indexOf(valgtElement);
         if (index !== -1) {
             const nextIndex = modulo(index + offset, listeElementer.length);
-            const nesteElement = listeElementer[nextIndex];
-            velgElement(nesteElement);
+            velgElement(listeElementer[nextIndex]);
         }
     };
 
-    useHotkey('arrowup', velg(-1), dependencies, 'Neste listelement', listeRef?.current);
-    useHotkey('arrowdown', velg(1), dependencies, 'Neste listeelement', listeRef?.current);
+    useHotkey('arrowup', velg(-1), dependencies, 'Forrige listeelement', element);
+    useHotkey('arrowdown', velg(1), dependencies, 'Neste listeelement', element);
 }
 
 /**

--- a/src/components/ytelser/List/YtelseItem.tsx
+++ b/src/components/ytelser/List/YtelseItem.tsx
@@ -68,7 +68,8 @@ export const YtelseItem = ({ ytelse }: { ytelse: YtelseVedtak }) => {
                 e.preventDefault();
                 onClick();
             }}
-            tabIndex={0}
+            tabIndex={aktivYtelse === id ? 0 : -1}
+            aria-current={aktivYtelse === id ? true : undefined}
             role="link"
             onKeyDown={(e) => {
                 if (e.key !== 'Enter' && e.key !== ' ' && e.key !== 'Spacebar') return;

--- a/src/components/ytelser/List/index.tsx
+++ b/src/components/ytelser/List/index.tsx
@@ -1,4 +1,4 @@
-import { useSearch } from '@tanstack/react-router';
+import { getRouteApi, useSearch } from '@tanstack/react-router';
 import ErrorBoundary from 'src/components/ErrorBoundary';
 import { PaginatedList } from 'src/components/PaginatedList';
 import { YtelseItem } from 'src/components/ytelser/List/YtelseItem';
@@ -12,14 +12,19 @@ export const YtelserList = () => (
     </ErrorBoundary>
 );
 
+const routeApi = getRouteApi('/new/person/ytelser');
+
 const YtelseList = () => {
     const { data: ytelser, isLoading } = useFilterYtelser();
     const antallListeElementer = useAntallListeElementeBasertPaaSkjermStorrelse();
+    const navigate = routeApi.useNavigate();
 
     const selectedKey = useSearch({
         from: '/new/person/ytelser',
         select: (p) => p.id
     });
+
+    const selectedItem = ytelser.find((y) => getUnikYtelseKey(y) === selectedKey);
 
     return (
         <PaginatedList
@@ -36,6 +41,8 @@ const YtelseList = () => {
             isLoading={isLoading}
             keyExtractor={getUnikYtelseKey}
             renderItem={({ item }) => <YtelseItem ytelse={item} />}
+            onSelectItem={(ytelse) => navigate({ search: { id: getUnikYtelseKey(ytelse) } })}
+            selectedItem={selectedItem}
         />
     );
 };


### PR DESCRIPTION
Tre utbedringer i denne PR-en:

**Bruk av piltaster i resultatlistene i "Kommunikasjon"- og "Ytelse"-faner**
Med piltastene kan du nå navigere mellom "kortene" med piltastene. Når et kort kommer i fokus vil detalj-vinduet automatisk åpnes opp for det aktuelle kortet.

**Bruk av piltaster i navigasjons-meny**
Samme som over, men for å åpne opp en fane må bruker trykke enter.

**Liten bug fix i eksisterende hook "usePiltasterIListe"**
Hooken hadde en bug som gjorde at piltastene i enkelte tilfeller ikke tillott navigering i aktuell liste.