### PR TITLE
Bugfix ny kommunikasjon

### DIFF
--- a/src/components/melding/FortsettDialog.tsx
+++ b/src/components/melding/FortsettDialog.tsx
@@ -1,4 +1,4 @@
-import { Bleed, Box, Button, Checkbox, HStack, InlineMessage, Loader, VStack } from '@navikt/ds-react';
+import { Alert, Bleed, Box, Button, Checkbox, Dialog, HStack, InlineMessage, Loader, VStack } from '@navikt/ds-react';
 import { useForm, type ValidationError } from '@tanstack/react-form';
 import { useSearch } from '@tanstack/react-router';
 import { useAtomValue, useSetAtom } from 'jotai';
@@ -9,6 +9,7 @@ import useDraft from 'src/app/personside/dialogpanel/use-draft';
 import { FeatureToggles } from 'src/components/featureToggle/toggleIDs';
 import useFeatureToggle from 'src/components/featureToggle/useFeatureToggle';
 import { Link } from 'src/components/Link';
+import { traadstittel } from 'src/components/Meldinger/List/utils';
 import { AvbrytAlert } from 'src/components/melding/BetaKommunikasjon/AvbrytAlert';
 import AutoCompleteTekstTips from 'src/components/melding/standardtekster/AutoCompleteTekstTips';
 import StandardTekstModal from 'src/components/melding/standardtekster/StandardTeksterModal';
@@ -23,6 +24,7 @@ import {
     type Traad,
     TraadType
 } from 'src/lib/types/modiapersonoversikt-api';
+import { type Temagruppe, temagruppeTekst } from 'src/lib/types/temagruppe';
 import { trackFortsettDialog } from 'src/utils/analytics';
 import useDynamicHeightTextArea from 'src/utils/hooks/use-dynamic-height-text-area';
 import type { z } from 'zod';
