### PR TITLE
Hent beregninger for dagpenger med gjenstående dager

### DIFF
--- a/src/components/ytelser/Detail/dagpenger/index.tsx
+++ b/src/components/ytelser/Detail/dagpenger/index.tsx
@@ -3,10 +3,9 @@ import Card from 'src/components/Card';
 import { TitleValuePairsComponent } from 'src/components/ytelser/Detail';
 import { periodeEllerNull } from 'src/components/ytelser/utils';
 import type {
-    PeriodeDagpengerDto,
-    PeriodeDagpengerDtoKilde,
-    PeriodeDagpengerDtoYtelseType,
-    PseudoDagpengerVedtak
+    BeregnetDagDagpengerDto,
+    BeregnetDagDagpengerDtoKilde,
+    Dagpenger
 } from 'src/generated/modiapersonoversikt-api';
 import { datoEllerTomString, formaterDato } from 'src/utils/string-utils';
 
@@ -14,7 +13,7 @@ import { datoEllerTomString, formaterDato } from 'src/utils/string-utils';
  * name. Not as good as a hashmap or maybe a gettext PO based solution, ideally
  * maintained by somebody else, but likely to work reasonably well even if the
  * sets change. */
-const prettyEnum = (ytelseType: PeriodeDagpengerDtoKilde | PeriodeDagpengerDtoYtelseType) =>
+const prettyEnum = (ytelseType: BeregnetDagDagpengerDtoKilde) =>
     ytelseType
         .replace(/^DAGPENGER_/, '')
         .replace('ARBEIDSSOKER', 'ARBEIDSSØKER')
