### PR TITLE
Enforce pnpm 11.6 og flytt config til pnpm-workspace

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,7 @@ jobs:
             - uses: actions/checkout@v6
             - uses: pnpm/action-setup@v5
               with:
-                version: 9
+                version: 11.6.0
                 run_install: false
             - uses: actions/setup-node@v6
               with:

--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -20,7 +20,7 @@ jobs:
               uses: actions/checkout@v6
             - uses: pnpm/action-setup@v5
               with:
-                version: 9
+                version: 11.6.0
                 run_install: false
             - uses: actions/setup-node@v6
               with:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -23,7 +23,7 @@ jobs:
             - uses: actions/checkout@v6
             - uses: pnpm/action-setup@v5
               with:
-                version: 9
+                version: 11.6.0
                 run_install: false
             - uses: actions/setup-node@v6
               with:

--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -22,7 +22,7 @@ jobs:
     - uses: actions/checkout@v6
     - uses: pnpm/action-setup@v5
       with:
-        version: 9
+        version: 11.6.0
         run_install: false
     - uses: actions/setup-node@v6
       with:

--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -21,7 +21,7 @@ jobs:
       - uses: actions/checkout@v6
       - uses: pnpm/action-setup@v5
         with:
-          version: 9
+          version: 11.6.0
           run_install: false
 
       - uses: actions/setup-node@v6

--- a/.npmrc
+++ b/.npmrc
@@ -1,5 +1,0 @@
-engine-strict=true
-registry=https://registry.npmjs.org
-
-//npm.pkg.github.com/:_authToken=${NODE_AUTH_TOKEN}
-@navikt:registry=https://npm.pkg.github.com

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@ FROM node:24-slim AS builder
 
 ENV PNPM_HOME="/pnpm"
 ENV PATH="$PNPM_HOME:$PATH"
-RUN corepack enable && npm i -g corepack@latest
+RUN corepack enable && corepack prepare pnpm@11.6.0 --activate
 
 WORKDIR /app
 COPY pnpm-lock.yaml .npmrc /app

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,17 +7,15 @@ RUN corepack enable && corepack prepare pnpm@11.6.0 --activate
 WORKDIR /app
 COPY pnpm-lock.yaml  /app
 RUN --mount=type=secret,id=node_auth_token \
-  NODE_AUTH_TOKEN=$(cat /run/secrets/node_auth_token) \
+  env "pnpm_config_//npm.pkg.github.com/:_authToken=$(cat /run/secrets/node_auth_token)" \
   pnpm fetch
 
 COPY . /app
 RUN --mount=type=secret,id=node_auth_token \
-  NODE_AUTH_TOKEN=$(cat /run/secrets/node_auth_token) \
+  env "pnpm_config_//npm.pkg.github.com/:_authToken=$(cat /run/secrets/node_auth_token)" \
   pnpm install -r --offline
 
-RUN --mount=type=secret,id=node_auth_token \
-  NODE_AUTH_TOKEN=$(cat /run/secrets/node_auth_token) \
-  pnpm run build
+RUN pnpm run build
 
 FROM europe-north1-docker.pkg.dev/nais-management-233d/personoversikt/modia-frontend:1.13
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,7 @@ ENV PATH="$PNPM_HOME:$PATH"
 RUN corepack enable && corepack prepare pnpm@11.6.0 --activate
 
 WORKDIR /app
-COPY pnpm-lock.yaml .npmrc /app
+COPY pnpm-lock.yaml  /app
 RUN --mount=type=secret,id=node_auth_token \
   NODE_AUTH_TOKEN=$(cat /run/secrets/node_auth_token) \
   pnpm fetch

--- a/README.md
+++ b/README.md
@@ -26,10 +26,10 @@ Kun et `LOCAL_TOKEN` er nødvendig. Dette kan hentes fra
 <https://azure-token-generator.intern.dev.nav.no/api/obo?aud=dev-gcp:personoversikt:modiapersonoversikt>.
 
 #### Laste ned pakker fra @navikt 
-Opprett githubtoken og konfigurer SSO for å autorisere tokenet mot navikt (husk å legg til expiration date)
+Opprett GitHub-token og konfigurer SSO for å autorisere tokenet mot navikt (husk å legg til expiration date)
 Set tokenet i pnpm config:
 ```console
-pnpm config set //npm.pkg.github.com/:_authToken <gh_token>
+pnpm config set //npm.pkg.github.com/:_authToken <gh_token> --location=user
 ```
 
 Start appen

--- a/README.md
+++ b/README.md
@@ -25,6 +25,15 @@ av tokens for kallene som skjer til `/proxy` og `/modiapersonoversikt-draft`.
 Kun et `LOCAL_TOKEN` er nødvendig. Dette kan hentes fra
 <https://azure-token-generator.intern.dev.nav.no/api/obo?aud=dev-gcp:personoversikt:modiapersonoversikt>.
 
+#### Laste ned pakker fra @navikt 
+Opprett githubtoken og konfigurer SSO for å autorisere tokenet mot navikt (husk å legg til expiration date)
+Set tokenet i pnpm config:
+```console
+pnpm config set //npm.pkg.github.com/:_authToken <gh_token>
+```
+
+Start appen
+
 ```console
 pnpm i
 pnpm run start

--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
     "license": "MIT",
     "main": "build/dist/index.js",
     "type": "module",
+    "packageManager": "pnpm@11.6.0",
     "files": [
         "build/dist/"
     ],
@@ -190,14 +191,5 @@
     },
     "msw": {
         "workerDirectory": "./public"
-    },
-    "pnpm": {
-        "ignoredBuiltDependencies": [
-            "esbuild",
-            "msw"
-        ],
-        "onlyBuiltDependencies": [
-            "msw"
-        ]
     }
 }

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,0 +1,10 @@
+engineStrict: true
+
+registries:
+  default: https://registry.npmjs.org/
+  '@navikt': https://npm.pkg.github.com/
+
+allowBuilds:
+  esbuild: false
+  msw: false
+  protobufjs: false

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -6,5 +6,5 @@ registries:
 
 allowBuilds:
   esbuild: false
-  msw: false
+  msw: true
   protobufjs: false


### PR DESCRIPTION
Docker build brukte den nyeste pnpm-versjonen som er 11.6, medan me var stuck på versjon 9.
Versjon 11.6 inneholder breaking changes der ein ikkje lenger godtar å injecte tokens i  `.npmrc` fila. Så dette er for ekstra sikkerhet.
https://github.com/pnpm/pnpm/releases

Me er no over på på versjon 11.6  av pnpm på alle steder og det blir også enforca at det blir brukt lokalt via packagemanger i `package.json`. Dette krever litt endringer i korleis `NODE_AUTH_TOKEN` blir injecta. Dette er tokenet spm er brukt for å laste ned pakker fra @navikt. Istaden for at pnpm leser fra `.npmrc` fila (som no er sletta) så eksporterer me variabelen til global config slik at den ikkje ligger i repositoriet, og dette skjer runtime. Har oppdatert dockerfila i henhold til nye autentiserings-innstillinger i versjon 11.6: https://pnpm.io/npmrc.
Resten av configen som var i `.npmrc` fila er flytta til `pnpm-workspace.yaml`.

Dette må også gjerast lokalt ved utvikling, så sjå oppdatert readme for dette.