### PR TITLE
Lukker åpent meldingspanel ved søk etter ny person

### DIFF
--- a/src/app/personside/infotabs/meldinger/traadvisning/__snapshots__/TraadVisningWrapper.test.tsx.snap
+++ b/src/app/personside/infotabs/meldinger/traadvisning/__snapshots__/TraadVisningWrapper.test.tsx.snap
@@ -2,7 +2,48 @@
 
 exports[`Viser traad med verktøylinje 1`] = `
 <DocumentFragment>
-  .c26 .snakkeboble-panel {
+  .c16 .ekspanderbartPanel {
+  position: relative;
+}
+
+.c16 .ekspanderbartPanel__hode {
+  padding: 0.35rem 0.5rem;
+  position: sticky;
+  top: 0;
+}
+
+.c16 .ekspanderbartPanel__innhold {
+  padding: 0.3rem;
+}
+
+.c14 {
+  display: flex;
+}
+
+.c14 >* {
+  margin: 0;
+}
+
+.c14 >*:not(:last-child) {
+  margin-right: 1rem;
+}
+
+.c15 .radioknapp+label {
+  cline-height: 1.25rem;
+}
+
+.c15 .radioknapp+label:before {
+  height: 1.25rem;
+  width: 1.25rem;
+}
+
+.c13 {
+  position: relative;
+  text-align: center;
+  padding-top: 1rem;
+}
+
+.c26 .snakkeboble-panel {
   flex-basis: 40rem;
   padding: 0.5rem 0.5rem 0.3rem;
 }
@@ -152,47 +193,6 @@ exports[`Viser traad med verktøylinje 1`] = `
   margin-bottom: 2rem;
   border-bottom: solid 0.0625rem #78706a;
   page-break-inside: avoid;