@@ -24,23 +23,22 @@ const prettyEnum = (ytelseType: PeriodeDagpengerDtoKilde | PeriodeDagpengerDtoYt
         .replace('_', ' ')
         .replace(/\b./, (initial: string) => initial.toUpperCase());
 
-const rowKey = (periode: PeriodeDagpengerDto) => periode.ytelseType + periode.fraOgMedDato;
+const rowKey = (ytelse: BeregnetDagDagpengerDto) => ytelse.fraOgMed;
 
 /**
  * Periods may not have an end. periodeEllerNull happens to format this just the
  * way we want.
  */
-const rowHeader = (periode: PeriodeDagpengerDto) =>
-    `${prettyEnum(periode.ytelseType)} ${periodeEllerNull({
-        fra: periode.fraOgMedDato,
-        til: periode.tilOgMedDato
+const rowHeader = (ytelse: BeregnetDagDagpengerDto) =>
+    `${periodeEllerNull({
+        fra: ytelse.fraOgMed,
+        til: ytelse.tilOgMed
     })}`;
 
-const PeriodeContent = ({ periode }: { periode: PeriodeDagpengerDto }) => {
+const PeriodeContent = ({ periode }: { periode: BeregnetDagDagpengerDto }) => {
     const entries = {
-        'Fra og med': formaterDato(periode.fraOgMedDato),
-        'Til og med': datoEllerTomString(periode.tilOgMedDato),
-        Type: prettyEnum(periode.ytelseType),
+        'Fra og med': formaterDato(periode.fraOgMed),
+        'Til og med': datoEllerTomString(periode.tilOgMed),
         Kilde: prettyEnum(periode.kilde)
     };
     return (
@@ -58,7 +56,7 @@ const PeriodeContent = ({ periode }: { periode: PeriodeDagpengerDto }) => {
  * Accordion seems like way overkill, but we use it to keep in theme with the
  * rest of the ytelser.
  */
-const Perioder = ({ perioder }: { perioder: PeriodeDagpengerDto[] }) => (
+const Perioder = ({ perioder }: { perioder: BeregnetDagDagpengerDto[] }) => (
     <Card paddingBlock="4">
         <Heading as="h4" size="small">
             Perioder
@@ -76,7 +74,7 @@ const Perioder = ({ perioder }: { perioder: PeriodeDagpengerDto[] }) => (
     </Card>
 );
 
-export const DagpengerDetails = ({ ytelse }: { ytelse: PseudoDagpengerVedtak }) => (
+export const DagpengerDetails = ({ ytelse }: { ytelse: Dagpenger }) => (
     <VStack gap="space-4" minHeight="0">
         <Card padding="space-16">
             <Heading as="h3" size="small">

--- a/src/components/ytelser/Detail/dagpenger/index.tsx
+++ b/src/components/ytelser/Detail/dagpenger/index.tsx
@@ -1,4 +1,5 @@
 import { Accordion, Heading, VStack } from '@navikt/ds-react';
+import { Normaltekst } from 'nav-frontend-typografi';
 import Card from 'src/components/Card';
 import { TitleValuePairsComponent } from 'src/components/ytelser/Detail';
 import { periodeEllerNull } from 'src/components/ytelser/utils';
@@ -7,7 +8,6 @@ import type {
     BeregnetDagDagpengerDtoKilde,
     Dagpenger
 } from 'src/generated/modiapersonoversikt-api';
-import { datoEllerTomString, formaterDato } from 'src/utils/string-utils';
 
 /* Takes enum entry for benefit type and source and derives a human readable
  * name. Not as good as a hashmap or maybe a gettext PO based solution, ideally
@@ -37,16 +37,13 @@ const rowHeader = (ytelse: BeregnetDagDagpengerDto) =>
 
 const PeriodeContent = ({ periode }: { periode: BeregnetDagDagpengerDto }) => {
     const entries = {
-        'Fra og med': formaterDato(periode.fraOgMed),
-        'Til og med': datoEllerTomString(periode.tilOgMed),
-        Kilde: prettyEnum(periode.kilde)
+        Kilde: prettyEnum(periode.kilde),
+        Sats: periode.sats,
+        'Gjenstående dager': periode.gjenståendeDager
     };
     return (
         <Accordion.Content>
-            <Heading as="h5" size="small">
-                Anviste utbetalinger
-            </Heading>
-            <TitleValuePairsComponent entries={entries} columns={{ xs: 2, lg: 4 }} />
+            <TitleValuePairsComponent entries={entries} columns={{ xs: 2, md: 3 }} />
         </Accordion.Content>
     );
 };
@@ -61,10 +58,10 @@ const Perioder = ({ perioder }: { perioder: BeregnetDagDagpengerDto[] }) => (
         <Heading as="h4" size="small">
             Perioder
         </Heading>
-        <Accordion size="small" headingSize="xsmall">
-            {perioder.map((periode) => {
+        <Accordion size="small">
+            {perioder.map((periode, i) => {
                 return (
-                    <Accordion.Item key={rowKey(periode)} defaultOpen>
+                    <Accordion.Item key={rowKey(periode)} defaultOpen={i === 0}>
                         <Accordion.Header>{rowHeader(periode)}</Accordion.Header>
                         <PeriodeContent periode={periode} />
                     </Accordion.Item>
@@ -77,9 +74,14 @@ const Perioder = ({ perioder }: { perioder: BeregnetDagDagpengerDto[] }) => (
 export const DagpengerDetails = ({ ytelse }: { ytelse: Dagpenger }) => (
     <VStack gap="space-4" minHeight="0">
         <Card padding="space-16">
-            <Heading as="h3" size="small">
+            <Heading as="h3" size="small" spacing>
                 Om dagpenger
             </Heading>
+            <Normaltekst>
+                Dataen er basert på beregnede meldeperioder fra både Arena og DP-sak. Sats er inklusiv barnetillegg og
+                eventuelt redusert etter samordning. Gjenstående dager er dager med dagpengerettighet etter perioden.
+            </Normaltekst>
+
             <VStack gap="space-4" minHeight="0">
                 <Perioder perioder={ytelse.perioder} />
             </VStack>

--- a/src/components/ytelser/Detail/dagpenger/index.tsx
+++ b/src/components/ytelser/Detail/dagpenger/index.tsx
@@ -25,10 +25,6 @@ const prettyEnum = (ytelseType: BeregnetDagDagpengerDtoKilde) =>
 
 const rowKey = (ytelse: BeregnetDagDagpengerDto) => ytelse.fraOgMed;
 
-/**
- * Periods may not have an end. periodeEllerNull happens to format this just the
- * way we want.
- */
 const rowHeader = (ytelse: BeregnetDagDagpengerDto) =>
     `${periodeEllerNull({
         fra: ytelse.fraOgMed,

--- a/src/components/ytelser/Detail/foreldrepenger/index.tsx
+++ b/src/components/ytelser/Detail/foreldrepenger/index.tsx
@@ -38,8 +38,8 @@ const ForeldrepengerPerioder = ({ ytelse }: { ytelse: Foreldrepenger }) => {
             <Accordion size="small">
                 {ytelse.perioder.map((periode, index) => {
                     return (
-                        <Accordion.Item key={`${index}-${periode.fom}`}>
-                            <Accordion.Header>{`Periode - ${datoEllerTomString(periode.fom)}`}</Accordion.Header>
+                        <Accordion.Item key={`${index}-${periode.fom}`} defaultOpen={index === 0}>
+                            <Accordion.Header>{`${datoEllerTomString(periode.fom)} – ${datoEllerTomString(periode.tom)}`}</Accordion.Header>
                             <Accordion.Content>
                                 <TitleValuePairsComponent entries={getEntries(periode)} columns={{ xs: 2, md: 3 }} />
                             </Accordion.Content>

--- a/src/components/ytelser/Detail/index.tsx
+++ b/src/components/ytelser/Detail/index.tsx
@@ -11,14 +11,14 @@ import { TiltaksPengerDetails } from 'src/components/ytelser/Detail/tiltakspenge
 import { useSetIdQueryParam } from 'src/components/ytelser/useSetIdQueryParam';
 import { getUnikYtelseKey, useFilterYtelser, type YtelseVedtak } from 'src/components/ytelser/utils';
 import type {
+    Dagpenger,
     Foreldrepenger,
     PensjonSak,
-    PseudoDagpengerVedtak,
     Sykepenger,
-    SykepengerSpokelse,
-    VedtakDto
+    SykepengerSpokelse
 } from 'src/generated/modiapersonoversikt-api';
 import type { Arbeidsavklaringspenger } from 'src/models/ytelse/arbeidsavklaringspenger';
+import type { Tiltakspenger } from 'src/models/ytelse/tiltakspenger';
 import { YtelseVedtakYtelseType } from 'src/models/ytelse/ytelse-utils';
 
 const TitleValuePairComponent = ({ title, value }: { title: string; value: string | number | null | undefined }) => {
@@ -88,8 +88,8 @@ const YtelseDataDetails = ({ ytelser }: { ytelser: YtelseVedtak[] }) => {
     switch (selectedYtelse.ytelseType) {
         case YtelseVedtakYtelseType.Sykepenger:
             return <SykepengerDetails sykepenger={selectedYtelse.ytelseData.data as Sykepenger} />;
-        case YtelseVedtakYtelseType.Tiltakspenge:
-            return <TiltaksPengerDetails tiltaksPenger={selectedYtelse.ytelseData.data as VedtakDto} />;
+        case YtelseVedtakYtelseType.Tiltakspenger:
+            return <TiltaksPengerDetails tiltaksPenger={selectedYtelse.ytelseData.data as Tiltakspenger} />;
         case YtelseVedtakYtelseType.Pensjon:
             return <PensjonDetails pensjon={selectedYtelse.ytelseData.data as PensjonSak} />;
         case YtelseVedtakYtelseType.Arbeidsavklaringspenger:
@@ -97,7 +97,7 @@ const YtelseDataDetails = ({ ytelser }: { ytelser: YtelseVedtak[] }) => {
         case YtelseVedtakYtelseType.Foreldrepenger:
             return <ForeldrePengerDetails ytelse={selectedYtelse.ytelseData.data as Foreldrepenger} />;
         case YtelseVedtakYtelseType.Dagpenger:
-            return <DagpengerDetails ytelse={selectedYtelse.ytelseData.data as PseudoDagpengerVedtak} />;
+            return <DagpengerDetails ytelse={selectedYtelse.ytelseData.data as Dagpenger} />;
         case YtelseVedtakYtelseType.SykepengerSpokelse:
             return <SykePengerSpokelseDetails ytelse={selectedYtelse.ytelseData.data as SykepengerSpokelse} />;
         default:

--- a/src/components/ytelser/Detail/tiltakspenger/index.tsx
+++ b/src/components/ytelser/Detail/tiltakspenger/index.tsx
@@ -1,10 +1,10 @@
 import { Heading, VStack } from '@navikt/ds-react';
 import Card from 'src/components/Card';
 import { TitleValuePairsComponent } from 'src/components/ytelser/Detail';
-import type { BarnetilleggPeriode, VedtakDto } from 'src/generated/modiapersonoversikt-api';
+import type { Tiltakspenger, TiltakspengerBarnetilleggPeriode } from 'src/models/ytelse/tiltakspenger';
 import { formaterDato } from 'src/utils/string-utils';
 
-const TiltaksPengerRetten = ({ tiltaksPenger }: { tiltaksPenger: VedtakDto }) => {
+const TiltaksPengerRetten = ({ tiltaksPenger }: { tiltaksPenger: Tiltakspenger }) => {
     const entries = {
         'Fra og med': formaterDato(tiltaksPenger.periode.fraOgMed),
         'Til og med': formaterDato(tiltaksPenger.periode.tilOgMed),
@@ -24,14 +24,14 @@ const TiltaksPengerRetten = ({ tiltaksPenger }: { tiltaksPenger: VedtakDto }) =>
     );
 };
 
-const getBarneTilleggEntries = (barnetilleggPeriode: BarnetilleggPeriode) => {
+const getBarneTilleggEntries = (barnetilleggPeriode: TiltakspengerBarnetilleggPeriode) => {
     return {
         'Antall barn': barnetilleggPeriode.antallBarn,
         Periode: `${formaterDato(barnetilleggPeriode.periode.fraOgMed)} - ${formaterDato(barnetilleggPeriode.periode.tilOgMed)}`
     };
 };
 
-const TiltaksPengerBarneTillegg = ({ tiltaksPenger }: { tiltaksPenger: VedtakDto }) => {
+const TiltaksPengerBarneTillegg = ({ tiltaksPenger }: { tiltaksPenger: Tiltakspenger }) => {
     if (!tiltaksPenger.barnetillegg?.perioder.length) return null;
     return (
         <Card padding="space-16">
@@ -45,7 +45,7 @@ const TiltaksPengerBarneTillegg = ({ tiltaksPenger }: { tiltaksPenger: VedtakDto
     );
 };
 
-export const TiltaksPengerDetails = ({ tiltaksPenger }: { tiltaksPenger: VedtakDto }) => {
+export const TiltaksPengerDetails = ({ tiltaksPenger }: { tiltaksPenger: Tiltakspenger }) => {
     return (
         <VStack gap="space-4" minHeight="0">
             <TiltaksPengerRetten tiltaksPenger={tiltaksPenger} />

--- a/src/components/ytelser/List/YtelseItem.tsx
+++ b/src/components/ytelser/List/YtelseItem.tsx
@@ -26,7 +26,7 @@ export const YtelseItem = ({ ytelse }: { ytelse: YtelseVedtak }) => {
     const getYtelseTittel = () => {
         switch (ytelse.ytelseType) {
             case YtelseVedtakYtelseType.Sykepenger:
-            case YtelseVedtakYtelseType.Tiltakspenge:
+            case YtelseVedtakYtelseType.Tiltakspenger:
             case YtelseVedtakYtelseType.Pensjon:
             case YtelseVedtakYtelseType.Arbeidsavklaringspenger:
             case YtelseVedtakYtelseType.Dagpenger:

--- a/src/components/ytelser/utils.ts
+++ b/src/components/ytelser/utils.ts
@@ -14,12 +14,11 @@ import {
 } from 'src/lib/clients/modiapersonoversikt-api';
 import type {
     CommonPeriode,
+    Dagpenger,
     Foreldrepenger,
     PensjonSak,
-    PseudoDagpengerVedtak,
     Sykepenger,
-    SykepengerSpokelse,
-    VedtakDto
+    SykepengerSpokelse
 } from 'src/lib/types/modiapersonoversikt-api';
 import {
     type Arbeidsavklaringspenger,
@@ -39,7 +38,7 @@ type Ytelse =
     | Pensjon
     | Arbeidsavklaringspenger
     | Foreldrepenger
-    | PseudoDagpengerVedtak
+    | Dagpenger
     | SykepengerSpokelse;
 
 type Placeholder = { returnOnForbidden: string; returnOnError: string; returnOnNotFound: string };
@@ -84,8 +83,8 @@ export function getYtelseIdDato(ytelse: YtelseVedtak): string {
             return getSykepengerDato(ytelse.ytelseData.data as Sykepenger);
         case YtelseVedtakYtelseType.SykepengerSpokelse:
             return getSykepengerSpokelseIdDato(ytelse.ytelseData.data as SykepengerSpokelse);
-        case YtelseVedtakYtelseType.Tiltakspenge:
-            return getTiltakspengerDato(ytelse.ytelseData.data as VedtakDto);
+        case YtelseVedtakYtelseType.Tiltakspenger:
+            return getTiltakspengerDato(ytelse.ytelseData.data as Tiltakspenger);
         case YtelseVedtakYtelseType.Pensjon:
             return getPensjonDato(ytelse.ytelseData.data as PensjonSak);
         case YtelseVedtakYtelseType.Arbeidsavklaringspenger:
@@ -93,7 +92,7 @@ export function getYtelseIdDato(ytelse: YtelseVedtak): string {
         case YtelseVedtakYtelseType.Foreldrepenger:
             return getForeldrepengerIdDato(ytelse.ytelseData.data as Foreldrepenger);
         case YtelseVedtakYtelseType.Dagpenger:
-            return getDagpengerIdDato(ytelse.ytelseData.data as PseudoDagpengerVedtak);
+            return getDagpengerIdDato(ytelse.ytelseData.data as Dagpenger);
         default:
             return '';
     }
@@ -105,8 +104,8 @@ export function getUnikYtelseKey(ytelse: YtelseVedtak) {
             return getUnikSykepengerKey(ytelse.ytelseData.data as Sykepenger);
         case YtelseVedtakYtelseType.SykepengerSpokelse:
             return getUnikSykepengerSpokelseKey(ytelse.ytelseData.data as SykepengerSpokelse);
-        case YtelseVedtakYtelseType.Tiltakspenge:
-            return getUnikTiltakspengerKey(ytelse.ytelseData.data as VedtakDto);
+        case YtelseVedtakYtelseType.Tiltakspenger:
+            return getUnikTiltakspengerKey(ytelse.ytelseData.data as Tiltakspenger);
         case YtelseVedtakYtelseType.Pensjon:
             return getPensjonpengerKey(ytelse.ytelseData.data as PensjonSak);
         case YtelseVedtakYtelseType.Arbeidsavklaringspenger:
@@ -114,7 +113,7 @@ export function getUnikYtelseKey(ytelse: YtelseVedtak) {
         case YtelseVedtakYtelseType.Foreldrepenger:
             return getUnikForeldrepengerKey(ytelse.ytelseData.data as Foreldrepenger);
         case YtelseVedtakYtelseType.Dagpenger:
-            return getUnikDagpengerKey(ytelse.ytelseData.data as PseudoDagpengerVedtak);
+            return getUnikDagpengerKey(ytelse.ytelseData.data as Dagpenger);
         default:
             return 'ukjent ytelse';
     }
@@ -128,7 +127,7 @@ function getUnikSykepengerSpokelseKey(ytelse: SykepengerSpokelse) {
     return `spokelse-${ytelse.utbetaltePerioder.firstOrNull()?.fom}`;
 }
 
-function getUnikTiltakspengerKey(ytelse: VedtakDto) {
+function getUnikTiltakspengerKey(ytelse: Tiltakspenger) {
     return `tiltakspenger${ytelse.vedtakId}`;
 }
 
@@ -145,7 +144,7 @@ function getSykepengerSpokelseIdDato(ytelse: SykepengerSpokelse) {
     return ytelse.utbetaltePerioder.lastOrNull()?.fom ?? dayjs().format(backendDatoformat);
 }
 
-function getTiltakspengerDato(ytelse: VedtakDto) {
+function getTiltakspengerDato(ytelse: Tiltakspenger) {
     return ytelse.periode.fraOgMed ?? dayjs().format(backendDatoformat);
 }
 
@@ -252,7 +251,7 @@ export const useFilterYtelser = (): QueryResult<YtelseVedtak[]> => {
     tiltakspengerResponse?.data?.map((ytelse) =>
         ytelser.push({
             ytelseData: { data: ytelse },
-            ytelseType: YtelseVedtakYtelseType.Tiltakspenge
+            ytelseType: YtelseVedtakYtelseType.Tiltakspenger
         })
     );
     pensjonResponse.data?.map((ytelse) =>

--- a/src/generated/modiapersonoversikt-api.ts
+++ b/src/generated/modiapersonoversikt-api.ts
@@ -1312,6 +1312,10 @@ export interface components {
         LocalDate: {
             /** Format: date */
             value?: string;
+            /** Format: date */
+            value$kotlinx_datetime: string;
+            /** Format: int32 */
+            monthNumber: number;
             /** Format: int32 */
             year: number;
             /** Format: int32 */
@@ -1322,14 +1326,16 @@ export interface components {
             dayOfWeek: LocalDateDayOfWeek;
             /** Format: int32 */
             dayOfYear: number;
-            /** Format: date */
-            value$kotlinx_datetime: string;
-            /** Format: int32 */
-            monthNumber: number;
         };
         LocalDateTime: {
             /** Format: date-time */
             value?: string;
+            /** Format: date-time */
+            value$kotlinx_datetime: string;
+            /** Format: int32 */
+            monthNumber: number;
+            /** Format: int32 */
+            nanosecond: number;
             time: components['schemas']['LocalTime'];
             /** Format: int32 */
             year: number;
@@ -1348,24 +1354,18 @@ export interface components {
             /** Format: int32 */
             dayOfYear: number;
             date: components['schemas']['LocalDate'];
-            /** Format: date-time */
-            value$kotlinx_datetime: string;
-            /** Format: int32 */
-            monthNumber: number;
-            /** Format: int32 */
-            nanosecond: number;
         };
         LocalTime: {
             value?: string;
+            value$kotlinx_datetime: string;
+            /** Format: int32 */
+            nanosecond: number;
             /** Format: int32 */
             hour: number;
             /** Format: int32 */
             minute: number;
             /** Format: int32 */
             second: number;
-            value$kotlinx_datetime: string;
-            /** Format: int32 */
-            nanosecond: number;
         };
         ResultatSoknadsstatus: {
             resultat: components['schemas']['SoknadsstatusSakstema'][];

--- a/src/generated/modiapersonoversikt-api.ts
+++ b/src/generated/modiapersonoversikt-api.ts
@@ -909,38 +909,38 @@ export interface components {
             fom?: string;
             tom?: string;
         };
-        Barnetillegg: {
-            perioder: components['schemas']['BarnetilleggPeriode'][];
-        };
-        BarnetilleggPeriode: {
-            /** Format: int32 */
-            antallBarn: number;
-            periode: components['schemas']['Periode'];
-        };
-        Periode: {
+        HentBehandlingsperioder200ResponseInnerPeriode: {
             /** Format: date */
             fraOgMed: string;
             /** Format: date */
             tilOgMed: string;
         };
-        VedtakDTO: {
+        HentVedtaksperioder200ResponseInner: {
             vedtakId: string;
             /** @enum {string} */
-            rettighet: VedtakDTORettighet;
-            periode: components['schemas']['Periode'];
+            rettighet: HentVedtaksperioder200ResponseInnerRettighet;
+            periode: components['schemas']['HentBehandlingsperioder200ResponseInnerPeriode'];
             /** @enum {string} */
-            kilde: VedtakDTOKilde;
-            barnetillegg?: components['schemas']['Barnetillegg'];
+            kilde: HentVedtaksperioder200ResponseInnerKilde;
+            barnetillegg?: components['schemas']['HentVedtaksperioder200ResponseInnerBarnetillegg'];
             /** Format: int32 */
             sats?: number;
             /** Format: int32 */
             satsBarnetillegg?: number;
-            vedtaksperiode?: components['schemas']['Periode'];
-            innvilgelsesperioder?: components['schemas']['Periode'][];
+            vedtaksperiode: components['schemas']['HentBehandlingsperioder200ResponseInnerPeriode'];
+            innvilgelsesperioder: components['schemas']['HentBehandlingsperioder200ResponseInnerPeriode'][];
             omgjortAvRammevedtakId?: string;
             omgjorRammevedtakId?: string;
             /** Format: date-time */
             vedtakstidspunkt?: string;
+        };
+        HentVedtaksperioder200ResponseInnerBarnetillegg: {
+            perioder: components['schemas']['HentVedtaksperioder200ResponseInnerBarnetilleggPerioderInner'][];
+        };
+        HentVedtaksperioder200ResponseInnerBarnetilleggPerioderInner: {
+            /** Format: int32 */
+            antallBarn: number;
+            periode: components['schemas']['HentBehandlingsperioder200ResponseInnerPeriode'];
         };
         CommonHistoriskUtbetaling: {
             vedtak?: components['schemas']['CommonPeriode'];
@@ -1104,18 +1104,22 @@ export interface components {
             /** Format: date */
             tilOgMedDato?: string;
         };
-        PeriodeDagpengerDto: {
+        BeregnetDagDagpengerDto: {
             /** Format: date */
-            fraOgMedDato: string;
-            /** @enum {string} */
-            kilde: PeriodeDagpengerDtoKilde;
-            /** @enum {string} */
-            ytelseType: PeriodeDagpengerDtoYtelseType;
+            fraOgMed: string;
             /** Format: date */
-            tilOgMedDato?: string;
+            tilOgMed: string;
+            /** Format: int32 */
+            sats: number;
+            /** Format: int32 */
+            'utbetaltBel\u00F8p': number;
+            /** Format: int32 */
+            'gjenst\u00E5endeDager': number;
+            /** @enum {string} */
+            kilde: BeregnetDagDagpengerDtoKilde;
         };
-        PseudoDagpengerVedtak: {
-            perioder: components['schemas']['PeriodeDagpengerDto'][];
+        Dagpenger: {
+            perioder: components['schemas']['BeregnetDagDagpengerDto'][];
             /** Format: date */
             eldsteFraOgMedDato?: string;
         };
@@ -1308,10 +1312,6 @@ export interface components {
         LocalDate: {
             /** Format: date */
             value?: string;
-            /** Format: date */
-            value$kotlinx_datetime: string;
-            /** Format: int32 */
-            monthNumber: number;
             /** Format: int32 */
             year: number;
             /** Format: int32 */
@@ -1322,16 +1322,14 @@ export interface components {
             dayOfWeek: LocalDateDayOfWeek;
             /** Format: int32 */
             dayOfYear: number;
+            /** Format: date */
+            value$kotlinx_datetime: string;
+            /** Format: int32 */
+            monthNumber: number;
         };
         LocalDateTime: {
             /** Format: date-time */
             value?: string;
-            /** Format: date-time */
-            value$kotlinx_datetime: string;
-            /** Format: int32 */
-            monthNumber: number;
-            /** Format: int32 */
-            nanosecond: number;
             time: components['schemas']['LocalTime'];
             /** Format: int32 */
             year: number;
@@ -1350,18 +1348,24 @@ export interface components {
             /** Format: int32 */
             dayOfYear: number;
             date: components['schemas']['LocalDate'];
+            /** Format: date-time */
+            value$kotlinx_datetime: string;
+            /** Format: int32 */
+            monthNumber: number;
+            /** Format: int32 */
+            nanosecond: number;
         };
         LocalTime: {
             value?: string;
-            value$kotlinx_datetime: string;
-            /** Format: int32 */
-            nanosecond: number;
             /** Format: int32 */
             hour: number;
             /** Format: int32 */
             minute: number;
             /** Format: int32 */
             second: number;
+            value$kotlinx_datetime: string;
+            /** Format: int32 */
+            nanosecond: number;
         };
         ResultatSoknadsstatus: {
             resultat: components['schemas']['SoknadsstatusSakstema'][];
@@ -1403,7 +1407,7 @@ export interface components {
         Sakstema: {
             temakode: string;
             temanavn: string;
-            harTilgang?: boolean;
+            harTilgang: boolean;
             /** Format: date-time */
             nyesteDokumentDato?: string;
         };
@@ -2071,7 +2075,7 @@ export interface components {
             sladding?: boolean;
             meldinger: components['schemas']['MeldingDTO'][];
             journalposter: components['schemas']['Journalpost'][];
-            journalforingFeilet?: boolean;
+            journalforingFeilet: boolean;
         };
         OpprettHenvendelseRequestV2: {
             fnr: string;
@@ -2171,10 +2175,13 @@ export interface components {
     pathItems: never;
 }
 export type FnrDatoRangeRequest = components['schemas']['FnrDatoRangeRequest'];
-export type Barnetillegg = components['schemas']['Barnetillegg'];
-export type BarnetilleggPeriode = components['schemas']['BarnetilleggPeriode'];
-export type Periode = components['schemas']['Periode'];
-export type VedtakDto = components['schemas']['VedtakDTO'];
+export type HentBehandlingsperioder200ResponseInnerPeriode =
+    components['schemas']['HentBehandlingsperioder200ResponseInnerPeriode'];
+export type HentVedtaksperioder200ResponseInner = components['schemas']['HentVedtaksperioder200ResponseInner'];
+export type HentVedtaksperioder200ResponseInnerBarnetillegg =
+    components['schemas']['HentVedtaksperioder200ResponseInnerBarnetillegg'];
+export type HentVedtaksperioder200ResponseInnerBarnetilleggPerioderInner =
+    components['schemas']['HentVedtaksperioder200ResponseInnerBarnetilleggPerioderInner'];
 export type CommonHistoriskUtbetaling = components['schemas']['CommonHistoriskUtbetaling'];
 export type CommonKommendeUtbetaling = components['schemas']['CommonKommendeUtbetaling'];
 export type CommonKreditortrekk = components['schemas']['CommonKreditortrekk'];
@@ -2193,8 +2200,8 @@ export type PensjonSak = components['schemas']['PensjonSak'];
 export type Foreldrepenger = components['schemas']['Foreldrepenger'];
 export type ForeldrepengerPeriode = components['schemas']['ForeldrepengerPeriode'];
 export type DatadelingRequestDagpengerDto = components['schemas']['DatadelingRequestDagpengerDto'];
-export type PeriodeDagpengerDto = components['schemas']['PeriodeDagpengerDto'];
-export type PseudoDagpengerVedtak = components['schemas']['PseudoDagpengerVedtak'];
+export type BeregnetDagDagpengerDto = components['schemas']['BeregnetDagDagpengerDto'];
+export type Dagpenger = components['schemas']['Dagpenger'];
 export type NonavaapapiinternPeriodeDto = components['schemas']['NonavaapapiinternPeriodeDTO'];
 export type NonavaapapiinternVedtakUtenUtbetalingDto =
     components['schemas']['NonavaapapiinternVedtakUtenUtbetalingDTO'];
@@ -2351,7 +2358,7 @@ export interface operations {
                     [name: string]: unknown;
                 };
                 content: {
-                    '*/*': components['schemas']['VedtakDTO'][];
+                    '*/*': components['schemas']['HentVedtaksperioder200ResponseInner'][];
                 };
             };
         };
@@ -2471,7 +2478,7 @@ export interface operations {
                     [name: string]: unknown;
                 };
                 content: {
-                    '*/*': components['schemas']['PseudoDagpengerVedtak'];
+                    '*/*': components['schemas']['Dagpenger'];
                 };
             };
         };
@@ -3664,12 +3671,12 @@ export interface operations {
         };
     };
 }
-export enum VedtakDTORettighet {
+export enum HentVedtaksperioder200ResponseInnerRettighet {
     TILTAKSPENGER = 'TILTAKSPENGER',
     TILTAKSPENGER_OG_BARNETILLEGG = 'TILTAKSPENGER_OG_BARNETILLEGG',
     INGENTING = 'INGENTING'
 }
-export enum VedtakDTOKilde {
+export enum HentVedtaksperioder200ResponseInnerKilde {
     TPSAK = 'TPSAK',
     ARENA = 'ARENA'
 }
@@ -3678,14 +3685,9 @@ export enum ForeldrepengerYtelse {
     FORELDREPENGER = 'FORELDREPENGER',
     SVANGERSKAPSPENGER = 'SVANGERSKAPSPENGER'
 }
-export enum PeriodeDagpengerDtoKilde {
+export enum BeregnetDagDagpengerDtoKilde {
     ARENA = 'ARENA',
     DP_SAK = 'DP_SAK'
-}
-export enum PeriodeDagpengerDtoYtelseType {
-    DAGPENGER_ARBEIDSSOKER_ORDINAER = 'DAGPENGER_ARBEIDSSOKER_ORDINAER',
-    DAGPENGER_PERMITTERING_ORDINAER = 'DAGPENGER_PERMITTERING_ORDINAER',
-    DAGPENGER_PERMITTERING_FISKEINDUSTRI = 'DAGPENGER_PERMITTERING_FISKEINDUSTRI'
 }
 export enum DokumentDokumentStatus {
     UNDER_REDIGERING = 'UNDER_REDIGERING',

--- a/src/mock/ytelse/dagpengerMock.ts
+++ b/src/mock/ytelse/dagpengerMock.ts
@@ -2,17 +2,16 @@ import { fakerNB_NO as faker } from '@faker-js/faker';
 import dayjs from 'dayjs';
 import navfaker from 'nav-faker/dist/index';
 import {
-    type PeriodeDagpengerDto,
-    PeriodeDagpengerDtoKilde,
-    PeriodeDagpengerDtoYtelseType,
-    type PseudoDagpengerVedtak
+    type BeregnetDagDagpengerDto,
+    BeregnetDagDagpengerDtoKilde,
+    type Dagpenger
 } from 'src/generated/modiapersonoversikt-api';
 import { statiskPeriodeDagpengerDtoMock } from 'src/mock/ytelse/statiskPeriodeDagpengerDtoMock';
 import { backendDatoformat } from 'src/utils/date-utils';
 import { aremark } from '../persondata/aremark';
 import { fyllRandomListe } from '../utils/mock-utils';
 
-export function getMockDagpengerResponse(fnr: string): PseudoDagpengerVedtak {
+export function getMockDagpengerResponse(fnr: string): Dagpenger {
     if (fnr === aremark.personIdent) {
         return statiskPeriodeDagpengerDtoMock;
     }
@@ -22,33 +21,32 @@ export function getMockDagpengerResponse(fnr: string): PseudoDagpengerVedtak {
     if (navfaker.random.vektetSjanse(0.3)) {
         return { perioder: [] };
     }
-    const perioder = fyllRandomListe<PeriodeDagpengerDto>(() => getMockPeriodeDagpengerDto(fnr), 3);
-    const først = perioder[0].fraOgMedDato;
+    const perioder = fyllRandomListe<BeregnetDagDagpengerDto>(() => getMockPeriodeDagpengerDto(fnr), 3);
+    const først = perioder[0].fraOgMed;
     return {
         perioder: perioder,
         eldsteFraOgMedDato: først
     };
 }
 
-function getMockPeriodeDagpengerDto(fnr: string): PeriodeDagpengerDto {
+function getMockPeriodeDagpengerDto(fnr: string): BeregnetDagDagpengerDto {
     faker.seed(Number(fnr));
     navfaker.seed(`${fnr}xyzzy`); // seed again for predictability
 
     const fomDato = dayjs(faker.date.past({ years: 2 })).format(backendDatoformat);
     const tomDato = dayjs(fomDato).add(faker.number.int(40), 'days').format(backendDatoformat);
 
-    const ytelseType = navfaker.random.arrayElement([
-        PeriodeDagpengerDtoYtelseType.DAGPENGER_ARBEIDSSOKER_ORDINAER,
-        PeriodeDagpengerDtoYtelseType.DAGPENGER_PERMITTERING_ORDINAER,
-        PeriodeDagpengerDtoYtelseType.DAGPENGER_PERMITTERING_FISKEINDUSTRI
+    const kilde = navfaker.random.arrayElement([
+        BeregnetDagDagpengerDtoKilde.ARENA,
+        BeregnetDagDagpengerDtoKilde.DP_SAK
     ]);
 
-    const kilde = navfaker.random.arrayElement([PeriodeDagpengerDtoKilde.ARENA, PeriodeDagpengerDtoKilde.DP_SAK]);
-
     return {
-        fraOgMedDato: fomDato,
-        ytelseType: ytelseType,
-        tilOgMedDato: tomDato,
-        kilde: kilde
+        fraOgMed: fomDato,
+        tilOgMed: tomDato,
+        kilde: kilde,
+        sats: 100,
+        gjenståendeDager: 10,
+        utbetaltBeløp: 50000
     };
 }

--- a/src/mock/ytelse/statiskPeriodeDagpengerDtoMock.ts
+++ b/src/mock/ytelse/statiskPeriodeDagpengerDtoMock.ts
@@ -1,4 +1,4 @@
-import type { BeregnetDagDagpengerDtoKilde } from 'src/generated/modiapersonoversikt-api';
+import { BeregnetDagDagpengerDtoKilde } from 'src/generated/modiapersonoversikt-api';
 
 export const statiskPeriodeDagpengerDtoMock = {
     eldsteFraOgMedDato: '2025-06-06',
@@ -6,7 +6,7 @@ export const statiskPeriodeDagpengerDtoMock = {
         {
             fraOgMed: '2025-06-06',
             tilOgMed: '2025-06-19',
-            kilde: 'ARENA' as BeregnetDagDagpengerDtoKilde,
+            kilde: BeregnetDagDagpengerDtoKilde.ARENA,
             sats: 100,
             gjenståendeDager: 3,
             utbetaltBeløp: 5000
@@ -14,7 +14,7 @@ export const statiskPeriodeDagpengerDtoMock = {
         {
             fraOgMed: '2025-08-08',
             tilOgMed: '2025-08-21',
-            kilde: 'ARENA' as BeregnetDagDagpengerDtoKilde,
+            kilde: BeregnetDagDagpengerDtoKilde.ARENA,
             sats: 100,
             gjenståendeDager: 10,
             utbetaltBeløp: 50000
@@ -22,7 +22,7 @@ export const statiskPeriodeDagpengerDtoMock = {
         {
             fraOgMed: '2025-10-10',
             tilOgMed: '2025-10-23',
-            kilde: 'DP_SAK' as BeregnetDagDagpengerDtoKilde,
+            kilde: BeregnetDagDagpengerDtoKilde.DP_SAK,
             sats: 100,
             gjenståendeDager: 12,
             utbetaltBeløp: 3000

--- a/src/mock/ytelse/statiskPeriodeDagpengerDtoMock.ts
+++ b/src/mock/ytelse/statiskPeriodeDagpengerDtoMock.ts
@@ -1,26 +1,31 @@
-import type { PeriodeDagpengerDtoKilde, PeriodeDagpengerDtoYtelseType } from 'src/generated/modiapersonoversikt-api';
+import type { BeregnetDagDagpengerDtoKilde } from 'src/generated/modiapersonoversikt-api';
 
-//export const statiskPeriodeDagpengerDtoMock: PseudoDagpengerVedtak = {
 export const statiskPeriodeDagpengerDtoMock = {
     eldsteFraOgMedDato: '2025-06-06',
     perioder: [
         {
-            fraOgMedDato: '2025-06-06',
-            ytelseType: 'DAGPENGER_ARBEIDSSOKER_MOCKET' as PeriodeDagpengerDtoYtelseType,
-            tilOgMedDato: '2025-06-19',
-            kilde: 'STATISK_MOCKEKILDE' as PeriodeDagpengerDtoKilde
+            fraOgMed: '2025-06-06',
+            tilOgMed: '2025-06-19',
+            kilde: 'ARENA' as BeregnetDagDagpengerDtoKilde,
+            sats: 100,
+            gjenståendeDager: 3,
+            utbetaltBeløp: 5000
         },
         {
-            fraOgMedDato: '2025-08-08',
-            ytelseType: 'DAGPENGER_ARBEIDSSOKER_MOCKET' as PeriodeDagpengerDtoYtelseType,
-            tilOgMedDato: '2025-08-21',
-            kilde: 'STATISK_MOCKEKILDE' as PeriodeDagpengerDtoKilde
+            fraOgMed: '2025-08-08',
+            tilOgMed: '2025-08-21',
+            kilde: 'ARENA' as BeregnetDagDagpengerDtoKilde,
+            sats: 100,
+            gjenståendeDager: 10,
+            utbetaltBeløp: 50000
         },
         {
-            fraOgMedDato: '2025-10-10',
-            ytelseType: 'DAGPENGER_ARBEIDSSOKER_MOCKET' as PeriodeDagpengerDtoYtelseType,
-            tilOgMedDato: '2025-10-23',
-            kilde: 'STATISK_MOCKEKILDE' as PeriodeDagpengerDtoKilde
+            fraOgMed: '2025-10-10',
+            tilOgMed: '2025-10-23',
+            kilde: 'DP_SAK' as BeregnetDagDagpengerDtoKilde,
+            sats: 100,
+            gjenståendeDager: 12,
+            utbetaltBeløp: 3000
         }
     ]
 };

--- a/src/mock/ytelse/statiskTiltakspengerMock.ts
+++ b/src/mock/ytelse/statiskTiltakspengerMock.ts
@@ -1,12 +1,23 @@
-import { VedtakDTOKilde, VedtakDTORettighet } from 'src/generated/modiapersonoversikt-api';
+import {
+    HentVedtaksperioder200ResponseInnerKilde,
+    HentVedtaksperioder200ResponseInnerRettighet
+} from 'src/generated/modiapersonoversikt-api';
+import type { Tiltakspenger } from 'src/models/ytelse/tiltakspenger';
 
-export const statiskTiltakspengerMock = {
+export const statiskTiltakspengerMock: Tiltakspenger = {
     periode: {
         fraOgMed: '2020-01-10',
         tilOgMed: '2020-02-21'
     },
-    kilde: VedtakDTOKilde.TPSAK,
-    rettighet: VedtakDTORettighet.TILTAKSPENGER,
+    vedtaksperiode: {
+        fraOgMed: '2020-01-10',
+        tilOgMed: '2020-02-21'
+    },
+    sats: 10,
+    satsBarnetillegg: 100,
+    innvilgelsesperioder: [],
+    kilde: HentVedtaksperioder200ResponseInnerKilde.TPSAK,
+    rettighet: HentVedtaksperioder200ResponseInnerRettighet.TILTAKSPENGER,
     vedtakId: '987sdfklo',
     barnetillegg: {
         perioder: [

--- a/src/mock/ytelse/tiltakspenger-mock.ts
+++ b/src/mock/ytelse/tiltakspenger-mock.ts
@@ -2,14 +2,17 @@ import { fakerNB_NO as faker } from '@faker-js/faker';
 import dayjs from 'dayjs';
 
 import navfaker from 'nav-faker/dist/index';
-import { VedtakDTOKilde, VedtakDTORettighet } from 'src/generated/modiapersonoversikt-api';
-import type { Tiltakspenger, TiltakspengerResource } from 'src/models/ytelse/tiltakspenger';
+import {
+    HentVedtaksperioder200ResponseInnerKilde,
+    HentVedtaksperioder200ResponseInnerRettighet
+} from 'src/generated/modiapersonoversikt-api';
+import type { Tiltakspenger } from 'src/models/ytelse/tiltakspenger';
 import { backendDatoformat } from 'src/utils/date-utils';
 import { aremark } from '../persondata/aremark';
 import { fyllRandomListe } from '../utils/mock-utils';
 import { statiskTiltakspengerMock } from './statiskTiltakspengerMock';
 
-export function getMockTiltakspenger(fødselsnummer: string): TiltakspengerResource {
+export function getMockTiltakspenger(fødselsnummer: string): Tiltakspenger[] {
     if (fødselsnummer === aremark.personIdent) {
         return [statiskTiltakspengerMock];
     }
@@ -18,7 +21,7 @@ export function getMockTiltakspenger(fødselsnummer: string): TiltakspengerResou
     navfaker.seed(`${fødselsnummer}tiltakspenger`);
 
     if (navfaker.random.vektetSjanse(0.3)) {
-        return null;
+        return [];
     }
 
     return fyllRandomListe<Tiltakspenger>((i) => getMockTiltakspengerYtelser(fødselsnummer, i), 3);
@@ -32,13 +35,20 @@ function getMockTiltakspengerYtelser(fødselsnummer: string, i?: number): Tiltak
     const tom = dayjs(fom).add(faker.number.int(40), 'days').format(backendDatoformat);
 
     return {
-        kilde: navfaker.random.vektetSjanse(0.4) ? VedtakDTOKilde.ARENA : VedtakDTOKilde.TPSAK,
+        kilde: navfaker.random.vektetSjanse(0.4)
+            ? HentVedtaksperioder200ResponseInnerKilde.ARENA
+            : HentVedtaksperioder200ResponseInnerKilde.TPSAK,
         vedtakId: faker.string.alphanumeric(8),
-        rettighet: VedtakDTORettighet.TILTAKSPENGER,
+        rettighet: HentVedtaksperioder200ResponseInnerRettighet.TILTAKSPENGER,
+        vedtaksperiode: {
+            fraOgMed: fom,
+            tilOgMed: tom
+        },
         periode: {
             fraOgMed: fom,
             tilOgMed: tom
         },
+        innvilgelsesperioder: [],
         barnetillegg: navfaker.random.vektetSjanse(0.5)
             ? { perioder: fyllRandomListe(mockBarnetillegg, 3, false) }
             : undefined

--- a/src/models/ytelse/dagpenger.ts
+++ b/src/models/ytelse/dagpenger.ts
@@ -1,12 +1,12 @@
 import dayjs from 'dayjs';
-import type { PseudoDagpengerVedtak } from 'src/generated/modiapersonoversikt-api';
+import type { Dagpenger } from 'src/generated/modiapersonoversikt-api';
 import { backendDatoformat } from 'src/utils/date-utils';
 
-export function getDagpengerIdDato(ytelse: PseudoDagpengerVedtak) {
+export function getDagpengerIdDato(ytelse: Dagpenger) {
     return ytelse.eldsteFraOgMedDato ?? dayjs().format(backendDatoformat);
 }
 
-export function getUnikDagpengerKey(ytelse: PseudoDagpengerVedtak) {
+export function getUnikDagpengerKey(ytelse: Dagpenger) {
     // TODO ensure this is actually unique
     return `dagpenger-${ytelse.eldsteFraOgMedDato ?? 'NONE'}`;
 }

--- a/src/models/ytelse/tiltakspenger.ts
+++ b/src/models/ytelse/tiltakspenger.ts
@@ -1,8 +1,9 @@
-import type { VedtakDto } from 'src/generated/modiapersonoversikt-api';
-
-export type TiltakspengerResource = Tiltakspenger[] | null;
-
-export type Tiltakspenger = VedtakDto;
+import type {
+    HentVedtaksperioder200ResponseInner,
+    HentVedtaksperioder200ResponseInnerBarnetilleggPerioderInner
+} from 'src/generated/modiapersonoversikt-api';
+export type Tiltakspenger = HentVedtaksperioder200ResponseInner;
+export type TiltakspengerBarnetilleggPeriode = HentVedtaksperioder200ResponseInnerBarnetilleggPerioderInner;
 
 export function getTiltakspengerIdDato(ytelse: Tiltakspenger) {
     return ytelse.periode.fraOgMed;

--- a/src/models/ytelse/ytelse-utils.ts
+++ b/src/models/ytelse/ytelse-utils.ts
@@ -1,4 +1,4 @@
-import type { Foreldrepenger, PseudoDagpengerVedtak, SykepengerSpokelse } from 'src/generated/modiapersonoversikt-api';
+import type { Dagpenger, Foreldrepenger, SykepengerSpokelse } from 'src/generated/modiapersonoversikt-api';
 import {
     type Arbeidsavklaringspenger,
     getArbeidsavklaringspengerIdDato,
@@ -14,7 +14,7 @@ import { getTiltakspengerIdDato, getUnikTiltakspengerKey, type Tiltakspenger } f
 
 export enum YtelseVedtakYtelseType {
     Sykepenger = 'Sykepenger (Infotrygd)',
-    Tiltakspenge = 'Tiltakspenger',
+    Tiltakspenger = 'Tiltakspenger',
     Pensjon = 'Pensjon',
     Arbeidsavklaringspenger = 'Arbeidsavklaringspenger',
     Foreldrepenger = 'Foreldrepenger',
@@ -28,7 +28,7 @@ export type Ytelse =
     | Pensjon
     | Arbeidsavklaringspenger
     | Foreldrepenger
-    | PseudoDagpengerVedtak
+    | Dagpenger
     | SykepengerSpokelse;
 
 export function isSykepengerSpokelse(ytelse: Ytelse): ytelse is SykepengerSpokelse {
@@ -51,7 +51,7 @@ export function isForeldrePenger(ytelse: Ytelse): ytelse is Foreldrepenger {
     return 'ytelse' in ytelse;
 }
 // only used here, not imported in old modia
-function isDagpenger(ytelse: Ytelse): ytelse is PseudoDagpengerVedtak {
+function isDagpenger(ytelse: Ytelse): ytelse is Dagpenger {
     return 'ytelseType' in ytelse; // this one is unique... right now
 }
 

--- a/src/models/ytelse/ytelse-utils.ts
+++ b/src/models/ytelse/ytelse-utils.ts
@@ -52,7 +52,7 @@ export function isForeldrePenger(ytelse: Ytelse): ytelse is Foreldrepenger {
 }
 // only used here, not imported in old modia
 function isDagpenger(ytelse: Ytelse): ytelse is Dagpenger {
-    return 'ytelseType' in ytelse; // this one is unique... right now
+    return 'gjenståendeDager' in ytelse; // this one is unique... right now
 }
 
 export function getYtelseIdDato(ytelse: Ytelse) {

--- a/src/rest/resources/tiltakspengerResource.tsx
+++ b/src/rest/resources/tiltakspengerResource.tsx
@@ -2,13 +2,13 @@ import { type UseQueryResult, useQuery } from '@tanstack/react-query';
 
 import { type FetchError, post } from '../../api/api';
 import { apiBaseUri } from '../../api/config';
-import type { TiltakspengerResource } from '../../models/ytelse/tiltakspenger';
+import type { Tiltakspenger } from '../../models/ytelse/tiltakspenger';
 
 export const useTiltakspenger = (
     fnr: string,
     fom: string,
     tom: string
-): UseQueryResult<TiltakspengerResource, FetchError> => {
+): UseQueryResult<Tiltakspenger[], FetchError> => {
     return useQuery({
         queryKey: ['tiltakspenger', fnr, fom, tom],
         queryFn: () =>


### PR DESCRIPTION
Ny responsetype er brukt for dagpenger så typene og detaljvisning er endret. Etter å ha generert opp typer frå APIet så blei også typene til tiltakspenger endret. Har derfor oppdatert dette også, men det er kun typer, visningen er lik.
Gjorde ein liten endring på foreldrepenger slik at periodene vises på samme måte som med dagpenger.

<img width="932" height="400" alt="image" src="https://github.com/user-attachments/assets/d99002b5-406a-4125-a0a4-9571ae834754" />

