### PR TITLE
Skip track besok gammel modia

### DIFF
--- a/index.html
+++ b/index.html
@@ -14,9 +14,22 @@
     <link rel="preload" href="https://cdn.nav.no/aksel/fonts/SourceSans3-normal.woff2" as="font" type="font/woff2" crossorigin/>
     <script>
         window.beforeSendAnalytics = (_event, payload) => {
-            const url = new URL(window.location.href);
-            if (url.host.includes('localhost')) return false;
-            return payload
+            const clearSearchParam = (href) => {
+                try {
+                    const url = new URL(href);
+                    url.search = '';
+                    return url.toString();
+                } catch {
+                    return href;
+                }
+            }
+
+            if (payload.url.includes('localhost')) return false;
+            return {
+            ...payload,
+                    url: clearSearchParam(payload.url),
+                    referrer: clearSearchParam(payload.referrer)
+            }
     };
     </script>
 

--- a/src/components/NyModia.tsx
+++ b/src/components/NyModia.tsx
@@ -20,7 +20,7 @@ export const nyModiaAtom = atom(
     }
 );
 
-const brukerHarValgtAtom = atom((get) => get(nyModiaStorageAtom) !== null);
+export const brukerHarValgtAtom = atom((get) => get(nyModiaStorageAtom) !== null);
 
 export const useNavigateToNewOrOldModia = () => {
     const { isOn, pending } = useFeatureToggle(FeatureToggles.NyModiaKnapp);

--- a/src/utils/analytics.ts
+++ b/src/utils/analytics.ts
@@ -1,5 +1,3 @@
-import { removeSearchString } from 'src/utils/hooks/usePageTracking';
-
 interface Umami {
     track(payload?: unknown): void;
     track(event_name: string, payload: unknown): void;
@@ -54,8 +52,8 @@ export enum filterType {
     TEMA = 'tema'
 }
 
-let _referrer = removeSearchString(document.referrer);
-let _url = removeSearchString(window.location.origin + window.location.pathname);
+let _referrer = document.referrer;
+let _url = window.location.origin + window.location.pathname;
 export const setAnalyticsReferrer = (href: string) => {
     _referrer = href;
 };

--- a/src/utils/hooks/usePageTracking.ts
+++ b/src/utils/hooks/usePageTracking.ts
@@ -6,7 +6,7 @@ import useFeatureToggle from 'src/components/featureToggle/useFeatureToggle';
 import { brukerHarValgtAtom, nyModiaAtom } from 'src/components/NyModia';
 import { setAnalyticsReferrer, setAnalyticsUrl, trackBesokUmami } from 'src/utils/analytics';
 
-export const removeSearchString = (href: string): string => {
+const removeSearchString = (href: string): string => {
     try {
         const url = new URL(href);
         url.search = '';

--- a/src/utils/hooks/usePageTracking.ts
+++ b/src/utils/hooks/usePageTracking.ts
@@ -3,7 +3,7 @@ import { useAtomValue } from 'jotai';
 import { useEffect, useRef } from 'react';
 import { FeatureToggles } from 'src/components/featureToggle/toggleIDs';
 import useFeatureToggle from 'src/components/featureToggle/useFeatureToggle';
-import { nyModiaAtom } from 'src/components/NyModia';
+import { brukerHarValgtAtom, nyModiaAtom } from 'src/components/NyModia';
 import { setAnalyticsReferrer, setAnalyticsUrl, trackBesokUmami } from 'src/utils/analytics';
 
 export const removeSearchString = (href: string): string => {
@@ -23,7 +23,8 @@ const isNyModiaRedirect = (fromPathname: string, toPathname: string): boolean =>
 
 export function usePageTracking() {
     const nyModia = useAtomValue(nyModiaAtom);
-    const { pending: featureToggleisPending } = useFeatureToggle(FeatureToggles.NyModiaKnapp);
+    const brukerHarValgt = useAtomValue(brukerHarValgtAtom);
+    const { isOn, pending: featureToggleisPending } = useFeatureToggle(FeatureToggles.NyModiaKnapp);
 
     const { location, isLoading: routerIsPending } = useRouterState({
         select: (s) => ({ location: s.location, isLoading: s.isLoading })
@@ -41,10 +42,11 @@ export function usePageTracking() {
         const toPathname = location.pathname;
         const currentUrl = removeSearchString(window.location.origin + toPathname);
 
-        prevRef.current = { pathname: location.pathname, url: currentUrl };
+        prevRef.current = { pathname: toPathname, url: currentUrl };
 
         // Om brukeren blir redirected fra gammel til ny modia så vil vi ikke tracke besøk til gammel modia
-        const willSkip = !isNewModiaUrl(toPathname) && nyModia;
+        const nyModiaWillBeEnabled = isOn && !brukerHarValgt;
+        const willSkip = !isNewModiaUrl(toPathname) && (nyModia || nyModiaWillBeEnabled);
 
         // Dette er den faktiske urlen vi vil tracke
         const nyModiaRedirect = !!fromPathname && isNyModiaRedirect(fromPathname, toPathname);
@@ -65,5 +67,5 @@ export function usePageTracking() {
 
         trackBesokUmami();
         lastTrackedUrlRef.current = currentUrl;
-    }, [location.pathname, routerIsPending, nyModia, featureToggleisPending]);
+    }, [location.pathname, routerIsPending, nyModia, featureToggleisPending, isOn, brukerHarValgt]);
 }


### PR DESCRIPTION
Okay eg prøver ein gang til. Det er to fikser her:

1. Det er ein siste "vask" for å fjerne søkeparamtere i både url og referrer. Då sikrar me at data både frå besok, egendefinerte events, og identify funksjoner blir vasker.
2. Det er ein case når det gjelder nye modia som me ikkje har fått med oss og det er om bruker ikkje har tatt eit aktivt valg om å bytte til ny modia. Då vil ny modia bli enabled på neste tracking, så den linken blir skippet. Det er muleg at de løser problemet med at det er så mange tracks i gamle modia.