### PR TITLE
Gosys dyplenker fiks

### DIFF
--- a/src/api/config.ts
+++ b/src/api/config.ts
@@ -16,4 +16,3 @@ export const includeCredentials: RequestInit = { credentials: 'include' };
 
 export const apiBaseUri = `${import.meta.env.BASE_URL}proxy/azure-api/rest`;
 export const apiBaseUriWithoutRest = `${import.meta.env.BASE_URL}proxy/azure-api`;
-export const contextHolderBaseUri = `${import.meta.env.BASE_URL}proxy/modiacontextholder/api`;

--- a/src/lib/clients/contextholder.ts
+++ b/src/lib/clients/contextholder.ts
@@ -1,0 +1,21 @@
+import { useMutation } from '@tanstack/react-query';
+import { type FetchError, post } from 'src/api/api';
+
+interface ContextResponse {
+    aktivBruker: string;
+    aktivEnhet: string;
+}
+
+function url(): string {
+    return `${import.meta.env.BASE_URL}proxy/modiacontextholder/api/context`;
+}
+
+export const useSetUserContext = () => {
+    return useMutation<ContextResponse, FetchError, { fnr: string }>({
+        mutationFn: ({ fnr }) =>
+            post(url(), {
+                eventType: 'NY_AKTIV_BRUKER',
+                verdi: fnr
+            })
+    });
+};

