### PR TITLE
Fjern forhandsvalgt dialogtype

### DIFF
--- a/e2e/meldinger.spec.ts
+++ b/e2e/meldinger.spec.ts
@@ -53,6 +53,7 @@ test('Send ny melding', async ({ page }) => {
 
     await page.getByRole('button', { name: 'Skriv ny melding' }).click();
     await page.getByRole('button', { name: 'Overskrid' }).click();
+    await page.getByRole('radio', { name: 'Referat' }).click();
     await page.getByRole('textbox').fill('playwright new melding');
     await page.getByLabel('Temagruppe').selectOption('Pensjon');
 

--- a/src/components/melding/NyMelding.tsx
+++ b/src/components/melding/NyMelding.tsx
@@ -49,7 +49,7 @@ function NyMelding() {
     const { update: updateDraft, remove: removeDraft, status: draftStatus } = useDraft(draftContext, draftLoader);
 
     const defaultFormOptions: DefaultFormOptions = {
-        meldingsType: MeldingsType.Referat,
+        meldingsType: undefined,
         melding: defaultMessage,
         tema: undefined,
         oppgaveliste: Oppgaveliste.MinListe,
@@ -64,7 +64,7 @@ function NyMelding() {
         },
         onSubmit: ({ value }) => {
             const body = generateRequestBody(value as NyMeldingSchema);
-            trackSendNyMelding(meldingsTyperTekst[meldingsType].tittel.toLowerCase());
+            if (meldingsType) trackSendNyMelding(meldingsTyperTekst[meldingsType].tittel.toLowerCase());
             mutate(
                 { body: body },
                 {
@@ -87,7 +87,7 @@ function NyMelding() {
     });
 
     const meldingsType = useStore(form.store, (state) => state.values.meldingsType);
-    const meldingsTypeTekst = meldingsTyperTekst[meldingsType];
+    const meldingsTypeTekst = meldingsType ? meldingsTyperTekst[meldingsType] : undefined;
     const textAreaRef = useRef<HTMLTextAreaElement>(null);
 
     return (
@@ -102,6 +102,11 @@ function NyMelding() {
                 <form.Field name="meldingsType">
                     {(field) => (
                         <VelgMeldingsType
+                            error={
+                                field.state.meta.errors.length ? (
+                                    <ValidationErrorMessage errors={field.state.meta.errors} />
+                                ) : undefined
+                            }
                             meldingsType={field.state.value}
                             setMeldingsType={(meldingsType) => {
                                 form.reset({
@@ -122,7 +127,11 @@ function NyMelding() {
                                 <VelgTema
                                     valgtTema={field.state.value}
                                     setValgtTema={(tema) => field.handleChange(tema)}
-                                    error={<ValidationErrorMessage errors={field.state.meta.errors} />}
+                                    error={
+                                        field.state.meta.errors.length ? (
+                                            <ValidationErrorMessage errors={field.state.meta.errors} />
+                                        ) : undefined
+                                    }
                                 />
                             )}
                         </form.Field>
@@ -173,7 +182,7 @@ function NyMelding() {
                                 <AutocompleteTextarea
                                     disabled={disableDialog}
                                     ref={textAreaRef}
-                                    label={meldingsTypeTekst.tittel}
+                                    label={meldingsTypeTekst?.tittel}
                                     hideLabel
                                     size="small"
                                     value={field.state.value}
@@ -242,7 +251,7 @@ function NyMelding() {
 }
 
 function ValidationErrorMessage({ errors }: { errors: ValidationError[] }) {
-    return errors.isNotEmpty() ? <ErrorMessage>{buildErrorMessage(errors)}</ErrorMessage> : null;
+    return errors.isNotEmpty() ? <ErrorMessage size="small">{buildErrorMessage(errors)}</ErrorMessage> : null;
 }
 
 function buildErrorMessage(errors: ValidationError[]) {
@@ -262,7 +271,7 @@ function generateRequestBody(value: NyMeldingSchema) {
         fritekst: value.melding,
         fnr: value.fnr
     };
-    let request: SendMeldingRequestV2;
+    let request: SendMeldingRequestV2 | undefined;
 
     switch (value.meldingsType) {
         case MeldingsType.Referat:
@@ -290,6 +299,8 @@ function generateRequestBody(value: NyMeldingSchema) {
                 erOppgaveTilknyttetAnsatt: value.oppgaveliste === Oppgaveliste.MinListe
             };
             break;
+        default:
+            throw new Error(`Ukjent meldingsType: ${value.meldingsType}`);
     }
     return request;
 }
@@ -297,7 +308,7 @@ function generateRequestBody(value: NyMeldingSchema) {
 type NyMeldingSchema = z.infer<typeof nyMeldingSchema>;
 
 interface DefaultFormOptions {
-    meldingsType: MeldingsType;
+    meldingsType?: MeldingsType;
     melding: string;
     tema?: Temagruppe;
     oppgaveliste?: Oppgaveliste;

--- a/src/components/melding/ValgForMeldingstype.tsx
+++ b/src/components/melding/ValgForMeldingstype.tsx
@@ -5,7 +5,7 @@ import type VelgTema from 'src/components/melding/VelgTema';
 import type VelgSak from 'src/components/sakVelger/VelgSak';
 
 interface ValgForMeldingstypeProps {
-    meldingsType: MeldingsType;
+    meldingsType?: MeldingsType;
     velgTema: ReactElement<typeof VelgTema>;
     velgOppgaveliste: ReactElement<typeof VelgOppgaveliste>;
     velgSak: ReactElement<typeof VelgSak>;
@@ -24,5 +24,7 @@ export function ValgForMeldingstype({ meldingsType, velgTema, velgOppgaveliste, 
             );
         case MeldingsType.Infomelding:
             return velgSak;
+        default:
+            return undefined;
     }
 }

--- a/src/components/melding/VelgMeldingsType.tsx
+++ b/src/components/melding/VelgMeldingsType.tsx
@@ -1,39 +1,41 @@
-import { Radio, RadioGroup, VStack } from '@navikt/ds-react';
+import { Radio, RadioGroup } from '@navikt/ds-react';
+import { Normaltekst } from 'nav-frontend-typografi';
+import type { ReactNode } from 'react';
 import { useDisableDialog } from 'src/lib/state/dialog';
 import { TraadType } from 'src/lib/types/modiapersonoversikt-api';
 
 interface VelgMeldingsTypeProps {
-    meldingsType: MeldingsType;
+    meldingsType?: MeldingsType;
     setMeldingsType: (meldingsType: MeldingsType) => void;
+    error?: ReactNode;
 }
 
-export function VelgMeldingsType({ meldingsType, setMeldingsType }: VelgMeldingsTypeProps) {
+export function VelgMeldingsType({ meldingsType, setMeldingsType, error }: VelgMeldingsTypeProps) {
     const disableDialog = useDisableDialog();
-
     return (
         <RadioGroup
-            legend="Type dialog"
-            hideLegend
+            error={error}
+            legend="Velg type dialog"
             onChange={setMeldingsType}
             value={meldingsType}
             size="small"
             disabled={disableDialog}
         >
-            <VStack gap="space-4">
-                <MeldingsTypeRadioKnapper valgtMeldingsType={meldingsType} />
-            </VStack>
+            <MeldingsTypeRadioKnapper />
         </RadioGroup>
     );
 }
 
-function MeldingsTypeRadioKnapper({ valgtMeldingsType }: { valgtMeldingsType: MeldingsType }) {
+function MeldingsTypeRadioKnapper() {
     return Object.entries(MeldingsType).map(([key, value]) => (
         <Radio
+            className="p-[0.3rem]"
             key={key}
             value={value}
-            description={valgtMeldingsType === value ? meldingsTyperTekst[value].beskrivelse : ''}
+            description={meldingsTyperTekst[value].beskrivelse}
+            size="small"
         >
-            {value}
+            <Normaltekst className="font-ax-bold">{value}</Normaltekst>
         </Radio>
     ));
 }
@@ -52,15 +54,15 @@ interface MeldingsTypeTekst {
 export const meldingsTyperTekst: Record<MeldingsType, MeldingsTypeTekst> = {
     Referat: {
         tittel: 'Referat',
-        beskrivelse: 'Bruker får ikke varsel, og kan ikke svare'
+        beskrivelse: 'Bruker mottar ikke varsel, og kan ikke svare'
     },
     Samtale: {
         tittel: 'Samtale',
-        beskrivelse: 'Brukeren mottar varsel, og kan svare'
+        beskrivelse: 'Bruker mottar varsel, og kan svare'
     },
     Infomelding: {
         tittel: 'Infomelding',
-        beskrivelse: 'Bruker mottar varsel, men kan ikke svare'
+        beskrivelse: 'Bruker mottar varsel, og kan ikke svare'
     }
 } as const;
 

--- a/src/components/melding/VelgTema.tsx
+++ b/src/components/melding/VelgTema.tsx
@@ -22,10 +22,10 @@ export default function VelgTema({ valgtTema, setValgtTema, error }: VelgTemaPro
                 }}
                 value={valgtTema ?? ''}
                 size="small"
+                error={error}
             >
                 <TemagruppeActionMenuItems />
             </Select>
-            {error}
         </VStack>
     );
 }

--- a/src/components/melding/nyMeldingSchema.ts
+++ b/src/components/melding/nyMeldingSchema.ts
@@ -26,25 +26,42 @@ const sakSchema = z.object(
 );
 
 const nyMeldingSchema = z
-    .discriminatedUnion('meldingsType', [
-        z.object({
-            meldingsType: z.literal(MeldingsType.Referat),
-            tema: z.nativeEnum(Temagruppe, {
-                message: 'Knytt meldingen til en temagruppe'
-            })
-        }),
-        z.object({
-            meldingsType: z.literal(MeldingsType.Samtale),
-            oppgaveliste: z.nativeEnum(Oppgaveliste),
-            sak: sakSchema
-        }),
-        z.object({
-            meldingsType: z.literal(MeldingsType.Infomelding),
-            oppgaveliste: z.nativeEnum(Oppgaveliste),
-            sak: sakSchema
-        })
-    ])
-    .and(commonSchema);
+    .object({
+        meldingsType: z.nativeEnum(MeldingsType, { message: 'Velg dialogtype' }).optional(),
+        melding: z.string().nonempty('Fyll ut meldingsfeltet').max(maksLengdeMelding, `Maks ${maksLengdeMelding} tegn`),
+        fnr: z.string(),
+        enhetsId: z.string(),
+        tema: z.nativeEnum(Temagruppe).optional(),
+        oppgaveliste: z.nativeEnum(Oppgaveliste).optional(),
+        sak: sakSchema.optional()
+    })
+    .superRefine((val, ctx) => {
+        if (!val.meldingsType) {
+            ctx.addIssue({ code: z.ZodIssueCode.custom, message: 'Velg dialogtype', path: ['meldingsType'] });
+            return z.NEVER;
+        }
+        switch (val.meldingsType) {
+            case MeldingsType.Referat:
+                if (!val.tema) {
+                    ctx.addIssue({
+                        code: z.ZodIssueCode.custom,
+                        message: 'Knytt meldingen til en temagruppe',
+                        path: ['tema']
+                    });
+                }
+                break;
+            case MeldingsType.Samtale:
+            case MeldingsType.Infomelding:
+                if (!val.sak) {
+                    ctx.addIssue({
+                        code: z.ZodIssueCode.custom,
+                        message: 'Meldingen må knyttes til en sak',
+                        path: ['sak']
+                    });
+                }
+                break;
+        }
+    });
 
 export default nyMeldingSchema;
 

--- a/src/components/melding/nyMeldingSchema.ts
+++ b/src/components/melding/nyMeldingSchema.ts
@@ -38,7 +38,7 @@ const nyMeldingSchema = z
     .superRefine((val, ctx) => {
         if (!val.meldingsType) {
             ctx.addIssue({ code: z.ZodIssueCode.custom, message: 'Velg dialogtype', path: ['meldingsType'] });
-            return z.NEVER;
+            return;
         }
         switch (val.meldingsType) {
             case MeldingsType.Referat:

--- a/src/index.css
+++ b/src/index.css
@@ -73,3 +73,7 @@
 .aksel-chat__avatar{
     border: none;
 }
+
+.aksel-radio__description {
+    font-style: italic;
+}


### PR DESCRIPTION
Bruker må ta eit aktivt valg av dialogtype. Om dette ikkje er gjort vil ikkje skjemaet valideres. Har også  gjort beskrivelsene under kvar dialogtype synleg heile tiden.