### PR TITLE
Endrer hook til å returnere alle utbetalinger

### DIFF
--- a/src/components/Utbetaling/Filter.tsx
+++ b/src/components/Utbetaling/Filter.tsx
@@ -73,7 +73,7 @@ const DateFilter = () => {
 
 const UtbetalingYtelserFilter = () => {
     const { data } = useFilterUtbetalinger();
-    const utbetalinger = data?.alleUtbetalinger ?? [];
+    const utbetalinger = data?.alleUtbetalinger;
     const [selectedYtelse, setSelectedYtelse] = useAtom(utbetalingFilterYtelseTypeAtom);
 
     const onToggleSelected = useCallback(

--- a/src/components/Utbetaling/Filter.tsx
+++ b/src/components/Utbetaling/Filter.tsx
@@ -73,7 +73,7 @@ const DateFilter = () => {
 
 const UtbetalingYtelserFilter = () => {
     const { data } = useFilterUtbetalinger();
-    const utbetalinger = data?.utbetalinger ?? [];
+    const utbetalinger = data?.alleUtbetalinger ?? [];
     const [selectedYtelse, setSelectedYtelse] = useAtom(utbetalingFilterYtelseTypeAtom);
 
     const onToggleSelected = useCallback(

--- a/src/components/Utbetaling/utils.ts
+++ b/src/components/Utbetaling/utils.ts
@@ -47,7 +47,7 @@ export const useFilterUtbetalinger = (): QueryResult<FilteredUtbetalingerRespons
         data: {
             ...utbetalingerResponse.data,
             utbetalinger: filterUtbetalinger(sortedUtbetalinger, filters) ?? [],
-            alleUtbetalinger: sortedUtbetalinger
+            alleUtbetalinger: sortedUtbetalinger ?? []
         },
         errorMessages: errorMessages.filter(Boolean)
     } as QueryResult<FilteredUtbetalingerResponse>;

--- a/src/components/Utbetaling/utils.ts
+++ b/src/components/Utbetaling/utils.ts
@@ -30,7 +30,9 @@ const filterUtbetalinger = (utbetalinger: Utbetaling[], filters: UtbetalingFilte
     return filteredList;
 };
 
-export const useFilterUtbetalinger = (): QueryResult<UtbetalingerResponseDto> => {
+type FilteredUtbetalingerResponse = UtbetalingerResponseDto & { alleUtbetalinger: Utbetaling[] };
+
+export const useFilterUtbetalinger = (): QueryResult<FilteredUtbetalingerResponse> => {
     const filters = useAtomValue(utbetalingFilterAtom);
     const startDato = (filters.dateRange.from ?? dayjs().subtract(2, 'year')).startOf('day').format('YYYY-MM-DD');
     const sluttDato = (filters.dateRange.to ?? dayjs()).endOf('day').format('YYYY-MM-DD');
@@ -44,10 +46,11 @@ export const useFilterUtbetalinger = (): QueryResult<UtbetalingerResponseDto> =>
         ...utbetalingerResponse,
         data: {
             ...utbetalingerResponse.data,
-            utbetalinger: filterUtbetalinger(sortedUtbetalinger, filters) ?? []
+            utbetalinger: filterUtbetalinger(sortedUtbetalinger, filters) ?? [],
+            alleUtbetalinger: sortedUtbetalinger
         },
         errorMessages: errorMessages.filter(Boolean)
-    } as QueryResult<UtbetalingerResponseDto>;
+    } as QueryResult<FilteredUtbetalingerResponse>;
 };
 
 const getNettoSumYtelser = (ytelser: Ytelse[]): number => {


### PR DESCRIPTION
Tidligere returnerte dropdownen ytelser basert på utbetalinger som allerede var blitt filtrert. Med denne endringen vil dropdownen reflektere alle utbetalinger slik at det er mulig å filtrere på flere ytelser samtidig.