### PR TITLE
forbedre nullsjekk for alder for foreldreansvar

### DIFF
--- a/src/components/PersonLinje/Details/Familie/index.tsx
+++ b/src/components/PersonLinje/Details/Familie/index.tsx
@@ -11,7 +11,7 @@ function Familie() {
 
     const person = data?.person;
     const feilendeSystemer = data?.feilendeSystemer;
-    const erUnder22 = person?.alder && person.alder <= 21;
+    const erUnder22 = person?.alder != null && person.alder <= 21;
     const harFeilendeSystem = harFeilendeSystemer(
         feilendeSystemer ?? [],
         PersonDataFeilendeSystemer.PDL_TREDJEPARTSPERSONER


### PR DESCRIPTION
For å unngå dette:
<img width="186" height="181" alt="image" src="https://github.com/user-attachments/assets/10a2746d-8256-465a-ba5e-9e10dd1766d5" />

Me har aldri kunna sjå foreldrene til barn på 0 år i nye modia