### PR TITLE
Kopier fnr familie

### DIFF
--- a/src/components/PersonLinje/Details/Familie/Sivilstand.tsx
+++ b/src/components/PersonLinje/Details/Familie/Sivilstand.tsx
@@ -1,7 +1,7 @@
 import { HeartFillIcon } from '@navikt/aksel-icons';
-import { Alert, BodyShort, CopyButton, Detail } from '@navikt/ds-react';
+import { Alert, BodyShort, Detail } from '@navikt/ds-react';
+import { KopierFnrKnapp } from 'src/components/PersonLinje/common/KopierFnrKnapp';
 import { type PersonData, SivilstandType } from 'src/lib/types/modiapersonoversikt-api';
-import { erGyldigishFnr } from 'src/utils/fnr-utils';
 import { formaterDato } from 'src/utils/string-utils';
 import Diskresjonskode from '../../common/DiskresjonsKode';
 import { erPartner, hentAlderEllerDod, hentNavn } from '../../utils';
@@ -47,7 +47,6 @@ function Partner(props: { partner: Sivilstand; harFeilendeSystem: boolean }) {
     }
     const navn = partnerRelasjon.navn.firstOrNull();
     const fnr = partnerRelasjon.fnr;
-    const fnrOppdelt = `${fnr.slice(0, 6)} ${fnr.slice(6)}`;
     const alderEllerDod = hentAlderEllerDod(partnerRelasjon);
     return (
         <>
@@ -58,20 +57,7 @@ function Partner(props: { partner: Sivilstand; harFeilendeSystem: boolean }) {
             <BodyShort size="small">
                 {navn && hentNavn(navn)} {alderEllerDod && `(${alderEllerDod})`}
             </BodyShort>
-            <Detail>
-                {fnr && erGyldigishFnr(fnr) ? (
-                    <CopyButton
-                        aria-label={`Kopier f.nr: ${fnrOppdelt}`}
-                        size="xsmall"
-                        className="p-0"
-                        copyText={fnr}
-                        activeText="Kopiert f.nr"
-                        text={`F.nr: ${fnrOppdelt}`}
-                    />
-                ) : (
-                    'Ukjent'
-                )}
-            </Detail>
+            <KopierFnrKnapp fnr={fnr} />
             <Detail textColor="subtle">
                 {partnerRelasjon.harSammeAdresse ? <>Bor med bruker</> : <>Bor ikke med bruker</>}
             </Detail>

--- a/src/components/PersonLinje/Details/Familie/Sivilstand.tsx
+++ b/src/components/PersonLinje/Details/Familie/Sivilstand.tsx
@@ -1,6 +1,7 @@
 import { HeartFillIcon } from '@navikt/aksel-icons';
-import { Alert, BodyShort, Detail } from '@navikt/ds-react';
+import { Alert, BodyShort, CopyButton, Detail } from '@navikt/ds-react';
 import { type PersonData, SivilstandType } from 'src/lib/types/modiapersonoversikt-api';
+import { erGyldigishFnr } from 'src/utils/fnr-utils';
 import { formaterDato } from 'src/utils/string-utils';
 import Diskresjonskode from '../../common/DiskresjonsKode';
 import { erPartner, hentAlderEllerDod, hentNavn } from '../../utils';
@@ -45,6 +46,9 @@ function Partner(props: { partner: Sivilstand; harFeilendeSystem: boolean }) {
         return null;
     }
     const navn = partnerRelasjon.navn.firstOrNull();
+    const fnr = partnerRelasjon.fnr;
+    const fnrOppdelt = `${fnr.slice(0, 6)} ${fnr.slice(6)}`;
+    const alderEllerDod = hentAlderEllerDod(partnerRelasjon);
     return (
         <>
             <BodyShort size="small">
@@ -52,9 +56,22 @@ function Partner(props: { partner: Sivilstand; harFeilendeSystem: boolean }) {
             </BodyShort>
             <Diskresjonskode adressebeskyttelse={partnerRelasjon.adressebeskyttelse} />
             <BodyShort size="small">
-                {navn && hentNavn(navn)} ({hentAlderEllerDod(partnerRelasjon)})
+                {navn && hentNavn(navn)} {alderEllerDod && `(${alderEllerDod})`}
             </BodyShort>
-            <Detail>{partnerRelasjon.fnr}</Detail>
+            <Detail>
+                {fnr && erGyldigishFnr(fnr) ? (
+                    <CopyButton
+                        aria-label={`Kopier f.nr: ${fnrOppdelt}`}
+                        size="xsmall"
+                        className="p-0"
+                        copyText={fnr}
+                        activeText="Kopiert f.nr"
+                        text={`F.nr: ${fnrOppdelt}`}
+                    />
+                ) : (
+                    'Ukjent'
+                )}
+            </Detail>
             <Detail textColor="subtle">
                 {partnerRelasjon.harSammeAdresse ? <>Bor med bruker</> : <>Bor ikke med bruker</>}
             </Detail>

--- a/src/components/PersonLinje/Details/Familie/components.tsx
+++ b/src/components/PersonLinje/Details/Familie/components.tsx
@@ -5,9 +5,9 @@ import {
     FigureOutwardFillIcon,
     PersonCrossFillIcon
 } from '@navikt/aksel-icons';
-import { Alert, BodyShort, CopyButton, Detail } from '@navikt/ds-react';
+import { Alert, BodyShort, Detail } from '@navikt/ds-react';
+import { KopierFnrKnapp } from 'src/components/PersonLinje/common/KopierFnrKnapp';
 import type { PersonData } from 'src/lib/types/modiapersonoversikt-api';
-import { erGyldigishFnr } from 'src/utils/fnr-utils';
 import BostedForRelasjon from '../../common/BostedForRelasjon';
 import Diskresjonskode from '../../common/DiskresjonsKode';
 import { harDiskresjonskode, hentAlderEllerDod, hentNavn } from '../../utils';
@@ -36,27 +36,13 @@ export function ForelderBarnRelasjonVisning({
     const alder = hentAlderEllerDod(relasjon) ? `(${hentAlderEllerDod(relasjon)})` : null;
     const navn = relasjon.navn.firstOrNull();
     const fnr = relasjon.ident;
-    const fnrOppdelt = fnr ? `${fnr.slice(0, 6)} ${fnr.slice(6)}` : null;
     return (
         <InfoElement title={beskrivelse} icon={<FamilierelasjonIkon relasjon={relasjon} erBarn={erBarn} />}>
             <Diskresjonskode adressebeskyttelse={relasjon.adressebeskyttelse} />
             <BodyShort size="small">
                 {navn && hentNavn(navn)} {alder}
             </BodyShort>
-            <Detail>
-                {fnr && erGyldigishFnr(fnr) ? (
-                    <CopyButton
-                        aria-label={`Kopier f.nr: ${fnrOppdelt}`}
-                        size="xsmall"
-                        className="p-0"
-                        copyText={fnr}
-                        activeText="Kopiert f.nr"
-                        text={`F.nr: ${fnrOppdelt}`}
-                    />
-                ) : (
-                    'Ukjent'
-                )}
-            </Detail>
+            <KopierFnrKnapp fnr={fnr} />
             <Detail textColor="subtle">
                 <BostedForRelasjon relasjon={relasjon} />
             </Detail>

--- a/src/components/PersonLinje/Details/Familie/components.tsx
+++ b/src/components/PersonLinje/Details/Familie/components.tsx
@@ -5,8 +5,9 @@ import {
     FigureOutwardFillIcon,
     PersonCrossFillIcon
 } from '@navikt/aksel-icons';
-import { Alert, BodyShort, Detail } from '@navikt/ds-react';
+import { Alert, BodyShort, CopyButton, Detail } from '@navikt/ds-react';
 import type { PersonData } from 'src/lib/types/modiapersonoversikt-api';
+import { erGyldigishFnr } from 'src/utils/fnr-utils';
 import BostedForRelasjon from '../../common/BostedForRelasjon';
 import Diskresjonskode from '../../common/DiskresjonsKode';
 import { harDiskresjonskode, hentAlderEllerDod, hentNavn } from '../../utils';
@@ -34,13 +35,28 @@ export function ForelderBarnRelasjonVisning({
     }
     const alder = hentAlderEllerDod(relasjon) ? `(${hentAlderEllerDod(relasjon)})` : null;
     const navn = relasjon.navn.firstOrNull();
+    const fnr = relasjon.ident;
+    const fnrOppdelt = fnr ? `${fnr.slice(0, 6)} ${fnr.slice(6)}` : null;
     return (
         <InfoElement title={beskrivelse} icon={<FamilierelasjonIkon relasjon={relasjon} erBarn={erBarn} />}>
             <Diskresjonskode adressebeskyttelse={relasjon.adressebeskyttelse} />
             <BodyShort size="small">
                 {navn && hentNavn(navn)} {alder}
             </BodyShort>
-            <Detail>{relasjon.ident ? relasjon.ident : 'Ukjent'}</Detail>
+            <Detail>
+                {fnr && erGyldigishFnr(fnr) ? (
+                    <CopyButton
+                        aria-label={`Kopier f.nr: ${fnrOppdelt}`}
+                        size="xsmall"
+                        className="p-0"
+                        copyText={fnr}
+                        activeText="Kopiert f.nr"
+                        text={`F.nr: ${fnrOppdelt}`}
+                    />
+                ) : (
+                    'Ukjent'
+                )}
+            </Detail>
             <Detail textColor="subtle">
                 <BostedForRelasjon relasjon={relasjon} />
             </Detail>

--- a/src/components/PersonLinje/Details/Fullmakt.tsx
+++ b/src/components/PersonLinje/Details/Fullmakt.tsx
@@ -1,5 +1,6 @@
 import { Chat2Icon, GlassesIcon, PencilIcon } from '@navikt/aksel-icons';
-import { Alert, Detail, HelpText, ReadMore, Table } from '@navikt/ds-react';
+import { Alert, BodyShort, Detail, HelpText, ReadMore, Table } from '@navikt/ds-react';
+import { KopierFnrKnapp } from 'src/components/PersonLinje/common/KopierFnrKnapp';
 import { usePersonData } from 'src/lib/clients/modiapersonoversikt-api';
 import {
     type OmraadeMedHandling,
@@ -89,9 +90,8 @@ function Fullmakt(props: { fullmakt: Fullmakt; harFeilendeSystem: boolean }) {
     return (
         <InfoElement title={beskrivelse}>
             {harFeilendeSystem}
-            <Detail>
-                {motpartsPersonNavn} {`(${props.fullmakt.motpartsPersonident})`}
-            </Detail>
+            <BodyShort size="small">{motpartsPersonNavn}</BodyShort>
+            <KopierFnrKnapp fnr={props.fullmakt.motpartsPersonident} />
             <KontaktinformasjonFullmakt
                 kontaktinformasjon={props.fullmakt.digitalKontaktinformasjonTredjepartsperson}
             />

--- a/src/components/PersonLinje/Details/KontaktInfo/Dodsbo.tsx
+++ b/src/components/PersonLinje/Details/KontaktInfo/Dodsbo.tsx
@@ -1,5 +1,6 @@
 import { LocationPinFillIcon } from '@navikt/aksel-icons';
 import { Alert, BodyShort, Box } from '@navikt/ds-react';
+import { KopierFnrKnapp } from 'src/components/PersonLinje/common/KopierFnrKnapp';
 import type { PersonData } from 'src/lib/types/modiapersonoversikt-api';
 import { formaterDato } from 'src/utils/string-utils';
 import { hentNavn } from '../../utils';
@@ -63,20 +64,20 @@ function PersonSomAdressatInfo({
     adressat: NonNullable<Adressat['personSomAdressat']>;
 }) {
     const manglerData = harFeilendeSystem ? <Alert variant="warning">Feilet ved uthenting av navn</Alert> : null;
-    const fnr = adressat.fnr ? <BodyShort size="small">{adressat.fnr}</BodyShort> : null;
     const fodselsdato = adressat.fodselsdato ? (
         <BodyShort size="small">{formaterDato(adressat.fodselsdato)}</BodyShort>
     ) : null;
-    const navn = adressat.navn ? (
-        <BodyShort size="small">{hentNavn(adressat.navn.firstOrNull() ?? undefined)}</BodyShort>
+
+    const navnKomp = adressat.navn ? (
+        <BodyShort size="small">{hentNavn(adressat.navn.firstOrNull() ?? undefined) ?? 'Ukjent navn'}</BodyShort>
     ) : null;
 
     return (
         <>
             {manglerData}
-            {navn}
-            {fnr}
+            {navnKomp}
             {fodselsdato}
+            <KopierFnrKnapp fnr={adressat.fnr} />
         </>
     );
 }

--- a/src/components/PersonLinje/Details/Vergemal.tsx
+++ b/src/components/PersonLinje/Details/Vergemal.tsx
@@ -1,5 +1,6 @@
 import { ExclamationmarkTriangleFillIcon } from '@navikt/aksel-icons';
 import { Alert, BodyShort, Box, Detail, HelpText, HStack } from '@navikt/ds-react';
+import { KopierFnrKnapp } from 'src/components/PersonLinje/common/KopierFnrKnapp';
 import { usePersonData } from 'src/lib/clients/modiapersonoversikt-api';
 import { type PersonData, PersonDataFeilendeSystemer } from 'src/lib/types/modiapersonoversikt-api';
 import ValidPeriod from '../common/ValidPeriod';
@@ -22,7 +23,7 @@ function Verge(props: { feilendeSystemer: PersonDataFeilendeSystemer[]; verge: V
         <InfoElement title="Verge">
             <Box className="mb-2">
                 {harFeilendeSystemOgIngenNavn}
-                <Detail>{verge.ident}</Detail>
+                <KopierFnrKnapp fnr={verge.ident} />
             </Box>
             {verge.tjenesteOppgaver && verge.tjenesteOppgaver?.length > 0 ? (
                 <>

--- a/src/components/PersonLinje/common/KopierFnrKnapp.tsx
+++ b/src/components/PersonLinje/common/KopierFnrKnapp.tsx
@@ -1,0 +1,19 @@
+import { CopyButton, Detail } from '@navikt/ds-react';
+import { erGyldigishFnr } from 'src/utils/fnr-utils';
+
+export const KopierFnrKnapp = ({ fnr }: { fnr?: string }) => {
+    const fnrOppdelt = fnr ? `${fnr.slice(0, 6)} ${fnr.slice(6)}` : null;
+
+    return fnr && erGyldigishFnr(fnr) ? (
+        <CopyButton
+            aria-label={`Kopier f.nr: ${fnrOppdelt}`}
+            size="xsmall"
+            className="p-0"
+            copyText={fnr}
+            activeText="Kopiert f.nr"
+            text={`F.nr: ${fnrOppdelt}`}
+        />
+    ) : (
+        <Detail className="p-0">Ukjent</Detail>
+    );
+};

--- a/src/components/PersonLinje/common/KopierFnrKnapp.tsx
+++ b/src/components/PersonLinje/common/KopierFnrKnapp.tsx
@@ -6,12 +6,12 @@ export const KopierFnrKnapp = ({ fnr }: { fnr?: string }) => {
 
     return fnr && erGyldigishFnr(fnr) ? (
         <CopyButton
-            aria-label={`Kopier f.nr: ${fnrOppdelt}`}
+            aria-label={`Kopier f.nr.: ${fnrOppdelt}`}
             size="xsmall"
             className="p-0"
             copyText={fnr}
-            activeText="Kopiert f.nr"
-            text={`F.nr: ${fnrOppdelt}`}
+            activeText="Kopiert f.nr."
+            text={`F.nr.: ${fnrOppdelt}`}
         />
     ) : (
         <Detail className="p-0">Ukjent</Detail>

--- a/src/components/PersonLinje/index.tsx
+++ b/src/components/PersonLinje/index.tsx
@@ -94,27 +94,23 @@ const PersonlinjeHeader = () => {
                         farge={farge}
                     />
                     <HStack marginInline={{ xs: 'space-0', lg: 'space-28' }} gap="space-12">
-                        <HStack className="cursor-[initial]" wrap={false} onClick={(e) => e.stopPropagation()}>
-                            <CopyButton
-                                aria-label={`Kopier f.nr: ${`${person.personIdent.slice(0, 6)} ${person.personIdent.slice(6)}`}`}
-                                size="xsmall"
-                                className="p-0 text-ax-text-neutral-subtle"
-                                copyText={data.person.personIdent}
-                                activeText="Kopiert f.nr"
-                                text={`F.nr: ${`${person.personIdent.slice(0, 6)} ${person.personIdent.slice(6)}`}`}
-                            />
-                        </HStack>
+                        <CopyButton
+                            aria-label={`Kopier f.nr: ${`${person.personIdent.slice(0, 6)} ${person.personIdent.slice(6)}`}`}
+                            size="xsmall"
+                            className="p-0 text-ax-text-neutral-subtle"
+                            copyText={data.person.personIdent}
+                            activeText="Kopiert f.nr"
+                            text={`F.nr: ${`${person.personIdent.slice(0, 6)} ${person.personIdent.slice(6)}`}`}
+                        />
                         {data.person.kontaktInformasjon.mobil?.value && (
-                            <HStack className="cursor-[initial]" wrap={false} onClick={(e) => e.stopPropagation()}>
-                                <CopyButton
-                                    className="p-0 text-ax-text-neutral-subtle"
-                                    activeText="Kopiert tlf.nr"
-                                    aria-label={`Kopier tlf.nr: ${formaterMobiltelefonnummer(data.person.kontaktInformasjon.mobil.value ?? '')}`}
-                                    text={`Tlf: ${formaterMobiltelefonnummer(data.person.kontaktInformasjon.mobil?.value ?? '')}`}
-                                    size="xsmall"
-                                    copyText={data.person.kontaktInformasjon.mobil.value}
-                                />
-                            </HStack>
+                            <CopyButton
+                                className="p-0 text-ax-text-neutral-subtle"
+                                activeText="Kopiert tlf.nr"
+                                aria-label={`Kopier tlf.nr: ${formaterMobiltelefonnummer(data.person.kontaktInformasjon.mobil.value ?? '')}`}
+                                text={`Tlf: ${formaterMobiltelefonnummer(data.person.kontaktInformasjon.mobil?.value ?? '')}`}
+                                size="xsmall"
+                                copyText={data.person.kontaktInformasjon.mobil.value}
+                            />
                         )}
                         <Statsborgerskap />
                     </HStack>

--- a/src/components/PersonLinje/index.tsx
+++ b/src/components/PersonLinje/index.tsx
@@ -3,6 +3,7 @@ import { BodyShort, Box, CopyButton, Heading, HStack, Skeleton } from '@navikt/d
 import { AlertBanner } from 'src/components/AlertBanner';
 import { erUbesvartHenvendelseFraBruker, useTraader } from 'src/components/Meldinger/List/utils';
 import { SkrivNyMeldingKnapp } from 'src/components/melding/SkrivNyMeldingKnapp';
+import { KopierFnrKnapp } from 'src/components/PersonLinje/common/KopierFnrKnapp';
 import Statsborgerskap from 'src/components/PersonLinje/Details/Familie/Statsborgerskap';
 import config from 'src/config';
 import { usePersonData, usePersonOppgaver } from 'src/lib/clients/modiapersonoversikt-api';
@@ -94,14 +95,7 @@ const PersonlinjeHeader = () => {
                         farge={farge}
                     />
                     <HStack marginInline={{ xs: 'space-0', lg: 'space-28' }} gap="space-12">
-                        <CopyButton
-                            aria-label={`Kopier f.nr: ${`${person.personIdent.slice(0, 6)} ${person.personIdent.slice(6)}`}`}
-                            size="xsmall"
-                            className="p-0 text-ax-text-neutral-subtle"
-                            copyText={data.person.personIdent}
-                            activeText="Kopiert f.nr"
-                            text={`F.nr: ${`${person.personIdent.slice(0, 6)} ${person.personIdent.slice(6)}`}`}
-                        />
+                        <KopierFnrKnapp fnr={person.personIdent} />
                         {data.person.kontaktInformasjon.mobil?.value && (
                             <CopyButton
                                 className="p-0 text-ax-text-neutral-subtle"

--- a/src/components/PersonLinje/index.tsx
+++ b/src/components/PersonLinje/index.tsx
@@ -95,12 +95,12 @@ const PersonlinjeHeader = () => {
                     />
                     <HStack marginInline={{ xs: 'space-0', lg: 'space-28' }} gap="space-12">
                         <CopyButton
-                            aria-label={`Kopier f.nr: ${`${person.personIdent.slice(0, 6)} ${person.personIdent.slice(6)}`}`}
+                            aria-label={`Kopier f.nr.: ${`${person.personIdent.slice(0, 6)} ${person.personIdent.slice(6)}`}`}
                             size="xsmall"
                             className="p-0 text-ax-text-neutral-subtle"
                             copyText={data.person.personIdent}
-                            activeText="Kopiert f.nr"
-                            text={`F.nr: ${`${person.personIdent.slice(0, 6)} ${person.personIdent.slice(6)}`}`}
+                            activeText="Kopiert f.nr."
+                            text={`F.nr.: ${`${person.personIdent.slice(0, 6)} ${person.personIdent.slice(6)}`}`}
                         />
                         {data.person.kontaktInformasjon.mobil?.value && (
                             <CopyButton

--- a/src/components/PersonLinje/index.tsx
+++ b/src/components/PersonLinje/index.tsx
@@ -3,7 +3,6 @@ import { BodyShort, Box, CopyButton, Heading, HStack, Skeleton } from '@navikt/d
 import { AlertBanner } from 'src/components/AlertBanner';
 import { erUbesvartHenvendelseFraBruker, useTraader } from 'src/components/Meldinger/List/utils';
 import { SkrivNyMeldingKnapp } from 'src/components/melding/SkrivNyMeldingKnapp';
-import { KopierFnrKnapp } from 'src/components/PersonLinje/common/KopierFnrKnapp';
 import Statsborgerskap from 'src/components/PersonLinje/Details/Familie/Statsborgerskap';
 import config from 'src/config';
 import { usePersonData, usePersonOppgaver } from 'src/lib/clients/modiapersonoversikt-api';
@@ -95,7 +94,14 @@ const PersonlinjeHeader = () => {
                         farge={farge}
                     />
                     <HStack marginInline={{ xs: 'space-0', lg: 'space-28' }} gap="space-12">
-                        <KopierFnrKnapp fnr={person.personIdent} />
+                        <CopyButton
+                            aria-label={`Kopier f.nr: ${`${person.personIdent.slice(0, 6)} ${person.personIdent.slice(6)}`}`}
+                            size="xsmall"
+                            className="p-0 text-ax-text-neutral-subtle"
+                            copyText={data.person.personIdent}
+                            activeText="Kopiert f.nr"
+                            text={`F.nr: ${`${person.personIdent.slice(0, 6)} ${person.personIdent.slice(6)}`}`}
+                        />
                         {data.person.kontaktInformasjon.mobil?.value && (
                             <CopyButton
                                 className="p-0 text-ax-text-neutral-subtle"

--- a/src/mock/persondata/persondata.ts
+++ b/src/mock/persondata/persondata.ts
@@ -298,9 +298,9 @@ function lagPerson(fnr: string): Person {
                               fnr: '10108000398',
                               navn: [
                                   {
-                                      fornavn: '',
+                                      fornavn: 'Test',
                                       mellomnavn: null,
-                                      etternavn: ''
+                                      etternavn: 'Testesen'
                                   }
                               ],
                               fodselsdato: '10.10.1980' as LocalDate


### PR DESCRIPTION
<img width="313" height="394" alt="image" src="https://github.com/user-attachments/assets/b58d7308-4006-4972-b917-1a191b056c53" />

Har lagt til kopierknapp på sivilstand, forelder/barn, verge, fullmakt og kontaktinfo for dødsbo. Kopierknappen er ein felles komponent som viser "ukjent" om fnr ikke finnes.