@@ -52,6 +54,7 @@ export const FortsettDialog = ({ traad }: Props) => {
     const { isOn: isNyKommunikasjonEnabled } = useFeatureToggle(FeatureToggles.NyKommunikasjon);
     const minRows = useDynamicHeightTextArea();
     const erValgtTraad = !search?.traadId || search?.traadId === traad.traadId;
+    const [openDialog, setOpenDialog] = useState(false);
 
     // Brukes for å sette initialverdien til meldingen basert på draften
     const [defaultMessage, setDefaultMessage] = useState('');
@@ -123,7 +126,7 @@ export const FortsettDialog = ({ traad }: Props) => {
         >
             <VStack gap="space-16">
                 {!erValgtTraad && (
-                    <InlineMessage size="small" status="warning" className="mt-2">
+                    <Alert size="small" variant="warning" className="mt-2">
                         Dialogen du nå svarer til, er ikke den som vises til venstre.
                         <Link
                             to="/new/person/meldinger"
@@ -132,7 +135,7 @@ export const FortsettDialog = ({ traad }: Props) => {
                         >
                             Gå til aktuell dialog
                         </Link>
-                    </InlineMessage>
+                    </Alert>
                 )}
                 {!erSamtalereferat && (
                     <>
@@ -233,7 +236,15 @@ export const FortsettDialog = ({ traad }: Props) => {
                             </HStack>
                             <HStack justify="end" gap="space-8" align="center" flexGrow="1" maxWidth="fit-content">
                                 <Button
-                                    type="submit"
+                                    aria-controls={openDialog ? 'svar-warning' : undefined}
+                                    onClick={(e) => {
+                                        e.preventDefault();
+                                        if (erValgtTraad) {
+                                            form.handleSubmit();
+                                        } else {
+                                            setOpenDialog(true);
+                                        }
+                                    }}
                                     data-testid="svar-knapp-fortsett-dialog"
                                     size="small"
                                     disabled={disableDialog || isPending}
@@ -267,6 +278,31 @@ export const FortsettDialog = ({ traad }: Props) => {
                     </Bleed>
                 </VStack>
             </VStack>
+            <Dialog open={openDialog} onOpenChange={setOpenDialog}>
+                <Dialog.Popup id="svar-warning">
+                    <Dialog.Header>
+                        <Dialog.Title>
+                            Svar på {traadstittel(traad).toLowerCase()} (
+                            {temagruppeTekst(traad.temagruppe as Temagruppe)})
+                        </Dialog.Title>
+                    </Dialog.Header>
+                    <Dialog.Body>
+                        <InlineMessage status="warning">
+                            Dialogen du nå svarer til, er ikke dialogen du har åpen
+                        </InlineMessage>
+                    </Dialog.Body>
+                    <Dialog.Footer>
+                        <Dialog.CloseTrigger>
+                            <Button variant="secondary" data-color="neutral">
+                                Avbryt
+                            </Button>
+                        </Dialog.CloseTrigger>
+                        <Dialog.CloseTrigger>
+                            <Button>Send melding</Button>
+                        </Dialog.CloseTrigger>
+                    </Dialog.Footer>
+                </Dialog.Popup>
+            </Dialog>
         </form>
     );
 };

--- a/src/components/melding/FortsettDialog.tsx
+++ b/src/components/melding/FortsettDialog.tsx
@@ -9,7 +9,7 @@ import useDraft from 'src/app/personside/dialogpanel/use-draft';
 import { FeatureToggles } from 'src/components/featureToggle/toggleIDs';
 import useFeatureToggle from 'src/components/featureToggle/useFeatureToggle';
 import { Link } from 'src/components/Link';
-import { traadstittel } from 'src/components/Meldinger/List/utils';
+import { getFormattertMeldingsDato, nyesteMelding, traadstittel } from 'src/components/Meldinger/List/utils';
 import { AvbrytAlert } from 'src/components/melding/BetaKommunikasjon/AvbrytAlert';
 import AutoCompleteTekstTips from 'src/components/melding/standardtekster/AutoCompleteTekstTips';
 import StandardTekstModal from 'src/components/melding/standardtekster/StandardTeksterModal';
@@ -283,7 +283,8 @@ export const FortsettDialog = ({ traad }: Props) => {
                     <Dialog.Header>
                         <Dialog.Title>
                             Svar på {traadstittel(traad).toLowerCase()} (
-                            {temagruppeTekst(traad.temagruppe as Temagruppe)})
+                            {temagruppeTekst(traad.temagruppe as Temagruppe)}{' '}
+                            {getFormattertMeldingsDato(nyesteMelding(traad)).slice(0, 8)})
                         </Dialog.Title>
                     </Dialog.Header>
                     <Dialog.Body>
@@ -298,7 +299,7 @@ export const FortsettDialog = ({ traad }: Props) => {
                             </Button>
                         </Dialog.CloseTrigger>
                         <Dialog.CloseTrigger>
-                            <Button>Send melding</Button>
+                            <Button onClick={form.handleSubmit}>Send melding</Button>
                         </Dialog.CloseTrigger>
                     </Dialog.Footer>
                 </Dialog.Popup>

--- a/src/components/melding/FortsettDialog.tsx
+++ b/src/components/melding/FortsettDialog.tsx
@@ -235,23 +235,6 @@ export const FortsettDialog = ({ traad }: Props) => {
                                 />
                             </HStack>
                             <HStack justify="end" gap="space-8" align="center" flexGrow="1" maxWidth="fit-content">
-                                <Button
-                                    aria-controls={openDialog ? 'svar-warning' : undefined}
-                                    onClick={(e) => {
-                                        e.preventDefault();
-                                        if (erValgtTraad) {
-                                            form.handleSubmit();
-                                        } else {
-                                            setOpenDialog(true);
-                                        }
-                                    }}
-                                    data-testid="svar-knapp-fortsett-dialog"
-                                    size="small"
-                                    disabled={disableDialog || isPending}
-                                    loading={isPending}
-                                >
-                                    Send til {brukerNavn} {oppgaveId ? 'og avslutt oppgave' : ''}
-                                </Button>
                                 {isNyKommunikasjonEnabled ? (
                                     <AvbrytAlert
                                         disablePopup={form.getFieldValue('melding').length === 0}
@@ -273,6 +256,23 @@ export const FortsettDialog = ({ traad }: Props) => {
                                         Avbryt
                                     </Button>
                                 )}
+                                <Button
+                                    aria-controls={openDialog ? 'svar-warning' : undefined}
+                                    onClick={(e) => {
+                                        e.preventDefault();
+                                        if (erValgtTraad) {
+                                            form.handleSubmit();
+                                        } else {
+                                            setOpenDialog(true);
+                                        }
+                                    }}
+                                    data-testid="svar-knapp-fortsett-dialog"
+                                    size="small"
+                                    disabled={disableDialog || isPending}
+                                    loading={isPending}
+                                >
+                                    Send til {brukerNavn} {oppgaveId ? 'og avslutt oppgave' : ''}
+                                </Button>
                             </HStack>
                         </HStack>
                     </Bleed>

--- a/src/components/melding/NyMelding.tsx
+++ b/src/components/melding/NyMelding.tsx
@@ -211,15 +211,6 @@ function NyMelding() {
                                 />
                             </HStack>
                             <HStack justify="end" gap="space-8" align="center" flexGrow="1" maxWidth="fit-content">
-                                <Button
-                                    disabled={disableDialog || isPending}
-                                    type="submit"
-                                    size="small"
-                                    data-testid="svar-knapp"
-                                    loading={isPending}
-                                >
-                                    Send til {brukerNavn}
-                                </Button>
                                 {isNyKommunikasjonEnabled && (
                                     <AvbrytAlert
                                         disablePopup={form.getFieldValue('melding').length === 0}
@@ -229,6 +220,15 @@ function NyMelding() {
                                         }}
                                     />
                                 )}
+                                <Button
+                                    disabled={disableDialog || isPending}
+                                    type="submit"
+                                    size="small"
+                                    data-testid="svar-knapp"
+                                    loading={isPending}
+                                >
+                                    Send til {brukerNavn}
+                                </Button>
                             </HStack>
                         </HStack>
                     </Bleed>

--- a/src/lib/state/dialog.ts
+++ b/src/lib/state/dialog.ts
@@ -1,9 +1,8 @@
 import { atom, useAtomValue } from 'jotai';
-import { atomWithStorage } from 'jotai/utils';
 import { usePersonData } from 'src/lib/clients/modiapersonoversikt-api';
 
-export const svarUnderArbeidAtom = atomWithStorage<string | undefined>('svar-under-arbeid', undefined);
-export const nyMeldingUnderArbeidAtom = atomWithStorage<boolean>('ny-melding-under-arbeid', false);
+export const svarUnderArbeidAtom = atom<string | undefined>(undefined);
+export const nyMeldingUnderArbeidAtom = atom<boolean>(false);
 export const draftAtom = atom<string>('');
 export const overskridKontaktReservasjonAtom = atom<boolean>(false);
 export const meldingPanelIsOpenAtom = atom(


### PR DESCRIPTION
**Denne PRen har tre commiter som er tre ulike fikser.**

1. Ein bugfix. Endra frå "atom with storage" til vanleg atom. Atom with storage betyr at localstorage blir brukt til å lagre om ein ny melding er under arbeid, eller svar er under arbeid. Dette lagar trøbbel om ein veileder har oppe to brukarar samtidig. Då fungerer det ikkje å klikke på svar-knappen. Om det mot formodning skjer noko som gjer at dei må starte på nytt så blir draften lagra, så ingen skade skjedd. 
2. Det var ikkje tydeleg nok om ein stod i ein anna dialog enn den ein faktisk svarar på, så endra frå inline message til stor alert. La også på ein dialog som også viser ein warning om at du er på ein ulik dialog enn den du svarer på, for sikkerhetsskyld. 
3. Det er naturleg at primaryknappen er til høgre når du har to valg, så har endra rekkefølge på på avbrytknapp og send-melding knapp.