--- a/src/lib/clients/contextholder.ts
+++ b/src/lib/clients/contextholder.ts
@@ -11,10 +11,11 @@ function url(): string {
 }
 
 export const useSetUserContext = () => {
-    return useMutation<ContextResponse, FetchError, { fnr: string }>({
-        mutationFn: ({ fnr }) =>
+    return useMutation<ContextResponse, FetchError, { fnr: string; verdiType: 'FNR' | 'FNR_CODE' }>({
+        mutationFn: ({ fnr, verdiType }) =>
             post(url(), {
                 eventType: 'NY_AKTIV_BRUKER',
+                verdiType: verdiType,
                 verdi: fnr
             })
     });

--- a/src/lib/clients/modiapersonoversikt-api.ts
+++ b/src/lib/clients/modiapersonoversikt-api.ts
@@ -141,11 +141,12 @@ export const usePersonOppgaver = () => {
 };
 
 export const useOppgave = (oppgaveId?: string) => {
-    if (oppgaveId === undefined) return { data: undefined, isLoading: false, isError: false };
-    // biome-ignore lint/correctness/useHookAtTopLevel:Biome migration - bør fikses
-    return $api.useQuery('get', '/rest/oppgaver/oppgavedata/{oppgaveId}', {
-        params: { path: { oppgaveId: oppgaveId } }
-    });
+    return $api.useQuery(
+        'get',
+        '/rest/oppgaver/oppgavedata/{oppgaveId}',
+        { params: { path: { oppgaveId: oppgaveId ?? '' } } },
+        { enabled: !!oppgaveId }
+    );
 };
 
 export const useNyesteVurderSvarOppgaveForTraad = (traadId: string) => {

--- a/src/routes/index.tsx
+++ b/src/routes/index.tsx
@@ -1,0 +1,14 @@
+import { createFileRoute } from '@tanstack/react-router';
+import { z } from 'zod';
+
+const indexSearchSchema = z.object({
+    sokFnrCode: z.string().optional(),
+    sokFnr: z.string().optional(),
+    henvendelseId: z.string().optional(),
+    oppgaveId: z.string().optional(),
+    behandlingsId: z.string().optional()
+});
+
+export const Route = createFileRoute('/')({
+    validateSearch: indexSearchSchema
+});

--- a/src/utils/HandleLegacyUrls.tsx
+++ b/src/utils/HandleLegacyUrls.tsx
@@ -1,15 +1,16 @@
 import { Loader } from '@navikt/ds-react';
 import { useMatchRoute, useNavigate } from '@tanstack/react-router';
+import { useSetAtom } from 'jotai';
 import { type PropsWithChildren, useEffect, useRef, useState } from 'react';
-import { post } from 'src/api/api';
-import { contextHolderBaseUri } from 'src/api/config';
 import { INFOTABS } from 'src/app/personside/infotabs/InfoTabEnum';
 import { paths } from 'src/app/routes/routing';
 import type { OppgaveDto } from 'src/generated/modiapersonoversikt-api';
+import { useSetUserContext } from 'src/lib/clients/contextholder';
 import { useOppgave } from 'src/lib/clients/modiapersonoversikt-api';
+import { dialogUnderArbeidAtom } from 'src/lib/state/dialog';
+import { trackDyplenkeFraEksternKilde } from 'src/utils/analytics';
 import { useSettAktivBruker } from 'src/utils/customHooks';
 import { erGyldigishFnr } from 'src/utils/fnr-utils';
-import { loggEvent } from 'src/utils/logger/frontendLogger';
 import { useQueryParams } from 'src/utils/url-utils';
 
 function HandleLegacyUrls({ children }: PropsWithChildren) {
@@ -28,6 +29,8 @@ function HandleLegacyUrls({ children }: PropsWithChildren) {
     const [delayRender, setDelayRender] = useState(!!validFnr || !!queryParams.oppgaveid);
     const { data: oppgaveData, isLoading } = useOppgave(queryParams.oppgaveid);
     const hasHandled = useRef(false);
+    const setDialogUnderArbeid = useSetAtom(dialogUnderArbeidAtom);
+    const setUserContext = useSetUserContext();
 
     useEffect(() => {
         if (queryParams.oppgaveid && isLoading) return;
@@ -37,18 +40,16 @@ function HandleLegacyUrls({ children }: PropsWithChildren) {
         const behandlingsId = queryParams.henvendelseid || queryParams.behandlingsid;
         const oppgaveId = queryParams.oppgaveid;
         if (queryParams.sokFnrCode) {
-            post<{
-                aktivBruker: string;
-                aktivEnhet: string;
-            }>(`${contextHolderBaseUri}/context`, {
-                eventType: 'NY_AKTIV_BRUKER',
-                verdiType: 'FNR_KODE',
-                verdi: queryParams.sokFnrCode
-            }).then((res) => {
-                const url = removeParamFromURL('sokFnrCode');
-                window.history.replaceState(null, '', url.toString());
-                handleLegacyUrls(res.aktivBruker, behandlingsId, oppgaveId, oppgaveData);
-            });
+            setUserContext.mutate(
+                { fnr: queryParams.sokFnrCode },
+                {
+                    onSuccess: (res) => {
+                        const url = removeParamFromURL('sokFnrCode');
+                        window.history.replaceState(null, '', url.toString());
+                        handleLegacyUrls(res.aktivBruker, behandlingsId, oppgaveId, oppgaveData);
+                    }
+                }
+            );
         } else {
             handleLegacyUrls(queryParams.sokFnr ?? validFnr, behandlingsId, oppgaveId, oppgaveData);
             setDelayRender(false);
@@ -56,52 +57,48 @@ function HandleLegacyUrls({ children }: PropsWithChildren) {
     }, [isLoading, oppgaveData]);
 
     const handleLegacyUrls = (fnr?: string, behandlingsId?: string, oppgaveId?: string, oppgaveData?: OppgaveDto) => {
-        const linkTilValgtHenvendelse = `${paths.personUri}/${INFOTABS.MELDINGER.path}` as const;
-        const newQuery = { traadId: behandlingsId };
-
         if (oppgaveId && behandlingsId && fnr) {
             settGjeldendeBruker(fnr, false);
-            loggEvent('Oppgave', 'FraGosys');
-            navigate({
-                to: linkTilValgtHenvendelse,
-                search: newQuery,
-                replace: true
-            });
+            trackDyplenkeFraEksternKilde('oppgave');
+            navigerTilTraadOgApneSvar(behandlingsId);
         } else if (fnr && behandlingsId) {
-            loggEvent('Henvendelse', 'FraGosys');
+            trackDyplenkeFraEksternKilde('henvendelse');
+            settGjeldendeBruker(fnr, false);
+            navigerTilTraadOgApneSvar(behandlingsId);
+        } else if (behandlingsId) {
+            trackDyplenkeFraEksternKilde('henvendelse');
+            navigerTilTraadOgApneSvar(behandlingsId);
+        } else if (oppgaveData) {
+            trackDyplenkeFraEksternKilde('kun oppgave');
+            if (!oppgaveData.fnr) return;
+            setUserContext.mutate(
+                { fnr: oppgaveData.fnr },
+                {
+                    onSuccess: () => {
+                        navigerTilTraadOgApneSvar(oppgaveData.traadId);
+                    }
+                }
+            );
+        } else if (fnr) {
+            trackDyplenkeFraEksternKilde('kun fnr');
             settGjeldendeBruker(fnr, false);
             navigate({
-                to: linkTilValgtHenvendelse,
-                search: newQuery,
+                to: `${paths.personUri}/${INFOTABS.MELDINGER.path}`,
                 replace: true
             });
-        } else if (behandlingsId) {
-            loggEvent('Henvendelse', 'FraGosys');
-            navigate({
-                to: linkTilValgtHenvendelse,
-                search: newQuery,
-                replace: true
-            });
-        } else if (oppgaveData) {
-            loggEvent('Oppgave', 'FraGosys');
-            post<{
-                aktivBruker: string;
-                aktivEnhet: string;
-            }>(`${contextHolderBaseUri}/context`, {
-                eventType: 'NY_AKTIV_BRUKER',
-                verdiType: 'FNR',
-                verdi: oppgaveData.fnr
-            }).then(() => {
-                const query = { traadId: oppgaveData.traadId };
-                navigate({
-                    to: linkTilValgtHenvendelse,
-                    search: query,
-                    replace: true
-                });
-            });
-        } else if (fnr) {
-            settGjeldendeBruker(fnr);
         }
+    };
+
+    const navigerTilTraadOgApneSvar = (traadId?: string) => {
+        const linkTilValgtHenvendelse = `${paths.personUri}/${INFOTABS.MELDINGER.path}` as const;
+        const newQuery = { traadId: traadId };
+
+        setDialogUnderArbeid(traadId);
+        navigate({
+            to: linkTilValgtHenvendelse,
+            search: newQuery,
+            replace: true
+        });
     };
 
     const removeParamFromURL = (param: string) => {

--- a/src/utils/HandleLegacyUrls.tsx
+++ b/src/utils/HandleLegacyUrls.tsx
@@ -1,12 +1,13 @@
 import { Loader } from '@navikt/ds-react';
 import { useMatchRoute, useNavigate } from '@tanstack/react-router';
-import { type PropsWithChildren, useState } from 'react';
+import { type PropsWithChildren, useEffect, useRef, useState } from 'react';
 import { post } from 'src/api/api';
 import { contextHolderBaseUri } from 'src/api/config';
 import { INFOTABS } from 'src/app/personside/infotabs/InfoTabEnum';
 import { paths } from 'src/app/routes/routing';
+import type { OppgaveDto } from 'src/generated/modiapersonoversikt-api';
 import { useOppgave } from 'src/lib/clients/modiapersonoversikt-api';
-import { useOnMount, useSettAktivBruker } from 'src/utils/customHooks';
+import { useSettAktivBruker } from 'src/utils/customHooks';
 import { erGyldigishFnr } from 'src/utils/fnr-utils';
 import { loggEvent } from 'src/utils/logger/frontendLogger';
 import { useQueryParams } from 'src/utils/url-utils';
@@ -24,10 +25,15 @@ function HandleLegacyUrls({ children }: PropsWithChildren) {
     const validFnr = fnrMatch && erGyldigishFnr(fnrMatch.fnr ?? '') ? fnrMatch.fnr : undefined;
     const settGjeldendeBruker = useSettAktivBruker();
     const navigate = useNavigate();
-    const [delayRender, setDelayRender] = useState(!!validFnr);
-    const { data: oppgaveData } = useOppgave(queryParams.oppgaveid);
+    const [delayRender, setDelayRender] = useState(!!validFnr || !!queryParams.oppgaveid);
+    const { data: oppgaveData, isLoading } = useOppgave(queryParams.oppgaveid);
+    const hasHandled = useRef(false);
 
-    useOnMount(() => {
+    useEffect(() => {
+        if (queryParams.oppgaveid && isLoading) return;
+        if (hasHandled.current) return;
+        hasHandled.current = true;
+
         const behandlingsId = queryParams.henvendelseid || queryParams.behandlingsid;
         const oppgaveId = queryParams.oppgaveid;
         if (queryParams.sokFnrCode) {
@@ -41,15 +47,15 @@ function HandleLegacyUrls({ children }: PropsWithChildren) {
             }).then((res) => {
                 const url = removeParamFromURL('sokFnrCode');
                 window.history.replaceState(null, '', url.toString());
-                handleLegacyUrls(res.aktivBruker, behandlingsId, oppgaveId);
+                handleLegacyUrls(res.aktivBruker, behandlingsId, oppgaveId, oppgaveData);
             });
         } else {
-            handleLegacyUrls(queryParams.sokFnr ?? validFnr, behandlingsId, oppgaveId);
+            handleLegacyUrls(queryParams.sokFnr ?? validFnr, behandlingsId, oppgaveId, oppgaveData);
             setDelayRender(false);
         }
-    });
+    }, [isLoading, oppgaveData]);
 
-    const handleLegacyUrls = (fnr?: string, behandlingsId?: string, oppgaveId?: string) => {
+    const handleLegacyUrls = (fnr?: string, behandlingsId?: string, oppgaveId?: string, oppgaveData?: OppgaveDto) => {
         const linkTilValgtHenvendelse = `${paths.personUri}/${INFOTABS.MELDINGER.path}` as const;
         const newQuery = { traadId: behandlingsId };
 

--- a/src/utils/HandleLegacyUrls.tsx
+++ b/src/utils/HandleLegacyUrls.tsx
@@ -41,7 +41,7 @@ function HandleLegacyUrls({ children }: PropsWithChildren) {
         const oppgaveId = queryParams.oppgaveid;
         if (queryParams.sokFnrCode) {
             setUserContext.mutate(
-                { fnr: queryParams.sokFnrCode },
+                { fnr: queryParams.sokFnrCode, verdiType: 'FNR_CODE' },
                 {
                     onSuccess: (res) => {
                         const url = removeParamFromURL('sokFnrCode');
@@ -72,7 +72,7 @@ function HandleLegacyUrls({ children }: PropsWithChildren) {
             trackDyplenkeFraEksternKilde('kun oppgave');
             if (!oppgaveData.fnr) return;
             setUserContext.mutate(
-                { fnr: oppgaveData.fnr },
+                { fnr: oppgaveData.fnr, verdiType: 'FNR' },
                 {
                     onSuccess: () => {
                         navigerTilTraadOgApneSvar(oppgaveData.traadId);

--- a/src/utils/HandleLegacyUrls.tsx
+++ b/src/utils/HandleLegacyUrls.tsx
@@ -1,5 +1,5 @@
 import { Loader } from '@navikt/ds-react';
-import { useMatchRoute, useNavigate } from '@tanstack/react-router';
+import { useMatchRoute, useNavigate, useSearch } from '@tanstack/react-router';
 import { useSetAtom } from 'jotai';
 import { type PropsWithChildren, useEffect, useRef, useState } from 'react';
 import { INFOTABS } from 'src/app/personside/infotabs/InfoTabEnum';
@@ -11,63 +11,57 @@ import { dialogUnderArbeidAtom } from 'src/lib/state/dialog';
 import { trackDyplenkeFraEksternKilde } from 'src/utils/analytics';
 import { useSettAktivBruker } from 'src/utils/customHooks';
 import { erGyldigishFnr } from 'src/utils/fnr-utils';
-import { useQueryParams } from 'src/utils/url-utils';
 
 function HandleLegacyUrls({ children }: PropsWithChildren) {
-    const queryParams = useQueryParams<{
-        sokFnr?: string;
-        sokFnrCode?: string;
-        oppgaveid?: string;
-        behandlingsid?: string;
-        henvendelseid?: string;
-    }>();
+    const { oppgaveId, sokFnr, sokFnrCode, henvendelseId, behandlingsId } = useSearch({ strict: false });
+
     const match = useMatchRoute();
     const fnrMatch = match({ to: '/person/$fnr' });
     const validFnr = fnrMatch && erGyldigishFnr(fnrMatch.fnr ?? '') ? fnrMatch.fnr : undefined;
     const settGjeldendeBruker = useSettAktivBruker();
     const navigate = useNavigate();
-    const [delayRender, setDelayRender] = useState(!!validFnr || !!queryParams.oppgaveid);
-    const { data: oppgaveData, isLoading } = useOppgave(queryParams.oppgaveid);
+    const [delayRender, setDelayRender] = useState(!!validFnr || !!oppgaveId);
+    const { data: oppgaveData, isLoading } = useOppgave(oppgaveId);
     const hasHandled = useRef(false);
     const setDialogUnderArbeid = useSetAtom(dialogUnderArbeidAtom);
     const setUserContext = useSetUserContext();
 
     useEffect(() => {
-        if (queryParams.oppgaveid && isLoading) return;
+        if (oppgaveId && isLoading) return;
         if (hasHandled.current) return;
         hasHandled.current = true;
 
-        const behandlingsId = queryParams.henvendelseid || queryParams.behandlingsid;
-        const oppgaveId = queryParams.oppgaveid;
-        if (queryParams.sokFnrCode) {
+        const traadId = henvendelseId || behandlingsId;
+
+        if (sokFnrCode) {
             setUserContext.mutate(
-                { fnr: queryParams.sokFnrCode, verdiType: 'FNR_CODE' },
+                { fnr: sokFnrCode, verdiType: 'FNR_CODE' },
                 {
                     onSuccess: (res) => {
                         const url = removeParamFromURL('sokFnrCode');
                         window.history.replaceState(null, '', url.toString());
-                        handleLegacyUrls(res.aktivBruker, behandlingsId, oppgaveId, oppgaveData);
+                        handleLegacyUrls(res.aktivBruker, traadId, oppgaveId, oppgaveData);
                     }
                 }
             );
         } else {
-            handleLegacyUrls(queryParams.sokFnr ?? validFnr, behandlingsId, oppgaveId, oppgaveData);
+            handleLegacyUrls(sokFnr ?? validFnr, traadId, oppgaveId, oppgaveData);
             setDelayRender(false);
         }
     }, [isLoading, oppgaveData]);
 
-    const handleLegacyUrls = (fnr?: string, behandlingsId?: string, oppgaveId?: string, oppgaveData?: OppgaveDto) => {
-        if (oppgaveId && behandlingsId && fnr) {
+    const handleLegacyUrls = (fnr?: string, traadId?: string, oppgaveId?: string, oppgaveData?: OppgaveDto) => {
+        if (oppgaveId && traadId && fnr) {
             settGjeldendeBruker(fnr, false);
             trackDyplenkeFraEksternKilde('oppgave');
-            navigerTilTraadOgApneSvar(behandlingsId);
-        } else if (fnr && behandlingsId) {
+            navigerTilTraadOgApneSvar(traadId);
+        } else if (fnr && traadId) {
             trackDyplenkeFraEksternKilde('henvendelse');
             settGjeldendeBruker(fnr, false);
-            navigerTilTraadOgApneSvar(behandlingsId);
-        } else if (behandlingsId) {
+            navigerTilTraadOgApneSvar(traadId);
+        } else if (traadId) {
             trackDyplenkeFraEksternKilde('henvendelse');
-            navigerTilTraadOgApneSvar(behandlingsId);
+            navigerTilTraadOgApneSvar(traadId);
         } else if (oppgaveData) {
             trackDyplenkeFraEksternKilde('kun oppgave');
             if (!oppgaveData.fnr) return;

--- a/src/utils/analytics.ts
+++ b/src/utils/analytics.ts
@@ -35,7 +35,8 @@ export enum trackingEvents {
     sendNyMelding = 'send ny melding',
     fortsettDialog = 'fortsett dialog',
     brukStandardtekst = 'bruk standardtekst',
-    brukAutofullfor = 'bruk autofullfør'
+    brukAutofullfor = 'bruk autofullfør',
+    eksternDyplenke = 'ekstern dyplenke'
 }
 
 export enum filterType {
@@ -47,6 +48,14 @@ export enum filterType {
     SOK = 'søk',
     TEMA = 'tema'
 }
+
+export const trackDyplenkeFraEksternKilde = (tekst: string) => {
+    if (!window.umami) {
+        console.warn('Umami is not initialized. Ignoring');
+        return;
+    }
+    window.umami.track(trackingEvents.eksternDyplenke, { tekst });
+};
 
 export const trackFortsettDialog = (traadType: string) => {
     if (!window.umami) {

--- a/src/utils/url-utils.ts
+++ b/src/utils/url-utils.ts
@@ -7,7 +7,7 @@ export function parseQueryString<TYPE>(queryParams: string): TYPE {
         .split('&')
         .map((it) => it.split('='));
     //biome-ignore lint/performance/noAccumulatingSpread: biome migration
-    return entries.reduce((acc, entry) => ({ ...acc, [entry[0].toLowerCase()]: entry[1] }), {} as TYPE);
+    return entries.reduce((acc, entry) => ({ ...acc, [entry[0]]: entry[1] }), {} as TYPE);
 }
 
 export function useQueryParams<TYPE>(): TYPE {

--- a/src/utils/url-utils.ts
+++ b/src/utils/url-utils.ts
@@ -7,7 +7,7 @@ export function parseQueryString<TYPE>(queryParams: string): TYPE {
         .split('&')
         .map((it) => it.split('='));
     //biome-ignore lint/performance/noAccumulatingSpread: biome migration
-    return entries.reduce((acc, entry) => ({ ...acc, [entry[0]]: entry[1] }), {} as TYPE);
+    return entries.reduce((acc, entry) => ({ ...acc, [entry[0].toLowerCase()]: entry[1] }), {} as TYPE);
 }
 
 export function useQueryParams<TYPE>(): TYPE {


### PR DESCRIPTION
Det var kun nokre få bugs, men mest opprydning i logikken som har fungert ein gang i tiden.

Det er muleg å bruke dyplenker på ulike måter. Om appen som kaller dyplenken ikkje brukar contextholderen så er det muleg å sette bruker på ulike andre måter via url: 

1. `/sokFnrCode=<code>`. Det blir gjort eit kall til contextholderen der koden blir gjort om til eit fødselsnummer i contextholderen og bruker blir satt.
2. /`person/<fnr>`.  fnr rett i url. Då blir det gjort eit kall til contextholderen direkte med fnr.
3. Ingen bruk av fødselsnummer, men kun oppgave-id `?oppgaveid=1234`. Det blir gjort eit kall til oppgave-api som returnerer oppgavedata som blant annen inneholder fødseslnummer og trådid.

Det kan også sendes med `behandlingsId` eller `henvendelseId` som blir bruk til å sette trådID. Då blir  url `/kommunikasjons/traadId=<x>`

Kva er fiksa og rydda?
- Om det kun sendes fnr så blir veileder navigert til kommunikasjonsfanen (dette er ein fiks)
- Såg at Gosys var litt inkonsekvente på liten og stor bokstav i henvendelseId/henvendelseid,  så no er ikkje søket lenger case-sensitivt.
- Bruker umami for å tracke bruk av dyplenkene
- Har brukt tanstack query til å sende request til contextholder. Har laga ei ny fil for klienten.
- Det fungerte ikkje å sende kun oppgaveId fordi dataen var ikkje loadet før etter redirect, så har fiksa på det og.

Dette skal fungere både i nye og gamle modia.