-}
-
-.c16 .ekspanderbartPanel {
-  position: relative;
-}
-
-.c16 .ekspanderbartPanel__hode {
-  padding: 0.35rem 0.5rem;
-  position: sticky;
-  top: 0;
-}
-
-.c16 .ekspanderbartPanel__innhold {
-  padding: 0.3rem;
-}
-
-.c14 {
-  display: flex;
-}
-
-.c14 >* {
-  margin: 0;
-}
-
-.c14 >*:not(:last-child) {
-  margin-right: 1rem;
-}
-
-.c15 .radioknapp+label {
-  cline-height: 1.25rem;
-}
-
-.c15 .radioknapp+label:before {
-  height: 1.25rem;
-  width: 1.25rem;
-}
-
-.c13 {
-  position: relative;
-  text-align: center;
-  padding-top: 1rem;
 }
 
 .c22 {

--- a/src/app/personside/infotabs/ytelser/__snapshots__/ValgtYtelse.test.tsx.snap
+++ b/src/app/personside/infotabs/ytelser/__snapshots__/ValgtYtelse.test.tsx.snap
@@ -2,34 +2,7 @@
 
 exports[`Om sykepenger matcher snapshot 1`] = `
 <DocumentFragment>
-  .c4 {
-  border-radius: 0.5rem;
-  background-color: #f1f0f0;
-  box-shadow: inset 0 0 0 0.3rem white,inset 0 0 0 0.37rem rgba(0, 0, 0, 0.15);
-  padding: 1.25rem;
-}
-
-.c4 >h3 {
-  margin-bottom: 1rem;
-}
-
-.c5 {
-  display: flex;
-  flex-wrap: wrap;
-}
-
-.c5 dt {
-  color: #645f5a;
-}
-
-.c5 >div {
-  margin: 0.5625rem 0;
-  padding-right: 0.7rem;
-  width: 13rem;
-  overflow-wrap: break-word;
-}
-
-.c6 {
+  .c6 {
   overflow: auto;
   box-shadow: 0 0 0 0.07rem rgba(0, 0, 0, 0.25);
   border-radius: .25rem;
@@ -59,6 +32,33 @@ exports[`Om sykepenger matcher snapshot 1`] = `
 
 .c6 [role='table'] [role='row']:nth-child(even) {
   background-color: rgba(0, 0, 0, 0.1);
+}
+
+.c4 {
+  border-radius: 0.5rem;
+  background-color: #f1f0f0;
+  box-shadow: inset 0 0 0 0.3rem white,inset 0 0 0 0.37rem rgba(0, 0, 0, 0.15);
+  padding: 1.25rem;
+}
+
+.c4 >h3 {
+  margin-bottom: 1rem;
+}
+
+.c5 {
+  display: flex;
+  flex-wrap: wrap;
+}
+
+.c5 dt {
+  color: #645f5a;
+}
+
+.c5 >div {
+  margin: 0.5625rem 0;
+  padding-right: 0.7rem;
+  width: 13rem;
+  overflow-wrap: break-word;
 }
 
 .c7 li:not(:first-child) {

--- a/src/app/personside/infotabs/ytelser/sykepenger/sykemelding/__snapshots__/Sykemelding.test.tsx.snap
+++ b/src/app/personside/infotabs/ytelser/sykepenger/sykemelding/__snapshots__/Sykemelding.test.tsx.snap
@@ -2,23 +2,7 @@
 
 exports[`Sykemelding matcher snapshot 1`] = `
 <DocumentFragment>
-  .c1 {
-  display: flex;
-  flex-wrap: wrap;
-}
-
-.c1 dt {
-  color: #645f5a;
-}
-
-.c1 >div {
-  margin: 0.5625rem 0;
-  padding-right: 0.7rem;
-  width: 13rem;
-  overflow-wrap: break-word;
-}
-
-.c2 {
+  .c2 {
   overflow: auto;
   box-shadow: 0 0 0 0.07rem rgba(0, 0, 0, 0.25);
   border-radius: .25rem;
@@ -48,6 +32,22 @@ exports[`Sykemelding matcher snapshot 1`] = `
 
 .c2 [role='table'] [role='row']:nth-child(even) {
   background-color: rgba(0, 0, 0, 0.1);
+}
+
+.c1 {
+  display: flex;
+  flex-wrap: wrap;
+}
+
+.c1 dt {
+  color: #645f5a;
+}
+
+.c1 >div {
+  margin: 0.5625rem 0;
+  padding-right: 0.7rem;
+  width: 13rem;
+  overflow-wrap: break-word;
 }
 
 .c0 {

--- a/src/components/melding/SendMelding.tsx
+++ b/src/components/melding/SendMelding.tsx
@@ -10,7 +10,10 @@ import {
 } from 'src/components/melding/BetaKommunikasjon/IkkeLukkbarNyMelding';
 import { useMeldinger, usePersonData } from 'src/lib/clients/modiapersonoversikt-api';
 import { aktivBrukerAtom } from 'src/lib/state/context';
-import { overskridKontaktReservasjonAtom, svarUnderArbeidAtom } from 'src/lib/state/dialog';
+import {
+    overskridKontaktReservasjonAtom,
+    svarUnderArbeidAtom
+} from 'src/lib/state/dialog';
 import { type Traad, type TraadDto, TraadType } from 'src/lib/types/modiapersonoversikt-api';
 import { type Temagruppe, temagruppeTekst } from 'src/lib/types/temagruppe';
 import { formatterDato } from 'src/utils/date-utils';
@@ -88,6 +91,12 @@ const SendMeldingContent = ({
     const [dialogUnderArbeid, setDialogUnderArbeid] = useAtom(svarUnderArbeidAtom);
     const traad = useMemo(() => traader.find((m) => m.traadId === dialogUnderArbeid), [traader, dialogUnderArbeid]);
     const [meldingsTittel, setMeldingsTittel] = useState(meldingsHeader(traad));
+
+    useEffect(() => {
+        if (dialogUnderArbeid !== undefined && traad === undefined) {
+            setDialogUnderArbeid(undefined);
+        }
+    }, [dialogUnderArbeid, traad]);
 
     const [suksessMelding, setSuksessMelding] = useAtom(dialogSuksessMeldingAtom);
     const [feilMelding, setFeilMelding] = useAtom(dialogFeilMeldingAtom);

--- a/src/components/melding/SendMelding.tsx
+++ b/src/components/melding/SendMelding.tsx
@@ -10,10 +10,7 @@ import {
 } from 'src/components/melding/BetaKommunikasjon/IkkeLukkbarNyMelding';
 import { useMeldinger, usePersonData } from 'src/lib/clients/modiapersonoversikt-api';
 import { aktivBrukerAtom } from 'src/lib/state/context';
-import {
-    overskridKontaktReservasjonAtom,
-    svarUnderArbeidAtom
-} from 'src/lib/state/dialog';
+import { overskridKontaktReservasjonAtom, svarUnderArbeidAtom } from 'src/lib/state/dialog';
 import { type Traad, type TraadDto, TraadType } from 'src/lib/types/modiapersonoversikt-api';
 import { type Temagruppe, temagruppeTekst } from 'src/lib/types/temagruppe';
 import { formatterDato } from 'src/utils/date-utils';

--- a/src/utils/customHooks.ts
+++ b/src/utils/customHooks.ts
@@ -1,5 +1,5 @@
 import { useNavigate } from '@tanstack/react-router';
-import { useAtomValue, useSetAtom } from 'jotai';
+import { useAtomValue, useSetAtom, useStore } from 'jotai';
 import { eq } from 'lodash';
 import type * as React from 'react';
 import {
@@ -15,6 +15,7 @@ import {
 import { useSelector } from 'react-redux';
 import { nyModiaAtom } from 'src/components/NyModia';
 import { aktivBrukerAtom } from 'src/lib/state/context';
+import { meldingPanelIsOpenAtom, nyMeldingUnderArbeidAtom, svarUnderArbeidAtom } from 'src/lib/state/dialog';
 import { trackBrukerEndret } from 'src/utils/analytics';
 import { paths } from '../app/routes/routing';
 import type { AppState } from '../redux/reducers';
@@ -90,11 +91,19 @@ export function useSettAktivBruker() {
     const setBruker = useSetAtom(aktivBrukerAtom);
     const nyModia = useAtomValue(nyModiaAtom);
     const navigate = useNavigate();
+    const store = useStore();
+
     return (fnr: string | null, redirect = true) => {
         if (!fnr) {
             navigate({ to: '/' });
             setBruker('');
             return;
+        }
+
+        const currentFnr = store.get(aktivBrukerAtom);
+        if (currentFnr && fnr !== currentFnr && store.get(meldingPanelIsOpenAtom)) {
+            store.set(svarUnderArbeidAtom, undefined);
+            store.set(nyMeldingUnderArbeidAtom, false);
         }
 
         setBruker(fnr);

--- a/src/utils/customHooks.ts
+++ b/src/utils/customHooks.ts
@@ -1,5 +1,5 @@
 import { useNavigate } from '@tanstack/react-router';
-import { useAtomValue, useSetAtom, useStore } from 'jotai';
+import { useAtom, useAtomValue, useSetAtom } from 'jotai';
 import { eq } from 'lodash';
 import type * as React from 'react';
 import {
@@ -88,10 +88,12 @@ export function useAppState<T>(selector: (state: AppState) => T) {
 }
 
 export function useSettAktivBruker() {
-    const setBruker = useSetAtom(aktivBrukerAtom);
+    const [currentFnr, setBruker] = useAtom(aktivBrukerAtom);
     const nyModia = useAtomValue(nyModiaAtom);
     const navigate = useNavigate();
-    const store = useStore();
+    const meldingPanelIsOpen = useAtomValue(meldingPanelIsOpenAtom);
+    const setSvarUnderArbeid = useSetAtom(svarUnderArbeidAtom);
+    const setNyMeldingUnderArbeid = useSetAtom(nyMeldingUnderArbeidAtom);
 
     return (fnr: string | null, redirect = true) => {
         if (!fnr) {
@@ -100,10 +102,9 @@ export function useSettAktivBruker() {
             return;
         }
 
-        const currentFnr = store.get(aktivBrukerAtom);
-        if (currentFnr && fnr !== currentFnr && store.get(meldingPanelIsOpenAtom)) {
-            store.set(svarUnderArbeidAtom, undefined);
-            store.set(nyMeldingUnderArbeidAtom, false);
+        if (currentFnr && fnr !== currentFnr && meldingPanelIsOpen) {
+            setSvarUnderArbeid(undefined);
+            setNyMeldingUnderArbeid(false);
         }
 
         setBruker(fnr);


### PR DESCRIPTION
Med det nye oppsettet for kommunikasjon ville man ved å ha en åpen dialog (enten ny melding eller svar på eksisterende) og søk etter ny person få opp feilmeldingen "Fant ikke dialogen under arbeid" hver gang. 

<img width="614" height="248" alt="image" src="https://github.com/user-attachments/assets/8823ad7b-84d9-4087-9b8e-351810de5823" />

Med denne fiksen vil meldingspanelet bli lukket når man søker opp ny person slik at man unngår denne feilmeldingen