### PR TITLE
Bugfix: Avslutt oppgaver når dialog avsluttes

### DIFF
--- a/src/components/Meldinger/Detail/Meldinger.tsx
+++ b/src/components/Meldinger/Detail/Meldinger.tsx
@@ -61,7 +61,7 @@ export const Meldinger = ({ meldinger, wrapper: Wrapper = DefaultWrapper }: Prop
                                 timestamp={formatterDatoTid(m.opprettetDato)}
                                 position={erFraNav ? 'right' : 'left'}
                                 className={erFraNav ? 'self-end' : undefined}
-                                variant={erFraNav ? 'info' : 'neutral'}
+                                data-color={erFraNav ? 'brand-blue' : 'neutral'}
                             >
                                 <Chat.Bubble className="text-wrap">
                                     <RichText

--- a/src/components/Meldinger/Detail/Meldinger.tsx
+++ b/src/components/Meldinger/Detail/Meldinger.tsx
@@ -57,7 +57,7 @@ export const Meldinger = ({ meldinger, wrapper: Wrapper = DefaultWrapper }: Prop
                             <Chat
                                 size="small"
                                 avatar={erFraNav ? 'nav' : <PersonIcon />}
-                                name={m.skrevetAvTekst}
+                                name={erFraNav ? m.skrevetAvTekst : undefined}
                                 timestamp={formatterDatoTid(m.opprettetDato)}
                                 position={erFraNav ? 'right' : 'left'}
                                 className={erFraNav ? 'self-end' : undefined}

--- a/src/components/Meldinger/Merk.tsx
+++ b/src/components/Meldinger/Merk.tsx
@@ -12,17 +12,19 @@ import {
     VStack
 } from '@navikt/ds-react';
 import { useAtomValue } from 'jotai';
-import { Suspense, useCallback, useState } from 'react';
+import { Suspense, useState } from 'react';
 import { AlertBanner } from 'src/components/AlertBanner';
 import ErrorBoundary from 'src/components/ErrorBoundary';
 import {
     useAvsluttDialogMutation,
+    useAvsluttOppgaveMutation,
     useMarkerFeilsendtMutation,
+    usePersonOppgaver,
     useSendTilSladdingMutation,
     useSladdeAarsaker
 } from 'src/lib/clients/modiapersonoversikt-api';
 import { aktivEnhetAtom, usePersonAtomValue } from 'src/lib/state/context';
-import type { Traad } from 'src/lib/types/modiapersonoversikt-api';
+import type { OppgaveDto, Traad } from 'src/lib/types/modiapersonoversikt-api';
 import { trackGenereltUmamiEvent, trackingEvents } from 'src/utils/analytics';
 import { Meldinger } from './Detail/Meldinger';
 import { erMeldingFeilsendt } from './List/utils';
@@ -41,25 +43,41 @@ export const AvsluttDialogModal = ({ traad, open, onClose }: ModalProps) => {
     const enhetId = useAtomValue(aktivEnhetAtom);
     const fnr = usePersonAtomValue();
     const { mutate, isPending } = useAvsluttDialogMutation();
+    const { mutate: mutateOppgave } = useAvsluttOppgaveMutation();
 
-    const avsluttDialog = useCallback(() => {
+    const { data: oppgaver = [] } = usePersonOppgaver();
+
+    const traadOppgaver = oppgaver?.filter((oppagve: OppgaveDto) => oppagve.traadId === traad.traadId);
+
+    const avsluttDialog = () => {
         trackGenereltUmamiEvent(trackingEvents.merkDialog, { tekst: 'lukk' });
         mutate(
             {
                 body: {
                     fnr,
                     traadId: traad.traadId,
-                    saksbehandlerValgtEnhet: enhetId as string
+                    saksbehandlerValgtEnhet: enhetId as string,
+                    oppgaveId: traadOppgaver[0]?.oppgaveId ?? undefined
                 }
             },
             {
                 onSettled: () => {
+                    // Avslutt resten av oppgavene som tilhører tråden om det er flere enn 1
+                    for (const oppgave of traadOppgaver.slice(1)) {
+                        mutateOppgave({
+                            body: {
+                                oppgaveid: oppgave.oppgaveId,
+                                fnr,
+                                saksbehandlerValgtEnhet: enhetId as string,
+                                beskrivelse: 'Dialog avsluttet'
+                            }
+                        });
+                    }
                     onClose();
                 }
             }
         );
-    }, [fnr, mutate, traad, enhetId, onClose]);
-
+    };
     return (
         <Modal
             open={open}
@@ -74,7 +92,7 @@ export const AvsluttDialogModal = ({ traad, open, onClose }: ModalProps) => {
         >
             <Modal.Body>
                 <InlineMessage status="warning">
-                    Ved avslutting blir dialogen låst og oppgave ferdigstilt. Det er ikke mulig å sende flere meldinger
+                    Ved avslutting blir dialogen låst og oppgaver ferdigstilt. Det er ikke mulig å sende flere meldinger
                     i denne dialogen i ettertid.
                 </InlineMessage>
             </Modal.Body>
@@ -94,7 +112,7 @@ export const MarkerFeilsendtModal = ({ traad, open, onClose }: ModalProps) => {
     const fnr = usePersonAtomValue();
     const { mutate, isPending } = useMarkerFeilsendtMutation();
 
-    const merkFeilsendt = useCallback(() => {
+    const merkFeilsendt = () => {
         trackGenereltUmamiEvent(trackingEvents.merkDialog, { tekst: 'feilsendt' });
         if (!traad) {
             onClose();
@@ -111,7 +129,7 @@ export const MarkerFeilsendtModal = ({ traad, open, onClose }: ModalProps) => {
                 }
             }
         );
-    }, [mutate, fnr, traad, onClose]);
+    };
 
     return (
         <Modal

--- a/src/lib/clients/modiapersonoversikt-api.ts
+++ b/src/lib/clients/modiapersonoversikt-api.ts
@@ -266,6 +266,11 @@ export const useAvsluttDialogMutation = () => {
                     params: { query: { enhet } }
                 }).queryKey
             });
+            queryClient.invalidateQueries({
+                queryKey: $api.queryOptions('post', '/rest/oppgaver/tildelt', {
+                    body: { fnr }
+                }).queryKey
+            });
             toast.success('Tråden ble avsluttet');
         },
         onError: () => {


### PR DESCRIPTION
**To fikser:**
- Fjernet avsendernavn på meldinger som kommer fra bruker. I gamle modia viser vi ingenting, men i nye modia ser det ut som på bildet under, for me får ikkje navnet sendt med i responsen. Det trengst heller ikkje når det kun er ein person meldingane kan komme frå.
- Det står at oppgaver skal avsluttes når dialog avsluttes. Dette har vi ikkje håndheva. Det er muleg å sende med 1 oppgaveid i lukkdialog, men om det er fleire oppgaver på tråd sender sender vi no request til eget endepunkt for å avslutte.

<img width="394" height="120" alt="image" src="https://github.com/user-attachments/assets/bfbee74b-ca16-440f-848c-928a198586e9" />

https://trello.com/c/nTLJMPlq/290-avslutt-oppgaveid-ved-manuell-avslutting-av-tr%C3%A5d-og-fjern-navn-p%C3%A5-melding-fra-bruker