### PR TITLE
Refactor umami initalization

### DIFF
--- a/index.html
+++ b/index.html
@@ -15,7 +15,6 @@
     <script>
         window.beforeSendAnalytics = (_event, payload) => {
             const url = new URL(window.location.href);
-            console.log({payload})
             if (url.host.includes('localhost')) return false;
             return payload
     };

--- a/index.html
+++ b/index.html
@@ -13,23 +13,17 @@
     
     <link rel="preload" href="https://cdn.nav.no/aksel/fonts/SourceSans3-normal.woff2" as="font" type="font/woff2" crossorigin/>
     <script>
-        window.sendWithEventData = (_event, payload) => {
-            const newUrl = new URL(window.location.href);
-            if (newUrl.host.includes('localhost')) return false;
-
-            newUrl.search = '';
-
-            return {
-                ...payload,
-                url: newUrl.toString()
-            };
+        window.beforeSendAnalytics = (_event, payload) => {
+            const url = new URL(window.location.href);
+            if (url.host.includes('localhost')) return false;
+            return payload
     };
     </script>
 
     <slot not-environment="prod">
         <script
                 defer
-                data-before-send="sendWithEventData"
+                data-before-send="beforeSendAnalytics"
                 src="https://cdn.nav.no/team-researchops/sporing/sporing-dev.js"
                 data-website-id="bc5cfdcd-ecc1-402b-8cb0-c30913f0bd13"
                 data-auto-track="false"
@@ -38,7 +32,7 @@
     <slot environment="prod">
         <script
                 defer
-                data-before-send="sendWithEventData"
+                data-before-send="beforeSendAnalytics"
                 src="https://cdn.nav.no/team-researchops/sporing/sporing.js"
                 data-website-id="a8c2ec9c-2846-4154-8841-5db26494171a"
                 data-auto-track="false"

--- a/index.html
+++ b/index.html
@@ -15,6 +15,7 @@
     <script>
         window.beforeSendAnalytics = (_event, payload) => {
             const url = new URL(window.location.href);
+            console.log({payload})
             if (url.host.includes('localhost')) return false;
             return payload
     };

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -3,7 +3,6 @@ import { createRoot } from 'react-dom/client';
 import './index.css';
 import { RouterProvider } from '@tanstack/react-router';
 import { StrictMode } from 'react';
-import { setAnalyticsReferrer, setAnalyticsUrl, trackBesokUmami } from 'src/utils/analytics';
 import { createRouter } from './router';
 import { initializeObservability } from './utils/observability';
 
@@ -22,35 +21,8 @@ if (import.meta.env.DEV) {
 
 initializeObservability();
 
-const removeSearchString = (href: string): string => {
-    try {
-        const url = new URL(href);
-        url.search = '';
-        return url.toString();
-    } catch {
-        return '';
-    }
-};
-
 export const router = createRouter();
 window.__router = router;
-
-router.subscribe('onResolved', (event) => {
-    // Setter url og referrer for analytics
-    const origin = window.location.origin;
-    const currentUrl = origin + event.toLocation.href;
-    const currentUrlWithoutSearch = removeSearchString(currentUrl);
-
-    const referrerUrl = event.fromLocation ? origin + event.fromLocation.href : document.referrer;
-    const referrerUrlWithoutSearch = removeSearchString(referrerUrl);
-
-    setAnalyticsReferrer(referrerUrlWithoutSearch);
-    setAnalyticsUrl(currentUrlWithoutSearch);
-
-    // Ikke track besøk om det kun er søkestrengen som har endret seg
-    if (referrerUrlWithoutSearch === currentUrlWithoutSearch) return;
-    trackBesokUmami();
-});
 
 let preRenderPromise: Promise<unknown> = Promise.resolve();
 

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -3,6 +3,7 @@ import { createRoot } from 'react-dom/client';
 import './index.css';
 import { RouterProvider } from '@tanstack/react-router';
 import { StrictMode } from 'react';
+import { setAnalyticsReferrer, setAnalyticsUrl } from 'src/utils/analytics';
 import { createRouter } from './router';
 import { initializeObservability } from './utils/observability';
 
@@ -23,6 +24,17 @@ initializeObservability();
 
 export const router = createRouter();
 window.__router = router;
+
+router.subscribe('onResolved', (event) => {
+    // Setter url og referrer for analytics
+    const origin = window.location.origin;
+    const currentUrl = origin + event.toLocation.href;
+
+    const referrerUrl = event.fromLocation ? origin + event.fromLocation.href : document.referrer;
+
+    setAnalyticsReferrer(referrerUrl);
+    setAnalyticsUrl(currentUrl);
+});
 
 let preRenderPromise: Promise<unknown> = Promise.resolve();
 

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -3,7 +3,7 @@ import { createRoot } from 'react-dom/client';
 import './index.css';
 import { RouterProvider } from '@tanstack/react-router';
 import { StrictMode } from 'react';
-import { setAnalyticsReferrer, setAnalyticsUrl } from 'src/utils/analytics';
+import { setAnalyticsReferrer, setAnalyticsUrl, trackBesokUmami } from 'src/utils/analytics';
 import { createRouter } from './router';
 import { initializeObservability } from './utils/observability';
 
@@ -22,6 +22,16 @@ if (import.meta.env.DEV) {
 
 initializeObservability();
 
+const removeSearchString = (href: string): string => {
+    try {
+        const url = new URL(href);
+        url.search = '';
+        return url.toString();
+    } catch {
+        return '';
+    }
+};
+
 export const router = createRouter();
 window.__router = router;
 
@@ -29,11 +39,17 @@ router.subscribe('onResolved', (event) => {
     // Setter url og referrer for analytics
     const origin = window.location.origin;
     const currentUrl = origin + event.toLocation.href;
+    const currentUrlWithoutSearch = removeSearchString(currentUrl);
 
     const referrerUrl = event.fromLocation ? origin + event.fromLocation.href : document.referrer;
+    const referrerUrlWithoutSearch = removeSearchString(referrerUrl);
 
-    setAnalyticsReferrer(referrerUrl);
-    setAnalyticsUrl(currentUrl);
+    setAnalyticsReferrer(referrerUrlWithoutSearch);
+    setAnalyticsUrl(currentUrlWithoutSearch);
+
+    // Ikke track besøk om det kun er søkestrengen som har endret seg
+    if (referrerUrlWithoutSearch === currentUrlWithoutSearch) return;
+    trackBesokUmami();
 });
 
 let preRenderPromise: Promise<unknown> = Promise.resolve();

--- a/src/routes/__root.tsx
+++ b/src/routes/__root.tsx
@@ -1,6 +1,6 @@
 import { Alert, Button, HStack, Link, Loader, Theme } from '@navikt/ds-react';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
-import { createRootRoute, Outlet, useMatchRoute, useRouterState } from '@tanstack/react-router';
+import { createRootRoute, Outlet, useMatchRoute } from '@tanstack/react-router';
 import { useAtomValue } from 'jotai';
 import { lazy, type PropsWithChildren, useEffect, useState } from 'react';
 import { Toaster } from 'sonner';
@@ -17,7 +17,6 @@ import { ValgtEnhetProvider } from 'src/context/valgtenhet-state';
 import { aktivBrukerLastetAtom, aktivEnhetAtom } from 'src/lib/state/context';
 import { ThemeProvider, themeAtom } from 'src/lib/state/theme';
 import { usePersistentWWLogin } from 'src/login/use-persistent-ww-login';
-import { trackBesokUmami } from 'src/utils/analytics';
 import HandleLegacyUrls from 'src/utils/HandleLegacyUrls';
 import useTimeout from 'src/utils/hooks/use-timeout';
 
@@ -44,25 +43,12 @@ function App({ children }: PropsWithChildren) {
     const valgtEnhet = useAtomValue(aktivEnhetAtom);
     const contextLoaded = useAtomValue(aktivBrukerLastetAtom);
     const [contextTimeout, setContextTimeout] = useState(false);
-    const routerStatus = useRouterState({ select: (s) => s.status });
 
     useTimeout(() => {
         setContextTimeout(true);
     }, 1500);
 
     useNavigateToNewOrOldModia();
-
-    useEffect(() => {
-        if (routerStatus !== 'idle') return;
-
-        const interval = setInterval(() => {
-            if (!window.umami) return;
-            clearInterval(interval);
-            trackBesokUmami();
-        }, 100);
-
-        return () => clearInterval(interval);
-    }, [routerStatus]);
 
     if (!contextLoaded && contextTimeout) {
         return (

--- a/src/routes/__root.tsx
+++ b/src/routes/__root.tsx
@@ -19,6 +19,7 @@ import { ThemeProvider, themeAtom } from 'src/lib/state/theme';
 import { usePersistentWWLogin } from 'src/login/use-persistent-ww-login';
 import HandleLegacyUrls from 'src/utils/HandleLegacyUrls';
 import useTimeout from 'src/utils/hooks/use-timeout';
+import { usePageTracking } from 'src/utils/hooks/usePageTracking';
 
 export const Route = createRootRoute({
     component: RootLayout,
@@ -49,6 +50,7 @@ function App({ children }: PropsWithChildren) {
     }, 1500);
 
     useNavigateToNewOrOldModia();
+    usePageTracking();
 
     if (!contextLoaded && contextTimeout) {
         return (

--- a/src/utils/analytics.ts
+++ b/src/utils/analytics.ts
@@ -51,9 +51,12 @@ export enum filterType {
     TEMA = 'tema'
 }
 
-const getReferrer = (): string => {
+let _referrer = document.referrer;
+let _url = '';
+
+const removeSearchString = (href: string): string => {
     try {
-        const url = new URL(document.referrer);
+        const url = new URL(href);
         url.search = '';
         return url.toString();
     } catch {
@@ -61,14 +64,28 @@ const getReferrer = (): string => {
     }
 };
 
+export const setAnalyticsReferrer = (href: string) => {
+    _referrer = removeSearchString(href);
+};
+
+export const setAnalyticsUrl = (href: string) => {
+    _url = removeSearchString(href);
+};
+
+const getReferrer = (): string => _referrer;
+const getUrl = (): string => _url;
+
 // Sentralisert sjekk og kall til umami.track. Skal brukes for alle egnedefinerte events. Legger automatisk på referrer på alle events.
 const trackEventUmami = (name: string, data?: Record<string, unknown>): void => {
     if (!window.umami) {
         console.warn('Umami is not initialized. Ignoring');
         return;
     }
+
     window.umami.track((payload: unknown) => ({
         ...(payload as Record<string, unknown>),
+        referrer: getReferrer(),
+        url: getUrl(),
         data,
         name
     }));
@@ -86,7 +103,8 @@ export const trackBesokUmami = () => {
 
     window.umami.track((payload: unknown) => ({
         ...(payload as Record<string, unknown>),
-        referrer: getReferrer()
+        referrer: getReferrer(),
+        url: getUrl()
     }));
 };
 

--- a/src/utils/analytics.ts
+++ b/src/utils/analytics.ts
@@ -51,6 +51,29 @@ export enum filterType {
     TEMA = 'tema'
 }
 
+const getReferrer = (): string => {
+    try {
+        const url = new URL(document.referrer);
+        url.search = '';
+        return url.toString();
+    } catch {
+        return '';
+    }
+};
+
+// Sentralisert sjekk og kall til umami.track. Skal brukes for alle egnedefinerte events. Legger automatisk på referrer på alle events.
+const trackEventUmami = (name: string, data?: Record<string, unknown>): void => {
+    if (!window.umami) {
+        console.warn('Umami is not initialized. Ignoring');
+        return;
+    }
+    window.umami.track((payload: unknown) => ({
+        ...(payload as Record<string, unknown>),
+        data,
+        name
+    }));
+};
+
 /*Denne tracker "generelt" besøk på siden, altså hver gang en ny link klikkes på og siden besøkes
 Brukes kun i __root og sørger for at kun 1 besøk blir tracket per sidevisning (etter redirects)
  De andre funksjonene er ment for å tracke spesifikke events som ikke nødvendigvis trigger en sidevisning, f.eks klikk på en fane, åpning av dialog osv
@@ -60,147 +83,71 @@ export const trackBesokUmami = () => {
         console.warn('Umami is not initialized. Ignoring');
         return;
     }
-    const referrer = (() => {
-        try {
-            const url = new URL(document.referrer);
-            url.search = '';
-            return url.toString();
-        } catch {
-            return '';
-        }
-    })();
 
     window.umami.track((payload: unknown) => ({
         ...(payload as Record<string, unknown>),
-        referrer
+        referrer: getReferrer()
     }));
 };
 
 export const trackFaneEndret = (nyFane: string, forrigefane: string) => {
-    if (!window.umami) {
-        console.warn('Umami is not initialized. Ignoring');
-        return;
-    }
-    window.umami.track(trackingEvents.faneEndret, { nyFane, forrigefane });
+    trackEventUmami(trackingEvents.faneEndret, { nyFane, forrigefane });
 };
 export const trackDyplenkeFraEksternKilde = (tekst: string) => {
-    if (!window.umami) {
-        console.warn('Umami is not initialized. Ignoring');
-        return;
-    }
-    window.umami.track(trackingEvents.eksternDyplenke, { tekst });
+    trackEventUmami(trackingEvents.eksternDyplenke, { tekst });
 };
 
 export const trackFortsettDialog = (traadType: string) => {
-    if (!window.umami) {
-        console.warn('Umami is not initialized. Ignoring');
-        return;
-    }
-    window.umami.track(trackingEvents.fortsettDialog, { traadType });
+    trackEventUmami(trackingEvents.fortsettDialog, { traadType });
 };
 
 export const trackSendNyMelding = (traadType: string) => {
-    if (!window.umami) {
-        console.warn('Umami is not initialized. Ignoring');
-        return;
-    }
-    window.umami.track(trackingEvents.sendNyMelding, { traadType });
+    trackEventUmami(trackingEvents.sendNyMelding, { traadType });
 };
 
-export const trackGenereltUmamiEvent = (eventNavn: trackingEvents, payload?: unknown) => {
-    if (!window.umami) {
-        console.warn('Umami is not initialized. Ignoring');
-        return;
-    }
-    window.umami.track(eventNavn, payload);
+export const trackGenereltUmamiEvent = (eventNavn: trackingEvents, payload?: Record<string, unknown>) => {
+    trackEventUmami(eventNavn, payload);
 };
 
 export const trackToggleNyModia = (erPaaNyModia: boolean) => {
-    if (!window.umami) {
-        console.warn('Umami is not initialized. Ignoring');
-        return;
-    }
-    window.umami.track(trackingEvents.toggleNyModia, { tekst: erPaaNyModia ? 'på' : 'av' });
+    trackEventUmami(trackingEvents.toggleNyModia, { tekst: erPaaNyModia ? 'på' : 'av' });
 };
 
 export const trackBrukerEndret = () => {
-    if (!window.umami) {
-        console.warn('Umami is not initialized. Ignoring');
-        return;
-    }
-    window.umami.track(trackingEvents.brukerEndret);
+    trackEventUmami(trackingEvents.brukerEndret);
 };
 
-export const trackFilterEndret = (fane: string, filterType: filterType) => {
-    if (!window.umami) {
-        console.warn('Umami is not initialized. Ignoring');
-        return;
-    }
-    window.umami.track(trackingEvents.filterEndret, {
+export const trackFilterEndret = (fane: string, type: filterType) => {
+    trackEventUmami(trackingEvents.filterEndret, {
         fane: fane.toLowerCase(),
-        filterType: filterType
+        filterType: type
     });
 };
 
 export const trackExpansionCardApnet = (name: string) => {
-    if (!window.umami) {
-        console.warn('Umami is not initialized. Ignoring');
-        return;
-    }
-    window.umami.track(trackingEvents.expansionCardApnet, {
-        tittel: name
-    });
+    trackEventUmami(trackingEvents.expansionCardApnet, { tittel: name });
 };
 
 export const trackExpansionCardLukket = (name: string) => {
-    if (!window.umami) {
-        console.warn('Umami is not initialized. Ignoring');
-        return;
-    }
-    window.umami.track(trackingEvents.expansionCardLukket, {
-        tittel: name
-    });
+    trackEventUmami(trackingEvents.expansionCardLukket, { tittel: name });
 };
 
 // Bruker denne til å tracke klikk på detaljvisning i ulike faner
 // F.eks vise enkelt ytelse, åpne et dokument i sakerfanen, åpner detalj om utbetaling osv
 export const trackVisDetaljvisning = (fane: string, tekst: string) => {
-    if (!window.umami) {
-        console.warn('Umami is not initialized. Ignoring');
-        return;
-    }
-    window.umami.track(trackingEvents.detaljvisningKlikket, {
-        fane: fane,
-        tekst: tekst
-    });
+    trackEventUmami(trackingEvents.detaljvisningKlikket, { fane, tekst });
 };
 
 export const trackAccordionOpened = (name: string) => {
-    if (!window.umami) {
-        console.warn('Umami is not initialized. Ignoring');
-        return;
-    }
-    window.umami.track(trackingEvents.accordionApnet, {
-        tittel: name
-    });
+    trackEventUmami(trackingEvents.accordionApnet, { tittel: name });
 };
 
 export const trackAccordionClosed = (name: string) => {
-    if (!window.umami) {
-        console.warn('Umami is not initialized. Ignoring');
-        return;
-    }
-    window.umami.track(trackingEvents.accordionLukket, {
-        tittel: name
-    });
+    trackEventUmami(trackingEvents.accordionLukket, { tittel: name });
 };
 
 export const trackEnhetEndret = () => {
-    if (!window.umami) {
-        console.warn('Umami is not initialized. Ignoring');
-        return;
-    }
-    window.umami.track(trackingEvents.enhetEndret);
+    trackEventUmami(trackingEvents.enhetEndret);
 };
 
 // Ved bruk av Umami identify vil alle påfølgende umami event knyttes til enhet.

--- a/src/utils/analytics.ts
+++ b/src/utils/analytics.ts
@@ -52,8 +52,7 @@ export enum filterType {
 }
 
 let _referrer = document.referrer;
-let _url = '';
-
+let _url = window.location.origin + window.location.pathname;
 export const setAnalyticsReferrer = (href: string) => {
     _referrer = href;
 };

--- a/src/utils/analytics.ts
+++ b/src/utils/analytics.ts
@@ -54,22 +54,12 @@ export enum filterType {
 let _referrer = document.referrer;
 let _url = '';
 
-const removeSearchString = (href: string): string => {
-    try {
-        const url = new URL(href);
-        url.search = '';
-        return url.toString();
-    } catch {
-        return '';
-    }
-};
-
 export const setAnalyticsReferrer = (href: string) => {
-    _referrer = removeSearchString(href);
+    _referrer = href;
 };
 
 export const setAnalyticsUrl = (href: string) => {
-    _url = removeSearchString(href);
+    _url = href;
 };
 
 const getReferrer = (): string => _referrer;

--- a/src/utils/analytics.ts
+++ b/src/utils/analytics.ts
@@ -65,7 +65,7 @@ export const setAnalyticsUrl = (href: string) => {
 const getReferrer = (): string => _referrer;
 const getUrl = (): string => _url;
 
-// Sentralisert sjekk og kall til umami.track. Skal brukes for alle egnedefinerte events. Legger automatisk på referrer på alle events.
+// Sentralisert sjekk og kall til umami.track. Skal brukes for alle egnedefinerte events.
 const trackEventUmami = (name: string, data?: Record<string, unknown>): void => {
     if (!window.umami) {
         console.warn('Umami is not initialized. Ignoring');
@@ -81,7 +81,7 @@ const trackEventUmami = (name: string, data?: Record<string, unknown>): void => 
 };
 
 /*Denne tracker "generelt" besøk på siden, altså hver gang en ny link klikkes på og siden besøkes
-Brukes kun i __root og sørger for at kun 1 besøk blir tracket per sidevisning (etter redirects)
+Brukes kun i main.tsx og sørger for at kun 1 besøk blir tracket per sidevisning (etter redirects)
  De andre funksjonene er ment for å tracke spesifikke events som ikke nødvendigvis trigger en sidevisning, f.eks klikk på en fane, åpning av dialog osv
  Ved f.eks fendring av faner så blir det gjort to kall til  umami, ett for besøket og ett for hendelsen "fane endret"*/
 export const trackBesokUmami = () => {

--- a/src/utils/analytics.ts
+++ b/src/utils/analytics.ts
@@ -80,10 +80,11 @@ const trackEventUmami = (name: string, data?: Record<string, unknown>): void => 
     }));
 };
 
-/*Denne tracker "generelt" besøk på siden, altså hver gang en ny link klikkes på og siden besøkes
-Brukes kun i main.tsx og sørger for at kun 1 besøk blir tracket per sidevisning (etter redirects)
- De andre funksjonene er ment for å tracke spesifikke events som ikke nødvendigvis trigger en sidevisning, f.eks klikk på en fane, åpning av dialog osv
- Ved f.eks fendring av faner så blir det gjort to kall til  umami, ett for besøket og ett for hendelsen "fane endret"*/
+/*Denne tracker "generelt" besøk på siden, altså hver gang en ny link klikkes på og siden besøkes.
+Brukes kun i usePageTracking og sørger for at kun 1 besøk blir tracket per sidevisning (etter redirects).
+De andre funksjonene er ment for å tracke spesifikke events som ikke nødvendigvis trigger en sidevisning, f.eks klikk på en fane, åpning av dialog osv.
+Ved f.eks endring av faner så blir det gjort to kall til umami, ett for besøket og ett for hendelsen "fane endret".
+NB: setAnalyticsReferrer må alltid kalles før denne funksjonen, slik at _referrer er korrekt satt.*/
 export const trackBesokUmami = () => {
     if (!window.umami) {
         console.warn('Umami is not initialized. Ignoring');

--- a/src/utils/analytics.ts
+++ b/src/utils/analytics.ts
@@ -84,7 +84,6 @@ const trackEventUmami = (name: string, data?: Record<string, unknown>): void => 
 
     window.umami.track((payload: unknown) => ({
         ...(payload as Record<string, unknown>),
-        referrer: getReferrer(),
         url: getUrl(),
         data,
         name

--- a/src/utils/hooks/usePageTracking.ts
+++ b/src/utils/hooks/usePageTracking.ts
@@ -16,7 +16,7 @@ const removeSearchString = (href: string): string => {
     }
 };
 
-const isNewModiaUrl = (pathname: string): boolean => pathname.includes('new');
+const isNewModiaUrl = (pathname: string): boolean => pathname.startsWith('/new');
 
 const isNyModiaRedirect = (fromPathname: string, toPathname: string): boolean =>
     isNewModiaUrl(toPathname) && fromPathname === toPathname.slice('/new'.length);

--- a/src/utils/hooks/usePageTracking.ts
+++ b/src/utils/hooks/usePageTracking.ts
@@ -1,0 +1,68 @@
+import { useRouterState } from '@tanstack/react-router';
+import { useAtomValue } from 'jotai';
+import { useEffect, useRef } from 'react';
+import { FeatureToggles } from 'src/components/featureToggle/toggleIDs';
+import useFeatureToggle from 'src/components/featureToggle/useFeatureToggle';
+import { nyModiaAtom } from 'src/components/NyModia';
+import { setAnalyticsReferrer, setAnalyticsUrl, trackBesokUmami } from 'src/utils/analytics';
+
+const removeSearchString = (href: string): string => {
+    try {
+        const url = new URL(href);
+        url.search = '';
+        return url.toString();
+    } catch {
+        return '';
+    }
+};
+
+const isNewModiaUrl = (pathname: string): boolean => pathname === '/new' || pathname.startsWith('/new/');
+
+const isNyModiaRedirect = (fromPathname: string, toPathname: string): boolean =>
+    isNewModiaUrl(toPathname) && fromPathname === toPathname.slice('/new'.length);
+
+export function usePageTracking() {
+    const nyModia = useAtomValue(nyModiaAtom);
+    const { pending: featureToggleisPending } = useFeatureToggle(FeatureToggles.NyModiaKnapp);
+
+    const { location, isLoading: routerIsPending } = useRouterState({
+        select: (s) => ({ location: s.location, isLoading: s.isLoading })
+    });
+    const prevRef = useRef<{ pathname: string; url: string } | null>(null);
+    // Siste faktisk trackede URL — brukes som referrer neste gang vi tracker.
+    // Skiller seg fra prevRef fordi vi ikke oppdaterer denne for skippede navigasjoner (gammel modia URL).
+    const lastTrackedUrlRef = useRef<string>('');
+
+    useEffect(() => {
+        if (featureToggleisPending || routerIsPending) return;
+
+        const origin = window.location.origin;
+        const currentUrl = removeSearchString(origin + location.href);
+        const prev = prevRef.current;
+        const fromPathname = prev?.pathname ?? '';
+
+        prevRef.current = { pathname: location.pathname, url: currentUrl };
+
+        // Om brukeren blir redirected fra gammel til ny modia så vil vi ikke tracke besøk til gammel modia
+        const willSkip = !isNewModiaUrl(location.pathname) && nyModia;
+        const nyModiaRedirect = !!fromPathname && isNyModiaRedirect(fromPathname, location.pathname);
+
+        if (nyModiaRedirect) {
+            // For intern navigasjon via dekoratøren: bruk siste trackede side som referrer.
+            if (lastTrackedUrlRef.current) {
+                setAnalyticsReferrer(lastTrackedUrlRef.current);
+            }
+        } else if (!willSkip) {
+            setAnalyticsReferrer(removeSearchString(prev?.url ?? document.referrer));
+        }
+        setAnalyticsUrl(currentUrl);
+
+        // Ikke track om det kun er søkestrengen har endret seg
+        const prevUrlWithoutSearch = prev ? removeSearchString(prev.url) : '';
+        if (prevUrlWithoutSearch === currentUrl) return;
+        if (willSkip) return;
+
+        trackBesokUmami();
+        lastTrackedUrlRef.current = currentUrl;
+    }, [location.pathname, location.href, routerIsPending, nyModia, featureToggleisPending]);
+}

--- a/src/utils/hooks/usePageTracking.ts
+++ b/src/utils/hooks/usePageTracking.ts
@@ -16,7 +16,7 @@ const removeSearchString = (href: string): string => {
     }
 };
 
-const isNewModiaUrl = (pathname: string): boolean => pathname === '/new' || pathname.startsWith('/new/');
+const isNewModiaUrl = (pathname: string): boolean => pathname.includes('new');
 
 const isNyModiaRedirect = (fromPathname: string, toPathname: string): boolean =>
     isNewModiaUrl(toPathname) && fromPathname === toPathname.slice('/new'.length);
@@ -36,19 +36,20 @@ export function usePageTracking() {
     useEffect(() => {
         if (featureToggleisPending || routerIsPending) return;
 
-        const origin = window.location.origin;
-        const currentUrl = removeSearchString(origin + location.href);
+        const currentUrl = removeSearchString(window.location.origin + location.href);
         const prev = prevRef.current;
         const fromPathname = prev?.pathname ?? '';
+        const toPathname = location.pathname;
 
         prevRef.current = { pathname: location.pathname, url: currentUrl };
 
         // Om brukeren blir redirected fra gammel til ny modia så vil vi ikke tracke besøk til gammel modia
-        const willSkip = !isNewModiaUrl(location.pathname) && nyModia;
-        const nyModiaRedirect = !!fromPathname && isNyModiaRedirect(fromPathname, location.pathname);
+        const willSkip = !isNewModiaUrl(toPathname) && nyModia;
+
+        // Dette er den faktiske urlen vi vil tracke
+        const nyModiaRedirect = !!fromPathname && isNyModiaRedirect(fromPathname, toPathname);
 
         if (nyModiaRedirect) {
-            // For intern navigasjon via dekoratøren: bruk siste trackede side som referrer.
             if (lastTrackedUrlRef.current) {
                 setAnalyticsReferrer(lastTrackedUrlRef.current);
             }
@@ -57,7 +58,7 @@ export function usePageTracking() {
         }
         setAnalyticsUrl(currentUrl);
 
-        // Ikke track om det kun er søkestrengen har endret seg
+        // Ikke track om det kun er søkestrengen som har endret seg
         const prevUrlWithoutSearch = prev ? removeSearchString(prev.url) : '';
         if (prevUrlWithoutSearch === currentUrl) return;
         if (willSkip) return;

--- a/src/utils/hooks/usePageTracking.ts
+++ b/src/utils/hooks/usePageTracking.ts
@@ -36,10 +36,10 @@ export function usePageTracking() {
     useEffect(() => {
         if (featureToggleisPending || routerIsPending) return;
 
-        const currentUrl = removeSearchString(window.location.origin + location.href);
         const prev = prevRef.current;
         const fromPathname = prev?.pathname ?? '';
         const toPathname = location.pathname;
+        const currentUrl = removeSearchString(window.location.origin + toPathname);
 
         prevRef.current = { pathname: location.pathname, url: currentUrl };
 
@@ -65,5 +65,5 @@ export function usePageTracking() {
 
         trackBesokUmami();
         lastTrackedUrlRef.current = currentUrl;
-    }, [location.pathname, location.href, routerIsPending, nyModia, featureToggleisPending]);
+    }, [location.pathname, routerIsPending, nyModia, featureToggleisPending]);
 }


### PR DESCRIPTION
**Siden appen er ein SPA med tanstack router så vil document.referer aldri bli endra så her trenger me ein del custom logikk. Har oppdatert logikken for at referrer og url er riktig + litt pynting i koden**

Har wrappet alle trackingfunksjoner i ein wrapperfunksjon slik at dei kan dele felles logikk (Sjekk at umami er initialisert og at me sender riktig url)

Har flytta trackBesok-logikk til ein separat hook:

1. Om det kun er søkeparameter som endrer seg så ønsker me ikkje å tracke besøk
2. Om lenka er til gamle modia men ny-modia toggler er påskrudd, så skipper me å tracke det besøket, men me må sette referrer til `document.referrer` for å få med oss den eksterne referreren til neste tracking (som er den riktige)
3. Når den riktige navigasjonen blir detektert gjennom variabelen nyModiaRedirect så bruker me den forrige referreren.


