### PR TITLE
Endre rekkefolge på knapper ved wrap

### DIFF
--- a/src/components/melding/FortsettDialog.tsx
+++ b/src/components/melding/FortsettDialog.tsx
@@ -234,7 +234,31 @@ export const FortsettDialog = ({ traad }: Props) => {
                                     }
                                 />
                             </HStack>
-                            <HStack justify="end" gap="space-8" align="center" flexGrow="1" maxWidth="fit-content">
+                            <HStack
+                                justify="end"
+                                gap="space-8"
+                                align="center"
+                                flexGrow="1"
+                                maxWidth="fit-content"
+                                className="flex-row-reverse"
+                            >
+                                <Button
+                                    aria-controls={openDialog ? 'svar-warning' : undefined}
+                                    onClick={(e) => {
+                                        e.preventDefault();
+                                        if (erValgtTraad) {
+                                            form.handleSubmit();
+                                        } else {
+                                            setOpenDialog(true);
+                                        }
+                                    }}
+                                    data-testid="svar-knapp-fortsett-dialog"
+                                    size="small"
+                                    disabled={disableDialog || isPending}
+                                    loading={isPending}
+                                >
+                                    Send til {brukerNavn} {oppgaveId ? 'og avslutt oppgave' : ''}
+                                </Button>
                                 {isNyKommunikasjonEnabled ? (
                                     <AvbrytAlert
                                         disablePopup={form.getFieldValue('melding').length === 0}
@@ -256,23 +280,6 @@ export const FortsettDialog = ({ traad }: Props) => {
                                         Avbryt
                                     </Button>
                                 )}
-                                <Button
-                                    aria-controls={openDialog ? 'svar-warning' : undefined}
-                                    onClick={(e) => {
-                                        e.preventDefault();
-                                        if (erValgtTraad) {
-                                            form.handleSubmit();
-                                        } else {
-                                            setOpenDialog(true);
-                                        }
-                                    }}
-                                    data-testid="svar-knapp-fortsett-dialog"
-                                    size="small"
-                                    disabled={disableDialog || isPending}
-                                    loading={isPending}
-                                >
-                                    Send til {brukerNavn} {oppgaveId ? 'og avslutt oppgave' : ''}
-                                </Button>
                             </HStack>
                         </HStack>
                     </Bleed>

--- a/src/components/melding/NyMelding.tsx
+++ b/src/components/melding/NyMelding.tsx
@@ -210,16 +210,14 @@ function NyMelding() {
                                     }
                                 />
                             </HStack>
-                            <HStack justify="end" gap="space-8" align="center" flexGrow="1" maxWidth="fit-content">
-                                {isNyKommunikasjonEnabled && (
-                                    <AvbrytAlert
-                                        disablePopup={form.getFieldValue('melding').length === 0}
-                                        handleAvbryt={() => {
-                                            removeDraft();
-                                            setNyMeldingUnderArbeid(false);
-                                        }}
-                                    />
-                                )}
+                            <HStack
+                                justify="end"
+                                gap="space-8"
+                                align="center"
+                                flexGrow="1"
+                                maxWidth="fit-content"
+                                className="flex-row-reverse"
+                            >
                                 <Button
                                     disabled={disableDialog || isPending}
                                     type="submit"
@@ -229,6 +227,15 @@ function NyMelding() {
                                 >
                                     Send til {brukerNavn}
                                 </Button>
+                                {isNyKommunikasjonEnabled && (
+                                    <AvbrytAlert
+                                        disablePopup={form.getFieldValue('melding').length === 0}
+                                        handleAvbryt={() => {
+                                            removeDraft();
+                                            setNyMeldingUnderArbeid(false);
+                                        }}
+                                    />
+                                )}
                             </HStack>
                         </HStack>
                     </Bleed>


### PR DESCRIPTION
Submitknapp er til høgre når knappane ligger ved sida av kvarandre. Når dei wrappes under kvarandre så ligger submitknapp øverst.

Fiksa det ved å endre rekkefølge på knappene i koden og la til "flex-row-reverse" for å reversere rekkefølgen når dei ligger ved sida av kvarandre.