### PR TITLE
Legg til felt om arbeidssøkerstatus under arbeidsoppfølging

### DIFF
--- a/src/app/personside/infotabs/oppfolging/Gjeldende14aVedtakDetaljer.tsx
+++ b/src/app/personside/infotabs/oppfolging/Gjeldende14aVedtakDetaljer.tsx
@@ -34,9 +34,13 @@ function Gjeldende14aVedtakDetaljer() {
 
     const gjeldende14aVedtakEntries = {
         'Har 14a vedtak': detaljer ? 'Ja' : 'Nei',
-        Innsatsgruppe: detaljer?.innsatsgruppe.beskrivelse,
-        Hovedmål: detaljer?.hovedmal?.beskrivelse,
-        Vedtaksdato: datoEllerNull(detaljer?.fattetDato)
+        ...(detaljer
+            ? {
+                  Innsatsgruppe: detaljer?.innsatsgruppe.beskrivelse,
+                  Hovedmål: detaljer?.hovedmal?.beskrivelse,
+                  Vedtaksdato: datoEllerNull(detaljer?.fattetDato)
+              }
+            : {})
     };
 
     return (

--- a/src/app/personside/infotabs/oppfolging/OppfolgingContainer.tsx
+++ b/src/app/personside/infotabs/oppfolging/OppfolgingContainer.tsx
@@ -1,3 +1,4 @@
+import { useOppslagArbeidssoekerregisteret } from 'src/lib/clients/modiapersonoversikt-api';
 import type { DetaljertOppfolging } from 'src/models/oppfolging';
 import { useOppfolgingFilter } from 'src/redux/oppfolging/reducer';
 import styled from 'styled-components';
@@ -30,11 +31,18 @@ function OppfolgingContainer() {
     const oppfolgingResponse = oppfolgingResource.useFetch(fraTilDato.fra, fraTilDato.til);
     const oppfolging = oppfolgingResponse.data as DetaljertOppfolging;
 
+    const { data, isError } = useOppslagArbeidssoekerregisteret();
+
     return (
         <OppfolgingStyle>
             <DetaljertInfoWrapper>
                 <OppfolgingFilter />
-                <VisOppfolgingDetaljer detaljertOppfolging={oppfolging ?? {}} isError={oppfolgingResponse.isError} />
+                <VisOppfolgingDetaljer
+                    detaljertOppfolging={oppfolging ?? {}}
+                    isErrorOppfolging={oppfolgingResponse.isError}
+                    isErrorArbeidssoekerRegisteret={isError}
+                    oppslagArbeidssoekerRegisteret={data}
+                />
             </DetaljertInfoWrapper>
             <SykefraversoppfolgingEkspanderbartPanel syfoPunkter={oppfolging?.sykefravaersoppfolging ?? []} />
             <OppfolgingYtelserEkspanderbartPanel ytelser={oppfolging?.ytelser ?? []} />

--- a/src/app/personside/infotabs/oppfolging/OppfolgingDetaljerKomponent.tsx
+++ b/src/app/personside/infotabs/oppfolging/OppfolgingDetaljerKomponent.tsx
@@ -6,7 +6,6 @@ import { useRef } from 'react';
 import Siste14aVedtakDetaljer from 'src/app/personside/infotabs/oppfolging/Gjeldende14aVedtakDetaljer';
 import type { DetaljertOppfolging } from 'src/models/oppfolging';
 import { pxToRem } from 'src/styles/personOversiktTheme';
-import { datoEllerNull } from 'src/utils/string-utils';
 import styled from 'styled-components';
 import DescriptionList from '../../../../components/DescriptionList';
 import { getErUnderOppfolging, getOppfolgingEnhet, getVeileder } from './oppfolging-utils';
@@ -26,7 +25,6 @@ interface Props {
 function VisOppfolgingDetaljer(props: Props) {
     const headerId = useRef(guid());
     const detaljer = props.detaljertOppfolging;
-    const meldeplikt = detaljer.meldeplikt ? 'Ja' : detaljer.meldeplikt === false ? 'Nei' : 'Meldeplikt Ukjent';
     const ikkeFullstendigData =
         detaljer.oppfolging === null ? (
             <AlertStripeAdvarsel>Kunne ikke hente ut all oppfølgings-informasjon</AlertStripeAdvarsel>
@@ -38,11 +36,7 @@ function VisOppfolgingDetaljer(props: Props) {
     const descriptionListProps = {
         'Er under oppfølging': getErUnderOppfolging(detaljer.oppfolging),
         Oppfølgingsenhet: getOppfolgingEnhet(detaljer.oppfolging),
-        Rettighetsgruppe: detaljer.rettighetsgruppe,
-        Veileder: getVeileder(detaljer.oppfolging?.veileder),
-        Meldeplikt: meldeplikt,
-        Formidlingsgruppe: detaljer.formidlingsgruppe,
-        Oppfølgingsvedtak: datoEllerNull(detaljer.vedtaksdato)
+        Veileder: getVeileder(detaljer.oppfolging?.veileder)
     };
 
     return (

--- a/src/app/personside/infotabs/oppfolging/OppfolgingDetaljerKomponent.tsx
+++ b/src/app/personside/infotabs/oppfolging/OppfolgingDetaljerKomponent.tsx
@@ -4,9 +4,6 @@ import Panel from 'nav-frontend-paneler';
 import { Undertittel } from 'nav-frontend-typografi';
 import { useRef } from 'react';
 import Siste14aVedtakDetaljer from 'src/app/personside/infotabs/oppfolging/Gjeldende14aVedtakDetaljer';
-import IfFeatureToggleOn from 'src/components/featureToggle/IfFeatureToggleOn';
-import { FeatureToggles } from 'src/components/featureToggle/toggleIDs';
-import useFeatureToggle from 'src/components/featureToggle/useFeatureToggle';
 import type { DetaljertOppfolging } from 'src/models/oppfolging';
 import { pxToRem } from 'src/styles/personOversiktTheme';
 import { datoEllerNull } from 'src/utils/string-utils';
@@ -37,27 +34,16 @@ function VisOppfolgingDetaljer(props: Props) {
     const errorLoadingData = props.isError ? (
         <AlertStripe type="advarsel">Kunne ikke laste inn informasjon om brukers oppfølging</AlertStripe>
     ) : null;
-    const { isOn } = useFeatureToggle(FeatureToggles.VisSiste14aVedtak);
-    const descriptionListProps = isOn
-        ? {
-              'Er under oppfølging': getErUnderOppfolging(detaljer.oppfolging),
-              Oppfølgingsenhet: getOppfolgingEnhet(detaljer.oppfolging),
-              Rettighetsgruppe: detaljer.rettighetsgruppe,
-              Veileder: getVeileder(detaljer.oppfolging?.veileder),
-              Meldeplikt: meldeplikt,
-              Formidlingsgruppe: detaljer.formidlingsgruppe,
-              Oppfølgingsvedtak: datoEllerNull(detaljer.vedtaksdato)
-          }
-        : {
-              'Er under oppfølging': getErUnderOppfolging(detaljer.oppfolging),
-              Oppfølgingsenhet: getOppfolgingEnhet(detaljer.oppfolging),
-              Innsatsgruppe: detaljer.innsatsgruppe,
-              Rettighetsgruppe: detaljer.rettighetsgruppe,
-              Veileder: getVeileder(detaljer.oppfolging?.veileder),
-              Meldeplikt: meldeplikt,
-              Formidlingsgruppe: detaljer.formidlingsgruppe,
-              Oppfølgingsvedtak: datoEllerNull(detaljer.vedtaksdato)
-          };
+
+    const descriptionListProps = {
+        'Er under oppfølging': getErUnderOppfolging(detaljer.oppfolging),
+        Oppfølgingsenhet: getOppfolgingEnhet(detaljer.oppfolging),
+        Rettighetsgruppe: detaljer.rettighetsgruppe,
+        Veileder: getVeileder(detaljer.oppfolging?.veileder),
+        Meldeplikt: meldeplikt,
+        Formidlingsgruppe: detaljer.formidlingsgruppe,
+        Oppfølgingsvedtak: datoEllerNull(detaljer.vedtaksdato)
+    };
 
     return (
         <StyledPanel aria-labelledby={headerId.current}>
@@ -67,9 +53,7 @@ function VisOppfolgingDetaljer(props: Props) {
                 <Undertittel id={headerId.current}>Arbeidsoppfølging</Undertittel>
                 <DescriptionList entries={descriptionListProps} />
                 <br />
-                <IfFeatureToggleOn toggleID={FeatureToggles.VisSiste14aVedtak}>
-                    <Siste14aVedtakDetaljer />
-                </IfFeatureToggleOn>
+                <Siste14aVedtakDetaljer />
             </article>
         </StyledPanel>
     );

--- a/src/app/personside/infotabs/oppfolging/OppfolgingDetaljerKomponent.tsx
+++ b/src/app/personside/infotabs/oppfolging/OppfolgingDetaljerKomponent.tsx
@@ -1,11 +1,14 @@
+import { Detail } from '@navikt/ds-react';
 import AlertStripe, { AlertStripeAdvarsel } from 'nav-frontend-alertstriper';
 import { guid } from 'nav-frontend-js-utils';
 import Panel from 'nav-frontend-paneler';
 import { Undertittel } from 'nav-frontend-typografi';
 import { useRef } from 'react';
 import Siste14aVedtakDetaljer from 'src/app/personside/infotabs/oppfolging/Gjeldende14aVedtakDetaljer';
+import type { AggregertPeriodeArbeidssoekerregisteretDto } from 'src/generated/modiapersonoversikt-api';
 import type { DetaljertOppfolging } from 'src/models/oppfolging';
 import { pxToRem } from 'src/styles/personOversiktTheme';
+import { formatterDato } from 'src/utils/date-utils';
 import styled from 'styled-components';
 import DescriptionList from '../../../../components/DescriptionList';
 import { getErUnderOppfolging, getOppfolgingEnhet, getVeileder } from './oppfolging-utils';
@@ -19,30 +22,60 @@ const StyledPanel = styled(Panel)`
 
 interface Props {
     detaljertOppfolging: DetaljertOppfolging;
-    isError?: boolean;
+    oppslagArbeidssoekerRegisteret?: AggregertPeriodeArbeidssoekerregisteretDto;
+    isErrorOppfolging?: boolean;
+    isErrorArbeidssoekerRegisteret?: boolean;
 }
 
 function VisOppfolgingDetaljer(props: Props) {
     const headerId = useRef(guid());
     const detaljer = props.detaljertOppfolging;
+    const oppslagArbeidssoekerRegisteret = props.oppslagArbeidssoekerRegisteret;
+
     const ikkeFullstendigData =
         detaljer.oppfolging === null ? (
             <AlertStripeAdvarsel>Kunne ikke hente ut all oppfølgings-informasjon</AlertStripeAdvarsel>
         ) : null;
-    const errorLoadingData = props.isError ? (
+    const errorLoadingData = props.isErrorOppfolging ? (
         <AlertStripe type="advarsel">Kunne ikke laste inn informasjon om brukers oppfølging</AlertStripe>
     ) : null;
+
+    const errorLoadingDataArbeidssoekerRegisteret = props.isErrorArbeidssoekerRegisteret ? (
+        <AlertStripe type="advarsel">Kunne ikke laste inn informasjon fra arbeidssøkerregisteret</AlertStripe>
+    ) : null;
+
+    const erRegistrertSomArbeidssoker = oppslagArbeidssoekerRegisteret && !oppslagArbeidssoekerRegisteret.avsluttet;
+    const sendtInnAvOpplysinger = oppslagArbeidssoekerRegisteret?.startet.sendtInnAv;
 
     const descriptionListProps = {
         'Er under oppfølging': getErUnderOppfolging(detaljer.oppfolging),
         Oppfølgingsenhet: getOppfolgingEnhet(detaljer.oppfolging),
-        Veileder: getVeileder(detaljer.oppfolging?.veileder)
+        Veileder: getVeileder(detaljer.oppfolging?.veileder),
+        ...(!errorLoadingDataArbeidssoekerRegisteret
+            ? {
+                  Arbeidssøkerstatus: erRegistrertSomArbeidssoker ? (
+                      <>
+                          Er registrert som arbeidssøker
+                          <Detail>Kilde: {sendtInnAvOpplysinger?.kilde ?? 'Ikke angitt'}</Detail>
+                          <Detail>
+                              Dato:{' '}
+                              {sendtInnAvOpplysinger?.tidspunkt
+                                  ? formatterDato(sendtInnAvOpplysinger.tidspunkt)
+                                  : 'Ikke angitt'}
+                          </Detail>
+                      </>
+                  ) : (
+                      'Er ikke registrert som arbeidssøker'
+                  )
+              }
+            : {})
     };
 
     return (
         <StyledPanel aria-labelledby={headerId.current}>
             <article>
                 {errorLoadingData}
+                {errorLoadingDataArbeidssoekerRegisteret}
                 {ikkeFullstendigData}
                 <Undertittel id={headerId.current}>Arbeidsoppfølging</Undertittel>
                 <DescriptionList entries={descriptionListProps} />

--- a/src/app/personside/infotabs/oppfolging/OppfolgingDetaljerKomponent.tsx
+++ b/src/app/personside/infotabs/oppfolging/OppfolgingDetaljerKomponent.tsx
@@ -45,7 +45,7 @@ function VisOppfolgingDetaljer(props: Props) {
     ) : null;
 
     const erRegistrertSomArbeidssoker = oppslagArbeidssoekerRegisteret && !oppslagArbeidssoekerRegisteret.avsluttet;
-    const sendtInnAvOpplysinger = oppslagArbeidssoekerRegisteret?.startet.sendtInnAv;
+    const arbeidssoekerregisteretOpplysinger = oppslagArbeidssoekerRegisteret?.opplysning;
 
     const descriptionListProps = {
         'Er under oppfølging': getErUnderOppfolging(detaljer.oppfolging),
@@ -53,19 +53,25 @@ function VisOppfolgingDetaljer(props: Props) {
         Veileder: getVeileder(detaljer.oppfolging?.veileder),
         ...(!errorLoadingDataArbeidssoekerRegisteret
             ? {
-                  Arbeidssøkerstatus: erRegistrertSomArbeidssoker ? (
+                  Arbeidssøkerstatus: (
                       <>
-                          Er registrert som arbeidssøker
-                          <Detail>Kilde: {sendtInnAvOpplysinger?.kilde ?? 'Ikke angitt'}</Detail>
-                          <Detail>
-                              Dato:{' '}
-                              {sendtInnAvOpplysinger?.tidspunkt
-                                  ? formatterDato(sendtInnAvOpplysinger.tidspunkt)
-                                  : 'Ikke angitt'}
-                          </Detail>
+                          {erRegistrertSomArbeidssoker
+                              ? 'Er registrert som arbeidssøker'
+                              : 'Er ikke registrert som arbeidssøker'}
+                          {arbeidssoekerregisteretOpplysinger && (
+                              <>
+                                  <Detail>
+                                      Dato:{' '}
+                                      {arbeidssoekerregisteretOpplysinger?.tidspunkt
+                                          ? formatterDato(arbeidssoekerregisteretOpplysinger.tidspunkt)
+                                          : 'Ikke angitt'}
+                                  </Detail>
+                                  <Detail>
+                                      Kilde: {arbeidssoekerregisteretOpplysinger?.sendtInnAv.kilde ?? 'Ikke angitt'}
+                                  </Detail>
+                              </>
+                          )}{' '}
                       </>
-                  ) : (
-                      'Er ikke registrert som arbeidssøker'
                   )
               }
             : {})

--- a/src/app/personside/infotabs/oppfolging/OppfolgingDetaljerKomponent.tsx
+++ b/src/app/personside/infotabs/oppfolging/OppfolgingDetaljerKomponent.tsx
@@ -59,17 +59,12 @@ function VisOppfolgingDetaljer(props: Props) {
                               ? 'Er registrert som arbeidssøker'
                               : 'Er ikke registrert som arbeidssøker'}
                           {arbeidssoekerregisteretOpplysinger && (
-                              <>
-                                  <Detail>
-                                      Dato:{' '}
-                                      {arbeidssoekerregisteretOpplysinger?.tidspunkt
-                                          ? formatterDato(arbeidssoekerregisteretOpplysinger.tidspunkt)
-                                          : 'Ikke angitt'}
-                                  </Detail>
-                                  <Detail>
-                                      Kilde: {arbeidssoekerregisteretOpplysinger?.sendtInnAv.kilde ?? 'Ikke angitt'}
-                                  </Detail>
-                              </>
+                              <Detail>
+                                  Dato:{' '}
+                                  {arbeidssoekerregisteretOpplysinger?.tidspunkt
+                                      ? formatterDato(arbeidssoekerregisteretOpplysinger.tidspunkt)
+                                      : 'Ikke angitt'}
+                              </Detail>
                           )}{' '}
                       </>
                   )

--- a/src/app/personside/infotabs/oppfolging/__snapshots__/OppfolgingContainer.test.tsx.snap
+++ b/src/app/personside/infotabs/oppfolging/__snapshots__/OppfolgingContainer.test.tsx.snap
@@ -435,18 +435,6 @@ exports[`Viser oppfølgingcontainer med alt innhold 1`] = `
               <dt
                 class="typo-normal"
               >
-                Rettighetsgruppe
-              </dt>
-              <dd
-                class="typo-element"
-              >
-                RGRP8
-              </dd>
-            </div>
-            <div>
-              <dt
-                class="typo-normal"
-              >
                 Veileder
               </dt>
               <dd
@@ -459,36 +447,23 @@ exports[`Viser oppfølgingcontainer med alt innhold 1`] = `
               <dt
                 class="typo-normal"
               >
-                Meldeplikt
+                Arbeidssøkerstatus
               </dt>
               <dd
                 class="typo-element"
               >
-                Nei
-              </dd>
-            </div>
-            <div>
-              <dt
-                class="typo-normal"
-              >
-                Formidlingsgruppe
-              </dt>
-              <dd
-                class="typo-element"
-              >
-                FMGRP2
-              </dd>
-            </div>
-            <div>
-              <dt
-                class="typo-normal"
-              >
-                Oppfølgingsvedtak
-              </dt>
-              <dd
-                class="typo-element"
-              >
-                24.04.2019
+                Er registrert som arbeidssøker
+                <p
+                  class="aksel-detail"
+                >
+                  Dato: 03.12.1969
+                </p>
+                <p
+                  class="aksel-detail"
+                >
+                  Kilde: arbeidssokerregisteret
+                </p>
+                 
               </dd>
             </div>
           </dl>
@@ -513,42 +488,6 @@ exports[`Viser oppfølgingcontainer med alt innhold 1`] = `
                   class="typo-element"
                 >
                   Nei
-                </dd>
-              </div>
-              <div>
-                <dt
-                  class="typo-normal"
-                >
-                  Innsatsgruppe
-                </dt>
-                <dd
-                  class="typo-element"
-                >
-                  —
-                </dd>
-              </div>
-              <div>
-                <dt
-                  class="typo-normal"
-                >
-                  Hovedmål
-                </dt>
-                <dd
-                  class="typo-element"
-                >
-                  —
-                </dd>
-              </div>
-              <div>
-                <dt
-                  class="typo-normal"
-                >
-                  Vedtaksdato
-                </dt>
-                <dd
-                  class="typo-element"
-                >
-                  —
                 </dd>
               </div>
             </dl>

--- a/src/app/personside/infotabs/oppfolging/__snapshots__/OppfolgingContainer.test.tsx.snap
+++ b/src/app/personside/infotabs/oppfolging/__snapshots__/OppfolgingContainer.test.tsx.snap
@@ -458,11 +458,6 @@ exports[`Viser oppfølgingcontainer med alt innhold 1`] = `
                 >
                   Dato: 03.12.1969
                 </p>
-                <p
-                  class="aksel-detail"
-                >
-                  Kilde: arbeidssokerregisteret
-                </p>
                  
               </dd>
             </div>

--- a/src/app/personside/infotabs/oversikt/OppfolgingOversikt.tsx
+++ b/src/app/personside/infotabs/oversikt/OppfolgingOversikt.tsx
@@ -81,15 +81,11 @@ function Veileder({ detaljertOppfolging }: { detaljertOppfolging: DetaljertOppfo
 }
 
 function OppfolgingVisning({ detaljertOppfolging }: { detaljertOppfolging: DetaljertOppfolging }) {
-    const innsatsgruppe = detaljertOppfolging.innsatsgruppe;
-
     return (
         <>
             <Element>Oppfølgende enhet:</Element>
             <Normaltekst>{getOppfolgingEnhet(detaljertOppfolging.oppfolging)}</Normaltekst>
             <Veileder detaljertOppfolging={detaljertOppfolging} />
-            <Element>Innsatsgruppe</Element>
-            <Normaltekst>{innsatsgruppe}</Normaltekst>
             <YtelserForBruker detaljertOppfolging={detaljertOppfolging} />
         </>
     );

--- a/src/app/personside/infotabs/oversikt/OppfolgingOversikt.tsx
+++ b/src/app/personside/infotabs/oversikt/OppfolgingOversikt.tsx
@@ -81,11 +81,15 @@ function Veileder({ detaljertOppfolging }: { detaljertOppfolging: DetaljertOppfo
 }
 
 function OppfolgingVisning({ detaljertOppfolging }: { detaljertOppfolging: DetaljertOppfolging }) {
+    const innsatsgruppe = detaljertOppfolging.innsatsgruppe;
+
     return (
         <>
             <Element>Oppfølgende enhet:</Element>
             <Normaltekst>{getOppfolgingEnhet(detaljertOppfolging.oppfolging)}</Normaltekst>
             <Veileder detaljertOppfolging={detaljertOppfolging} />
+            <Element>Innsatsgruppe</Element>
+            <Normaltekst>{innsatsgruppe}</Normaltekst>
             <YtelserForBruker detaljertOppfolging={detaljertOppfolging} />
         </>
     );

--- a/src/app/personside/infotabs/oversikt/OppfolgingOversikt.tsx
+++ b/src/app/personside/infotabs/oversikt/OppfolgingOversikt.tsx
@@ -81,18 +81,11 @@ function Veileder({ detaljertOppfolging }: { detaljertOppfolging: DetaljertOppfo
 }
 
 function OppfolgingVisning({ detaljertOppfolging }: { detaljertOppfolging: DetaljertOppfolging }) {
-    const innsatsgruppe = detaljertOppfolging.innsatsgruppe;
-    const rettighetsgruppe = detaljertOppfolging.rettighetsgruppe;
-
     return (
         <>
             <Element>Oppfølgende enhet:</Element>
             <Normaltekst>{getOppfolgingEnhet(detaljertOppfolging.oppfolging)}</Normaltekst>
             <Veileder detaljertOppfolging={detaljertOppfolging} />
-            <Element>Innsatsgruppe / Rettighetsgruppe:</Element>
-            <Normaltekst>
-                {innsatsgruppe} / {rettighetsgruppe}
-            </Normaltekst>
             <YtelserForBruker detaljertOppfolging={detaljertOppfolging} />
         </>
     );

--- a/src/components/Oppfolging/index.tsx
+++ b/src/components/Oppfolging/index.tsx
@@ -42,7 +42,7 @@ const OppfolgingDetaljer = () => {
                     <InlineMessage status="info">Brukeren har ingen oppfølging.</InlineMessage>
                 </Box>
             ) : (
-                <HGrid gap="space-16" columns={{ sm: 1, md: 3, lg: 4 }} className="mt-2" align="start">
+                <HGrid gap="space-16" columns={{ sm: 1, md: 2, lg: 4 }} className="mt-2" align="start">
                     <VStack justify="space-between">
                         <BodyShort size="small" weight="semibold">
                             Status:
@@ -206,7 +206,7 @@ const SykefravaersoppfolgingDetaljer = () => {
     );
 };
 
-export const ArbeidssoekerregisteretDetaljer = () => {
+const ArbeidssoekerregisteretDetaljer = () => {
     const { data, isError } = useOppslagArbeidssoekerregisteret();
 
     if (isError) return;

--- a/src/components/Oppfolging/index.tsx
+++ b/src/components/Oppfolging/index.tsx
@@ -27,10 +27,11 @@ import { datoEllerNull } from 'src/utils/string-utils';
 
 const OppfolgingDetaljer = () => {
     const { data: arbeidsOppfolging, isLoading, isError } = useArbeidsoppfolging();
+    const { isLoading: arbeidssoekerregisteretLoading } = useOppslagArbeidssoekerregisteret();
 
     if (isError) return;
 
-    if (isLoading) return <Skeleton variant="rectangle" height={166} />;
+    if (isLoading || arbeidssoekerregisteretLoading) return <Skeleton variant="rectangle" height={166} />;
 
     return (
         <>
@@ -125,7 +126,7 @@ const Gjeldende14aVedtakDetaljer = () => {
 
 const SykefravaersoppfolgingDetaljer = () => {
     const { data, isError, isLoading } = useSykefravaersoppfolging();
-    const sykefravaersoppfolging = data?.sykefravaersoppfolging;
+    const sykefravaersoppfolging = data?.sykefravaersoppfolging ?? [];
     const [sort, setSort] = useState<SortState | undefined>({ orderBy: 'dato', direction: 'descending' });
     const [page, setPage] = useState(1);
 
@@ -133,7 +134,7 @@ const SykefravaersoppfolgingDetaljer = () => {
 
     if (isLoading) return <Skeleton variant="rectangle" height={166} />;
 
-    if (!sykefravaersoppfolging || sykefravaersoppfolging.length === 0) {
+    if (sykefravaersoppfolging.length === 0) {
         return <InlineMessage status="info">Brukeren har ingen sykefraværs-oppfølging</InlineMessage>;
     }
 
@@ -212,7 +213,7 @@ const ArbeidssoekerregisteretDetaljer = () => {
     if (isError) return;
 
     const erRegistrertSomArbeidssoker = data && !data.avsluttet;
-    const sendtInnAvOpplysinger = data?.startet.sendtInnAv;
+    const detaljer = data?.opplysning;
 
     return (
         <VStack justify="space-between">
@@ -226,11 +227,10 @@ const ArbeidssoekerregisteretDetaljer = () => {
                     Er <span className="font-semibold">ikke</span> registrert som arbeidssøker
                 </BodyShort>
             )}
-            {erRegistrertSomArbeidssoker && (
+            {detaljer && (
                 <Detail>
-                    Dato: {data?.opplysning?.tidspunkt ? formatterDato(data.opplysning.tidspunkt) : 'Ikke angitt'}{' '}
-                    <br />
-                    Kilde: {sendtInnAvOpplysinger?.kilde ?? 'Ikke angitt'} <br />
+                    Dato: {detaljer?.tidspunkt ? formatterDato(detaljer.tidspunkt) : 'Ikke angitt'} <br />
+                    Kilde: {detaljer?.sendtInnAv.kilde ?? 'Ikke angitt'} <br />
                 </Detail>
             )}
         </VStack>

--- a/src/components/Oppfolging/index.tsx
+++ b/src/components/Oppfolging/index.tsx
@@ -1,8 +1,10 @@
 import {
-    Alert,
     BodyShort,
+    Box,
+    Detail,
     Heading,
     HGrid,
+    InlineMessage,
     Pagination,
     Skeleton,
     type SortState,
@@ -13,12 +15,14 @@ import { useState } from 'react';
 import { AlertBanner } from 'src/components/AlertBanner';
 import Card from 'src/components/Card';
 import ErrorBoundary from 'src/components/ErrorBoundary';
-import { getMeldeplikt, getOppfolgingEnhet, getVeileder } from 'src/components/Oppfolging/utils';
+import { getOppfolgingEnhet, getVeileder } from 'src/components/Oppfolging/utils';
 import {
     useArbeidsoppfolging,
     useGjeldende14aVedtak,
+    useOppslagArbeidssoekerregisteret,
     useSykefravaersoppfolging
 } from 'src/lib/clients/modiapersonoversikt-api';
+import { formatterDato } from 'src/utils/date-utils';
 import { datoEllerNull } from 'src/utils/string-utils';
 
 const OppfolgingDetaljer = () => {
@@ -28,55 +32,44 @@ const OppfolgingDetaljer = () => {
 
     if (isLoading) return <Skeleton variant="rectangle" height={166} />;
 
-    if (!arbeidsOppfolging) {
-        return <Alert variant="info">Brukeren har ingen oppfølging.</Alert>;
-    }
-
     return (
         <>
             <Heading as="h3" size="small">
                 Arbeidsoppfølging
             </Heading>
-            <HGrid gap="space-16" columns={{ sm: 1, md: 2, lg: 3 }} className="mt-2">
-                <VStack justify="space-between">
-                    <BodyShort size="small" weight="semibold">
-                        Status:
-                    </BodyShort>
-                    <BodyShort size="small">
-                        {arbeidsOppfolging.oppfolging?.erUnderOppfolging ? 'Under oppfølging' : 'Ikke under oppfølging'}
-                    </BodyShort>
-                </VStack>
-                <VStack justify="space-between">
-                    <BodyShort size="small" weight="semibold">
-                        Oppfølgingsenhet:
-                    </BodyShort>
-                    <BodyShort size="small">{getOppfolgingEnhet(arbeidsOppfolging.oppfolging)}</BodyShort>
-                </VStack>
-                <VStack justify="space-between">
-                    <BodyShort size="small" weight="semibold">
-                        Veileder:
-                    </BodyShort>
-                    <BodyShort size="small">{getVeileder(arbeidsOppfolging.oppfolging?.veileder)}</BodyShort>
-                </VStack>
-                <VStack justify="space-between">
-                    <BodyShort size="small" weight="semibold">
-                        Meldeplikt:
-                    </BodyShort>
-                    <BodyShort size="small">{getMeldeplikt(arbeidsOppfolging.meldeplikt)}</BodyShort>
-                </VStack>
-                <VStack justify="space-between">
-                    <BodyShort size="small" weight="semibold">
-                        Formidlingsgruppe:
-                    </BodyShort>
-                    <BodyShort size="small">{arbeidsOppfolging.formidlingsgruppe}</BodyShort>
-                </VStack>
-                <VStack justify="space-between">
-                    <BodyShort size="small" weight="semibold">
-                        Oppfølgingsvedtak:
-                    </BodyShort>
-                    <BodyShort size="small">{datoEllerNull(arbeidsOppfolging.vedtaksdato)}</BodyShort>
-                </VStack>
-            </HGrid>
+            {!arbeidsOppfolging ? (
+                <Box paddingBlock="space-8">
+                    <InlineMessage status="info">Brukeren har ingen oppfølging.</InlineMessage>
+                </Box>
+            ) : (
+                <HGrid gap="space-16" columns={{ sm: 1, md: 3, lg: 4 }} className="mt-2" align="start">
+                    <VStack justify="space-between">
+                        <BodyShort size="small" weight="semibold">
+                            Status:
+                        </BodyShort>
+                        <BodyShort size="small">
+                            {arbeidsOppfolging.oppfolging?.erUnderOppfolging
+                                ? 'Under oppfølging'
+                                : 'Ikke under oppfølging'}
+                        </BodyShort>
+                    </VStack>
+                    <VStack justify="space-between">
+                        <BodyShort size="small" weight="semibold">
+                            Oppfølgingsenhet:
+                        </BodyShort>
+                        <BodyShort size="small">{getOppfolgingEnhet(arbeidsOppfolging.oppfolging)}</BodyShort>
+                    </VStack>
+                    <VStack justify="space-between">
+                        <BodyShort size="small" weight="semibold">
+                            Veileder:
+                        </BodyShort>
+                        <BodyShort size="small">{getVeileder(arbeidsOppfolging.oppfolging?.veileder)}</BodyShort>
+                    </VStack>
+                    <ErrorBoundary boundaryName="arbeidssoekerregisteretDetaljer">
+                        <ArbeidssoekerregisteretDetaljer />
+                    </ErrorBoundary>
+                </HGrid>
+            )}
         </>
     );
 };
@@ -103,24 +96,28 @@ const Gjeldende14aVedtakDetaljer = () => {
                         {gjeldende14aVedtak ? 'Har § 14 a-vedtak' : 'Har ikke § 14 a-vedtak'}
                     </BodyShort>
                 </VStack>
-                <VStack justify="space-between">
-                    <BodyShort size="small" weight="semibold">
-                        Innsatsgruppe:
-                    </BodyShort>
-                    <BodyShort size="small">{gjeldende14aVedtak?.innsatsgruppe.beskrivelse}</BodyShort>
-                </VStack>
-                <VStack justify="space-between">
-                    <BodyShort size="small" weight="semibold">
-                        Hovedmål:
-                    </BodyShort>
-                    <BodyShort size="small">{gjeldende14aVedtak?.hovedmal?.beskrivelse}</BodyShort>
-                </VStack>
-                <VStack justify="space-between">
-                    <BodyShort size="small" weight="semibold">
-                        Vedtaksdato:
-                    </BodyShort>
-                    <BodyShort size="small">{datoEllerNull(gjeldende14aVedtak?.fattetDato)}</BodyShort>
-                </VStack>
+                {gjeldende14aVedtak && (
+                    <>
+                        <VStack justify="space-between">
+                            <BodyShort size="small" weight="semibold">
+                                Innsatsgruppe:
+                            </BodyShort>
+                            <BodyShort size="small">{gjeldende14aVedtak?.innsatsgruppe.beskrivelse}</BodyShort>
+                        </VStack>
+                        <VStack justify="space-between">
+                            <BodyShort size="small" weight="semibold">
+                                Hovedmål:
+                            </BodyShort>
+                            <BodyShort size="small">{gjeldende14aVedtak?.hovedmal?.beskrivelse}</BodyShort>
+                        </VStack>
+                        <VStack justify="space-between">
+                            <BodyShort size="small" weight="semibold">
+                                Vedtaksdato:
+                            </BodyShort>
+                            <BodyShort size="small">{datoEllerNull(gjeldende14aVedtak?.fattetDato)}</BodyShort>
+                        </VStack>
+                    </>
+                )}
             </HGrid>
         </>
     );
@@ -137,7 +134,7 @@ const SykefravaersoppfolgingDetaljer = () => {
     if (isLoading) return <Skeleton variant="rectangle" height={166} />;
 
     if (!sykefravaersoppfolging || sykefravaersoppfolging.length === 0) {
-        return <Alert variant="info">Brukeren har ingen sykefraværs-oppfølging.</Alert>;
+        return <InlineMessage status="info">Brukeren har ingen sykefraværs-oppfølging</InlineMessage>;
     }
 
     const handleSort = (sortKey: string) => {
@@ -166,38 +163,77 @@ const SykefravaersoppfolgingDetaljer = () => {
                 <Heading as="h3" size="small">
                     Sykefraværsoppfølging
                 </Heading>
-                <Table zebraStripes={true} sort={sort} onSortChange={handleSort} size="small">
-                    <Table.Header>
-                        <Table.Row>
-                            <Table.ColumnHeader sortKey="dato" sortable>
-                                Innen
-                            </Table.ColumnHeader>
-                            <Table.HeaderCell scope="col">Hendelse</Table.HeaderCell>
-                            <Table.HeaderCell scope="col">Status</Table.HeaderCell>
-                        </Table.Row>
-                    </Table.Header>
-                    <Table.Body>
-                        {tabellData.map((element, index) => {
-                            return (
-                                <Table.Row shadeOnHover={true} key={index}>
-                                    <Table.DataCell>{datoEllerNull(element.dato) ?? 'Ikke angitt'}</Table.DataCell>
-                                    <Table.DataCell>{element.syfoHendelse ?? 'Ikke angitt'}</Table.DataCell>
-                                    <Table.DataCell>{element.status ?? 'Ikke angitt'}</Table.DataCell>
+                {!sykefravaersoppfolging || sykefravaersoppfolging.length === 0 ? (
+                    <InlineMessage status="info">Brukeren har ingen sykefraværs-oppfølging</InlineMessage>
+                ) : (
+                    <>
+                        <Table zebraStripes={true} sort={sort} onSortChange={handleSort} size="small">
+                            <Table.Header>
+                                <Table.Row>
+                                    <Table.ColumnHeader sortKey="dato" sortable>
+                                        Innen
+                                    </Table.ColumnHeader>
+                                    <Table.HeaderCell scope="col">Hendelse</Table.HeaderCell>
+                                    <Table.HeaderCell scope="col">Status</Table.HeaderCell>
                                 </Table.Row>
-                            );
-                        })}
-                    </Table.Body>
-                </Table>
-                {sortedData.length > rowsPerPage && (
-                    <Pagination
-                        page={page}
-                        onPageChange={setPage}
-                        count={Math.ceil(sortedData.length / rowsPerPage)}
-                        size="xsmall"
-                    />
+                            </Table.Header>
+                            <Table.Body>
+                                {tabellData.map((element, index) => {
+                                    return (
+                                        <Table.Row shadeOnHover={true} key={index}>
+                                            <Table.DataCell>
+                                                {datoEllerNull(element.dato) ?? 'Ikke angitt'}
+                                            </Table.DataCell>
+                                            <Table.DataCell>{element.syfoHendelse ?? 'Ikke angitt'}</Table.DataCell>
+                                            <Table.DataCell>{element.status ?? 'Ikke angitt'}</Table.DataCell>
+                                        </Table.Row>
+                                    );
+                                })}
+                            </Table.Body>
+                        </Table>
+                        {sortedData.length > rowsPerPage && (
+                            <Pagination
+                                page={page}
+                                onPageChange={setPage}
+                                count={Math.ceil(sortedData.length / rowsPerPage)}
+                                size="xsmall"
+                            />
+                        )}
+                    </>
                 )}
             </VStack>
         </Card>
+    );
+};
+
+export const ArbeidssoekerregisteretDetaljer = () => {
+    const { data, isError } = useOppslagArbeidssoekerregisteret();
+
+    if (isError) return;
+
+    const erRegistrertSomArbeidssoker = data && !data.avsluttet;
+    const sendtInnAvOpplysinger = data?.startet.sendtInnAv;
+
+    return (
+        <VStack justify="space-between">
+            <BodyShort size="small" weight="semibold">
+                Arbeidssøkerstatus:
+            </BodyShort>
+            {erRegistrertSomArbeidssoker ? (
+                <BodyShort size="small">Er registrert som arbeidssøker</BodyShort>
+            ) : (
+                <BodyShort size="small">
+                    Er <span className="font-semibold">ikke</span> registrert som arbeidssøker
+                </BodyShort>
+            )}
+            {erRegistrertSomArbeidssoker && (
+                <Detail>
+                    Dato: {data?.opplysning?.tidspunkt ? formatterDato(data.opplysning.tidspunkt) : 'Ikke angitt'}{' '}
+                    <br />
+                    Kilde: {sendtInnAvOpplysinger?.kilde ?? 'Ikke angitt'} <br />
+                </Detail>
+            )}
+        </VStack>
     );
 };
 
@@ -205,6 +241,7 @@ const OppfolgingPageContent = () => {
     const { errorMessages: gjeldende14aVedtakErrorMessage, isError: gjeldende14aVedtakErro } = useGjeldende14aVedtak();
     const { errorMessages: arbeidsoppfolgingErrorMessage, isError: arbeidsoppfolgingError } = useArbeidsoppfolging();
     const { errorMessages: syfoErrorMessage } = useSykefravaersoppfolging();
+    const { errorMessages: arbeidssoekerregisteretErrorMessage } = useOppslagArbeidssoekerregisteret();
 
     const doubleErrors = arbeidsoppfolgingError && gjeldende14aVedtakErro;
     const hasErrors = arbeidsoppfolgingError || gjeldende14aVedtakErro;
@@ -214,7 +251,12 @@ const OppfolgingPageContent = () => {
                 Oppfølging
             </Heading>
             <AlertBanner
-                alerts={[...arbeidsoppfolgingErrorMessage, ...gjeldende14aVedtakErrorMessage, ...syfoErrorMessage]}
+                alerts={[
+                    ...arbeidsoppfolgingErrorMessage,
+                    ...gjeldende14aVedtakErrorMessage,
+                    ...syfoErrorMessage,
+                    ...arbeidssoekerregisteretErrorMessage
+                ]}
             />
             {!doubleErrors && (
                 <Card padding="space-16">
@@ -227,6 +269,7 @@ const OppfolgingPageContent = () => {
                     </ErrorBoundary>
                 </Card>
             )}
+
             <ErrorBoundary boundaryName="sykefraversoppfolgingDetaljer">
                 <SykefravaersoppfolgingDetaljer />
             </ErrorBoundary>

--- a/src/components/Oppfolging/index.tsx
+++ b/src/components/Oppfolging/index.tsx
@@ -27,11 +27,10 @@ import { datoEllerNull } from 'src/utils/string-utils';
 
 const OppfolgingDetaljer = () => {
     const { data: arbeidsOppfolging, isLoading, isError } = useArbeidsoppfolging();
-    const { isLoading: arbeidssoekerregisteretLoading } = useOppslagArbeidssoekerregisteret();
 
     if (isError) return;
 
-    if (isLoading || arbeidssoekerregisteretLoading) return <Skeleton variant="rectangle" height={166} />;
+    if (isLoading) return <Skeleton variant="rectangle" height={166} />;
 
     return (
         <>
@@ -208,9 +207,10 @@ const SykefravaersoppfolgingDetaljer = () => {
 };
 
 const ArbeidssoekerregisteretDetaljer = () => {
-    const { data, isError } = useOppslagArbeidssoekerregisteret();
+    const { data, isError, isLoading } = useOppslagArbeidssoekerregisteret();
 
     if (isError) return;
+    if (isLoading) return <Skeleton variant="rectangle" height={50} />;
 
     const erRegistrertSomArbeidssoker = data && !data.avsluttet;
     const detaljer = data?.opplysning;

--- a/src/components/Oppfolging/index.tsx
+++ b/src/components/Oppfolging/index.tsx
@@ -228,10 +228,10 @@ const ArbeidssoekerregisteretDetaljer = () => {
                 </BodyShort>
             )}
             {detaljer && (
-                <Detail>
-                    Dato: {detaljer?.tidspunkt ? formatterDato(detaljer.tidspunkt) : 'Ikke angitt'} <br />
-                    Kilde: {detaljer?.sendtInnAv.kilde ?? 'Ikke angitt'} <br />
-                </Detail>
+                <>
+                    <Detail>Dato: {detaljer?.tidspunkt ? formatterDato(detaljer.tidspunkt) : 'Ikke angitt'} </Detail>
+                    <Detail>Kilde: {detaljer?.sendtInnAv.kilde ?? 'Ikke angitt'}</Detail>
+                </>
             )}
         </VStack>
     );

--- a/src/components/Oppfolging/index.tsx
+++ b/src/components/Oppfolging/index.tsx
@@ -228,10 +228,7 @@ const ArbeidssoekerregisteretDetaljer = () => {
                 </BodyShort>
             )}
             {detaljer && (
-                <>
-                    <Detail>Dato: {detaljer?.tidspunkt ? formatterDato(detaljer.tidspunkt) : 'Ikke angitt'} </Detail>
-                    <Detail>Kilde: {detaljer?.sendtInnAv.kilde ?? 'Ikke angitt'}</Detail>
-                </>
+                <Detail>Dato: {detaljer?.tidspunkt ? formatterDato(detaljer.tidspunkt) : 'Ikke angitt'} </Detail>
             )}
         </VStack>
     );

--- a/src/components/Oppfolging/utils.ts
+++ b/src/components/Oppfolging/utils.ts
@@ -11,7 +11,3 @@ export function getOppfolgingEnhet(oppfolging?: OppfolgingDto): string {
 export function getVeileder(veileder?: Veileder): string {
     return veileder ? `${veileder.navn} (${veileder.ident})` : '-';
 }
-
-export function getMeldeplikt(meldeplikt?: boolean): string {
-    return meldeplikt ? 'Ja' : meldeplikt === false ? 'Nei' : 'Meldeplikt Ukjent';
-}

--- a/src/components/featureToggle/toggleIDs.ts
+++ b/src/components/featureToggle/toggleIDs.ts
@@ -1,6 +1,5 @@
 export enum FeatureToggles {
     VisPromptMeldingSending = 'modiapersonoversikt.vis-promt-naar-melding-sendes',
-    VisSiste14aVedtak = 'modiapersonoversikt.vis-siste-14a-vedtak',
     JournalforUtenSvar = 'modiapersonoversikt.meldinger-uten-svar-kan-journalfores',
     NyModiaKnapp = 'modiapersonoversikt.ny-modia-knapp',
     InfotrygdSykepenger = 'modiapersonoversikt.infotrygd-sykepenger',

--- a/src/generated/modiapersonoversikt-api.ts
+++ b/src/generated/modiapersonoversikt-api.ts
@@ -356,6 +356,22 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    '/rest/oppfolging/oppslag-arbeidssoekerregisteret': {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        post: operations['hentOppslagArbeidssoekerregisteret'];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     '/rest/oppfolging/hent-gjeldende-14a-vedtak': {
         parameters: {
             query?: never;
@@ -1312,10 +1328,6 @@ export interface components {
         LocalDate: {
             /** Format: date */
             value?: string;
-            /** Format: date */
-            value$kotlinx_datetime: string;
-            /** Format: int32 */
-            monthNumber: number;
             /** Format: int32 */
             year: number;
             /** Format: int32 */
@@ -1326,16 +1338,14 @@ export interface components {
             dayOfWeek: LocalDateDayOfWeek;
             /** Format: int32 */
             dayOfYear: number;
+            /** Format: date */
+            value$kotlinx_datetime: string;
+            /** Format: int32 */
+            monthNumber: number;
         };
         LocalDateTime: {
             /** Format: date-time */
             value?: string;
-            /** Format: date-time */
-            value$kotlinx_datetime: string;
-            /** Format: int32 */
-            monthNumber: number;
-            /** Format: int32 */
-            nanosecond: number;
             time: components['schemas']['LocalTime'];
             /** Format: int32 */
             year: number;
@@ -1354,18 +1364,24 @@ export interface components {
             /** Format: int32 */
             dayOfYear: number;
             date: components['schemas']['LocalDate'];
+            /** Format: date-time */
+            value$kotlinx_datetime: string;
+            /** Format: int32 */
+            monthNumber: number;
+            /** Format: int32 */
+            nanosecond: number;
         };
         LocalTime: {
             value?: string;
-            value$kotlinx_datetime: string;
-            /** Format: int32 */
-            nanosecond: number;
             /** Format: int32 */
             hour: number;
             /** Format: int32 */
             minute: number;
             /** Format: int32 */
             second: number;
+            value$kotlinx_datetime: string;
+            /** Format: int32 */
+            nanosecond: number;
         };
         ResultatSoknadsstatus: {
             resultat: components['schemas']['SoknadsstatusSakstema'][];
@@ -1858,6 +1874,142 @@ export interface components {
         SykefravaerOppfolgingDTO: {
             sykefravaersoppfolging?: components['schemas']['SyfoPunktDTO'][];
         };
+        AggregertPeriodeArbeidssoekerregisteretDto: {
+            /** Format: uuid */
+            id: string;
+            identitetsnummer: string;
+            startet: components['schemas']['PeriodeStartetArbeidssoekerregisteretDto'];
+            avsluttet?: components['schemas']['PeriodeAvluttetArbeidssoekerregisteretDto'];
+            opplysning?: components['schemas']['OpplysningerOmArbeidssoekerArbeidssoekerregisteretDto'];
+            profilering?: components['schemas']['ProfileringArbeidssoekerregisteretDto'];
+            egenvurdering?: components['schemas']['EgenvurderingArbeidssoekerregisteretDto'];
+            bekreftelse?: components['schemas']['BekreftelseArbeidssoekerregisteretDto'];
+        };
+        AnnetArbeidssoekerregisteretDto: {
+            /** @enum {string} */
+            andreForholdHindrerArbeid?: AnnetArbeidssoekerregisteretDtoAndreForholdHindrerArbeid;
+        };
+        BekreftelseArbeidssoekerregisteretDto: {
+            /** @enum {string} */
+            type: BekreftelseArbeidssoekerregisteretDtoType;
+            /** Format: uuid */
+            id: string;
+            /** @enum {string} */
+            bekreftelsesloesning: BekreftelseArbeidssoekerregisteretDtoBekreftelsesloesning;
+            /** @enum {string} */
+            status: BekreftelseArbeidssoekerregisteretDtoStatus;
+            svar: components['schemas']['SvarArbeidssoekerregisteretDto'];
+            /** Format: date-time */
+            tidspunkt: string;
+        };
+        BeskrivelseMedDetaljerArbeidssoekerregisteretDto: {
+            /** @enum {string} */
+            beskrivelse: BeskrivelseMedDetaljerArbeidssoekerregisteretDtoBeskrivelse;
+            detaljer: {
+                [key: string]: string;
+            };
+        };
+        BrukerArbeidssoekerregisteretDto: {
+            /** @enum {string} */
+            type: BrukerArbeidssoekerregisteretDtoType;
+            id: string;
+            sikkerhetsnivaa?: string;
+        };
+        EgenvurderingArbeidssoekerregisteretDto: {
+            /** @enum {string} */
+            type: EgenvurderingArbeidssoekerregisteretDtoType;
+            /** Format: uuid */
+            id: string;
+            /** Format: uuid */
+            profileringId: string;
+            sendtInnAv: components['schemas']['MetadataArbeidssoekerregisteretDto'];
+            /** @enum {string} */
+            profilertTil: EgenvurderingArbeidssoekerregisteretDtoProfilertTil;
+            /** @enum {string} */
+            egenvurdering: EgenvurderingArbeidssoekerregisteretDtoEgenvurdering;
+            /** Format: date-time */
+            tidspunkt: string;
+        };
+        HelseArbeidssoekerregisteretDto: {
+            /** @enum {string} */
+            helsetilstandHindrerArbeid?: HelseArbeidssoekerregisteretDtoHelsetilstandHindrerArbeid;
+        };
+        JobbsituasjonArbeidssoekerregisteretDto: {
+            beskrivelser: components['schemas']['BeskrivelseMedDetaljerArbeidssoekerregisteretDto'][];
+        };
+        MetadataArbeidssoekerregisteretDto: {
+            /** Format: date-time */
+            tidspunkt: string;
+            utfoertAv: components['schemas']['BrukerArbeidssoekerregisteretDto'];
+            kilde: string;
+            aarsak: string;
+            tidspunktFraKilde?: components['schemas']['TidspunktFraKildeArbeidssoekerregisteretDto'];
+        };
+        OpplysningerOmArbeidssoekerArbeidssoekerregisteretDto: {
+            /** @enum {string} */
+            type: OpplysningerOmArbeidssoekerArbeidssoekerregisteretDtoType;
+            /** Format: uuid */
+            id: string;
+            sendtInnAv: components['schemas']['MetadataArbeidssoekerregisteretDto'];
+            /** Format: date-time */
+            tidspunkt: string;
+            utdanning?: components['schemas']['UtdanningArbeidssoekerregisteretDto'];
+            helse?: components['schemas']['HelseArbeidssoekerregisteretDto'];
+            jobbsituasjon?: components['schemas']['JobbsituasjonArbeidssoekerregisteretDto'];
+            annet?: components['schemas']['AnnetArbeidssoekerregisteretDto'];
+        };
+        PeriodeAvluttetArbeidssoekerregisteretDto: {
+            /** @enum {string} */
+            type: PeriodeAvluttetArbeidssoekerregisteretDtoType;
+            sendtInnAv: components['schemas']['MetadataArbeidssoekerregisteretDto'];
+            /** Format: date-time */
+            tidspunkt: string;
+        };
+        PeriodeStartetArbeidssoekerregisteretDto: {
+            /** @enum {string} */
+            type: PeriodeStartetArbeidssoekerregisteretDtoType;
+            sendtInnAv: components['schemas']['MetadataArbeidssoekerregisteretDto'];
+            /** Format: date-time */
+            tidspunkt: string;
+        };
+        ProfileringArbeidssoekerregisteretDto: {
+            /** @enum {string} */
+            type: ProfileringArbeidssoekerregisteretDtoType;
+            /** Format: uuid */
+            id: string;
+            /** Format: uuid */
+            opplysningerOmArbeidssokerId: string;
+            sendtInnAv: components['schemas']['MetadataArbeidssoekerregisteretDto'];
+            /** @enum {string} */
+            profilertTil: ProfileringArbeidssoekerregisteretDtoProfilertTil;
+            jobbetSammenhengendeSeksAvTolvSisteMnd: boolean;
+            /** Format: date-time */
+            tidspunkt: string;
+            /** Format: int32 */
+            alder?: number;
+        };
+        SvarArbeidssoekerregisteretDto: {
+            sendtInnAv: components['schemas']['MetadataArbeidssoekerregisteretDto'];
+            /** Format: date-time */
+            gjelderFra: string;
+            /** Format: date-time */
+            gjelderTil: string;
+            harJobbetIDennePerioden: boolean;
+            vilFortsetteSomArbeidssoeker: boolean;
+        };
+        TidspunktFraKildeArbeidssoekerregisteretDto: {
+            /** Format: date-time */
+            tidspunkt: string;
+            /** @enum {string} */
+            avviksType: TidspunktFraKildeArbeidssoekerregisteretDtoAvviksType;
+        };
+        UtdanningArbeidssoekerregisteretDto: {
+            nus: string;
+            /** @enum {string} */
+            bestaatt?: UtdanningArbeidssoekerregisteretDtoBestaatt;
+            /** @enum {string} */
+            godkjent?: UtdanningArbeidssoekerregisteretDtoGodkjent;
+        };
         Gjeldende14aVedtak: {
             innsatsgruppe: components['schemas']['Innsatsgruppe'];
             hovedmal?: components['schemas']['Hovedmal'];
@@ -2298,6 +2450,28 @@ export type SyfoPunktDto = components['schemas']['SyfoPunktDTO'];
 export type UtvidetOppfolgingDto = components['schemas']['UtvidetOppfolgingDTO'];
 export type YtelseDto = components['schemas']['YtelseDTO'];
 export type SykefravaerOppfolgingDto = components['schemas']['SykefravaerOppfolgingDTO'];
+export type AggregertPeriodeArbeidssoekerregisteretDto =
+    components['schemas']['AggregertPeriodeArbeidssoekerregisteretDto'];
+export type AnnetArbeidssoekerregisteretDto = components['schemas']['AnnetArbeidssoekerregisteretDto'];
+export type BekreftelseArbeidssoekerregisteretDto = components['schemas']['BekreftelseArbeidssoekerregisteretDto'];
+export type BeskrivelseMedDetaljerArbeidssoekerregisteretDto =
+    components['schemas']['BeskrivelseMedDetaljerArbeidssoekerregisteretDto'];
+export type BrukerArbeidssoekerregisteretDto = components['schemas']['BrukerArbeidssoekerregisteretDto'];
+export type EgenvurderingArbeidssoekerregisteretDto = components['schemas']['EgenvurderingArbeidssoekerregisteretDto'];
+export type HelseArbeidssoekerregisteretDto = components['schemas']['HelseArbeidssoekerregisteretDto'];
+export type JobbsituasjonArbeidssoekerregisteretDto = components['schemas']['JobbsituasjonArbeidssoekerregisteretDto'];
+export type MetadataArbeidssoekerregisteretDto = components['schemas']['MetadataArbeidssoekerregisteretDto'];
+export type OpplysningerOmArbeidssoekerArbeidssoekerregisteretDto =
+    components['schemas']['OpplysningerOmArbeidssoekerArbeidssoekerregisteretDto'];
+export type PeriodeAvluttetArbeidssoekerregisteretDto =
+    components['schemas']['PeriodeAvluttetArbeidssoekerregisteretDto'];
+export type PeriodeStartetArbeidssoekerregisteretDto =
+    components['schemas']['PeriodeStartetArbeidssoekerregisteretDto'];
+export type ProfileringArbeidssoekerregisteretDto = components['schemas']['ProfileringArbeidssoekerregisteretDto'];
+export type SvarArbeidssoekerregisteretDto = components['schemas']['SvarArbeidssoekerregisteretDto'];
+export type TidspunktFraKildeArbeidssoekerregisteretDto =
+    components['schemas']['TidspunktFraKildeArbeidssoekerregisteretDto'];
+export type UtdanningArbeidssoekerregisteretDto = components['schemas']['UtdanningArbeidssoekerregisteretDto'];
 export type Gjeldende14aVedtak = components['schemas']['Gjeldende14aVedtak'];
 export type Gjeldende14aVedtakResponse = components['schemas']['Gjeldende14aVedtakResponse'];
 export type Hovedmal = components['schemas']['Hovedmal'];
@@ -2901,6 +3075,30 @@ export interface operations {
                 };
                 content: {
                     '*/*': components['schemas']['SykefravaerOppfolgingDTO'];
+                };
+            };
+        };
+    };
+    hentOppslagArbeidssoekerregisteret: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                'application/json': components['schemas']['FnrRequest'];
+            };
+        };
+        responses: {
+            /** @description OK */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    '*/*': components['schemas']['AggregertPeriodeArbeidssoekerregisteretDto'];
                 };
             };
         };
@@ -3894,6 +4092,111 @@ export enum IdentInformasjonGruppe {
     FOLKEREGISTERIDENT = 'FOLKEREGISTERIDENT',
     NPID = 'NPID',
     __UNKNOWN_VALUE = '__UNKNOWN_VALUE'
+}
+export enum AnnetArbeidssoekerregisteretDtoAndreForholdHindrerArbeid {
+    UKJENT_VERDI = 'UKJENT_VERDI',
+    JA = 'JA',
+    NEI = 'NEI',
+    VET_IKKE = 'VET_IKKE'
+}
+export enum BekreftelseArbeidssoekerregisteretDtoType {
+    BEKREFTELSE_V1 = 'BEKREFTELSE_V1'
+}
+export enum BekreftelseArbeidssoekerregisteretDtoBekreftelsesloesning {
+    UKJENT_VERDI = 'UKJENT_VERDI',
+    ARBEIDSSOEKERREGISTERET = 'ARBEIDSSOEKERREGISTERET',
+    DAGPENGER = 'DAGPENGER',
+    FRISKMELDT_TIL_ARBEIDSFORMIDLING = 'FRISKMELDT_TIL_ARBEIDSFORMIDLING'
+}
+export enum BekreftelseArbeidssoekerregisteretDtoStatus {
+    GYLDIG = 'GYLDIG',
+    UVENTET_KILDE = 'UVENTET_KILDE',
+    UTENFOR_PERIODE = 'UTENFOR_PERIODE'
+}
+export enum BeskrivelseMedDetaljerArbeidssoekerregisteretDtoBeskrivelse {
+    UKJENT_VERDI = 'UKJENT_VERDI',
+    UDEFINERT = 'UDEFINERT',
+    HAR_SAGT_OPP = 'HAR_SAGT_OPP',
+    HAR_BLITT_SAGT_OPP = 'HAR_BLITT_SAGT_OPP',
+    ER_PERMITTERT = 'ER_PERMITTERT',
+    ALDRI_HATT_JOBB = 'ALDRI_HATT_JOBB',
+    IKKE_VAERT_I_JOBB_SISTE_2_AAR = 'IKKE_VAERT_I_JOBB_SISTE_2_AAR',
+    AKKURAT_FULLFORT_UTDANNING = 'AKKURAT_FULLFORT_UTDANNING',
+    VIL_BYTTE_JOBB = 'VIL_BYTTE_JOBB',
+    USIKKER_JOBBSITUASJON = 'USIKKER_JOBBSITUASJON',
+    MIDLERTIDIG_JOBB = 'MIDLERTIDIG_JOBB',
+    DELTIDSJOBB_VIL_MER = 'DELTIDSJOBB_VIL_MER',
+    NY_JOBB = 'NY_JOBB',
+    KONKURS = 'KONKURS',
+    ANNET = 'ANNET'
+}
+export enum BrukerArbeidssoekerregisteretDtoType {
+    SLUTTBRUKER = 'SLUTTBRUKER',
+    VEILEDER = 'VEILEDER',
+    SYSTEM = 'SYSTEM',
+    UDEFINERT = 'UDEFINERT',
+    UKJENT_VERDI = 'UKJENT_VERDI'
+}
+export enum EgenvurderingArbeidssoekerregisteretDtoType {
+    EGENVURDERING_V1 = 'EGENVURDERING_V1'
+}
+export enum EgenvurderingArbeidssoekerregisteretDtoProfilertTil {
+    UKJENT_VERDI = 'UKJENT_VERDI',
+    UDEFINERT = 'UDEFINERT',
+    ANTATT_GODE_MULIGHETER = 'ANTATT_GODE_MULIGHETER',
+    ANTATT_BEHOV_FOR_VEILEDNING = 'ANTATT_BEHOV_FOR_VEILEDNING',
+    OPPGITT_HINDRINGER = 'OPPGITT_HINDRINGER'
+}
+export enum EgenvurderingArbeidssoekerregisteretDtoEgenvurdering {
+    UKJENT_VERDI = 'UKJENT_VERDI',
+    UDEFINERT = 'UDEFINERT',
+    ANTATT_GODE_MULIGHETER = 'ANTATT_GODE_MULIGHETER',
+    ANTATT_BEHOV_FOR_VEILEDNING = 'ANTATT_BEHOV_FOR_VEILEDNING',
+    OPPGITT_HINDRINGER = 'OPPGITT_HINDRINGER'
+}
+export enum HelseArbeidssoekerregisteretDtoHelsetilstandHindrerArbeid {
+    UKJENT_VERDI = 'UKJENT_VERDI',
+    JA = 'JA',
+    NEI = 'NEI',
+    VET_IKKE = 'VET_IKKE'
+}
+export enum OpplysningerOmArbeidssoekerArbeidssoekerregisteretDtoType {
+    OPPLYSNINGER_V4 = 'OPPLYSNINGER_V4'
+}
+export enum PeriodeAvluttetArbeidssoekerregisteretDtoType {
+    PERIODE_AVSLUTTET_V1 = 'PERIODE_AVSLUTTET_V1'
+}
+export enum PeriodeStartetArbeidssoekerregisteretDtoType {
+    PERIODE_STARTET_V1 = 'PERIODE_STARTET_V1'
+}
+export enum ProfileringArbeidssoekerregisteretDtoType {
+    PROFILERING_V1 = 'PROFILERING_V1'
+}
+export enum ProfileringArbeidssoekerregisteretDtoProfilertTil {
+    UKJENT_VERDI = 'UKJENT_VERDI',
+    UDEFINERT = 'UDEFINERT',
+    ANTATT_GODE_MULIGHETER = 'ANTATT_GODE_MULIGHETER',
+    ANTATT_BEHOV_FOR_VEILEDNING = 'ANTATT_BEHOV_FOR_VEILEDNING',
+    OPPGITT_HINDRINGER = 'OPPGITT_HINDRINGER'
+}
+export enum TidspunktFraKildeArbeidssoekerregisteretDtoAvviksType {
+    UKJENT_VERDI = 'UKJENT_VERDI',
+    FORSINKELSE = 'FORSINKELSE',
+    RETTING = 'RETTING',
+    SLETTET = 'SLETTET',
+    TIDSPUNKT_KORRIGERT = 'TIDSPUNKT_KORRIGERT'
+}
+export enum UtdanningArbeidssoekerregisteretDtoBestaatt {
+    UKJENT_VERDI = 'UKJENT_VERDI',
+    JA = 'JA',
+    NEI = 'NEI',
+    VET_IKKE = 'VET_IKKE'
+}
+export enum UtdanningArbeidssoekerregisteretDtoGodkjent {
+    UKJENT_VERDI = 'UKJENT_VERDI',
+    JA = 'JA',
+    NEI = 'NEI',
+    VET_IKKE = 'VET_IKKE'
 }
 export enum EnhetStatus {
     UNDER_ETABLERING = 'UNDER_ETABLERING',

--- a/src/lib/clients/modiapersonoversikt-api.ts
+++ b/src/lib/clients/modiapersonoversikt-api.ts
@@ -345,7 +345,7 @@ export const useOppslagArbeidssoekerregisteret = () => {
     const response = $api.useQuery('post', '/rest/oppfolging/oppslag-arbeidssoekerregisteret', {
         body: { fnr }
     });
-    const errorMessages = [errorPlaceholder(response, responseErrorMessage('data fra arbeidsøkerregisteret'))];
+    const errorMessages = [errorPlaceholder(response, responseErrorMessage('data fra arbeidssøkerregisteret'))];
     return {
         ...response,
         errorMessages: errorMessages.filter(Boolean)

--- a/src/lib/clients/modiapersonoversikt-api.ts
+++ b/src/lib/clients/modiapersonoversikt-api.ts
@@ -340,6 +340,18 @@ export const useSykefravaersoppfolging = () => {
     };
 };
 
+export const useOppslagArbeidssoekerregisteret = () => {
+    const fnr = usePersonAtomValue();
+    const response = $api.useQuery('post', '/rest/oppfolging/oppslag-arbeidssoekerregisteret', {
+        body: { fnr }
+    });
+    const errorMessages = [errorPlaceholder(response, responseErrorMessage('data fra arbeidsøkerregisteret'))];
+    return {
+        ...response,
+        errorMessages: errorMessages.filter(Boolean)
+    };
+};
+
 export const useGsakTema = () => {
     const response = $api.useQuery('get', '/rest/dialogoppgave/tema');
     const errorMessages = [errorPlaceholder(response, responseErrorMessage('temaer for meldinger'))];

--- a/src/mock/index.ts
+++ b/src/mock/index.ts
@@ -37,6 +37,7 @@ import {
     getMock14aVedtak,
     getMockArbeidsoppfolging,
     getMockOppfolging,
+    getMockOppslagArbeidssoekerregisteret,
     getMockSykefravaersoppfolging,
     getMockYtelserOgKontrakter
 } from './oppfolging-mock';
@@ -254,6 +255,15 @@ const arbeidsoppfolgingHandler = http.post(
     )
 );
 
+const oppslagArbeidssoekerregisteretHandler = http.post(
+    `${apiBaseUri}/oppfolging/oppslag-arbeidssoekerregisteret`,
+    withDelayedResponse(
+        randomDelay(),
+        fodselsNummerErGyldigStatus,
+        mockGeneratorMedFodselsnummerV2((fodselsnummer) => getMockOppslagArbeidssoekerregisteret(fodselsnummer))
+    )
+);
+
 const varslerHandler = http.post<PathParams, { fnr: string }>(`${apiBaseUri}/varsler`, async ({ request }) => {
     const body = await request.json();
     const fnr = body.fnr;
@@ -412,6 +422,7 @@ export const handlers: (HttpHandler | WebSocketHandler)[] = [
     gjeldende14aVedtakHandler,
     sykefravaeroppfolgingHandler,
     arbeidsoppfolgingHandler,
+    oppslagArbeidssoekerregisteretHandler,
     varslerHandler,
     opprettOppgaveHandler,
     opprettSkjermetOppgaveHandler,

--- a/src/mock/oppfolging-mock.ts
+++ b/src/mock/oppfolging-mock.ts
@@ -1,7 +1,28 @@
 import { fakerNB_NO as faker } from '@faker-js/faker';
 import dayjs from 'dayjs';
 import navfaker from 'nav-faker';
-import type { Gjeldende14aVedtak, SykefravaerOppfolgingDto } from 'src/generated/modiapersonoversikt-api';
+import type {
+    AggregertPeriodeArbeidssoekerregisteretDto,
+    Gjeldende14aVedtak,
+    MetadataArbeidssoekerregisteretDto,
+    SykefravaerOppfolgingDto
+} from 'src/generated/modiapersonoversikt-api';
+import {
+    BekreftelseArbeidssoekerregisteretDtoBekreftelsesloesning,
+    BekreftelseArbeidssoekerregisteretDtoStatus,
+    BekreftelseArbeidssoekerregisteretDtoType,
+    BeskrivelseMedDetaljerArbeidssoekerregisteretDtoBeskrivelse,
+    BrukerArbeidssoekerregisteretDtoType,
+    EgenvurderingArbeidssoekerregisteretDtoEgenvurdering,
+    EgenvurderingArbeidssoekerregisteretDtoProfilertTil,
+    EgenvurderingArbeidssoekerregisteretDtoType,
+    OpplysningerOmArbeidssoekerArbeidssoekerregisteretDtoType,
+    PeriodeStartetArbeidssoekerregisteretDtoType,
+    ProfileringArbeidssoekerregisteretDtoProfilertTil,
+    ProfileringArbeidssoekerregisteretDtoType,
+    UtdanningArbeidssoekerregisteretDtoBestaatt,
+    UtdanningArbeidssoekerregisteretDtoGodkjent
+} from 'src/generated/modiapersonoversikt-api';
 import type {
     AnsattEnhet,
     Arbeidsoppfolging,
@@ -140,5 +161,107 @@ function getArbeidsoppfolging(fodselsnummer: string): Arbeidsoppfolging {
         formidlingsgruppe: `FMGRP${faker.number.int(5)}`,
         vedtaksdato: dayjs(faker.date.recent({ days: 10 })).format(backendDatoformat),
         rettighetsgruppe: `RGRP${faker.number.int(10)}`
+    };
+}
+
+function getMetadata(): MetadataArbeidssoekerregisteretDto {
+    return {
+        tidspunkt: dayjs(faker.date.recent({ days: 30 })).toISOString(),
+        utfoertAv: {
+            type: faker.helpers.arrayElement([
+                BrukerArbeidssoekerregisteretDtoType.SLUTTBRUKER,
+                BrukerArbeidssoekerregisteretDtoType.VEILEDER,
+                BrukerArbeidssoekerregisteretDtoType.SYSTEM
+            ]),
+            id: faker.string.uuid()
+        },
+        kilde: 'arbeidssokerregisteret',
+        aarsak: 'Bruker registrerte seg'
+    };
+}
+
+export function getMockOppslagArbeidssoekerregisteret(
+    fodselsnummer: string
+): AggregertPeriodeArbeidssoekerregisteretDto {
+    faker.seed(Number(fodselsnummer));
+
+    const opplysningId = faker.string.uuid();
+    const profileringId = faker.string.uuid();
+
+    return {
+        id: faker.string.uuid(),
+        identitetsnummer: fodselsnummer,
+        startet: {
+            type: PeriodeStartetArbeidssoekerregisteretDtoType.PERIODE_STARTET_V1,
+            sendtInnAv: getMetadata(),
+            tidspunkt: dayjs(faker.date.recent({ days: 60 })).toISOString()
+        },
+        opplysning: {
+            type: OpplysningerOmArbeidssoekerArbeidssoekerregisteretDtoType.OPPLYSNINGER_V4,
+            id: opplysningId,
+            sendtInnAv: getMetadata(),
+            tidspunkt: dayjs(faker.date.recent({ days: 50 })).toISOString(),
+            utdanning: {
+                nus: '6',
+                bestaatt: UtdanningArbeidssoekerregisteretDtoBestaatt.JA,
+                godkjent: UtdanningArbeidssoekerregisteretDtoGodkjent.JA
+            },
+            jobbsituasjon: {
+                beskrivelser: [
+                    {
+                        beskrivelse: faker.helpers.arrayElement([
+                            BeskrivelseMedDetaljerArbeidssoekerregisteretDtoBeskrivelse.HAR_SAGT_OPP,
+                            BeskrivelseMedDetaljerArbeidssoekerregisteretDtoBeskrivelse.HAR_BLITT_SAGT_OPP,
+                            BeskrivelseMedDetaljerArbeidssoekerregisteretDtoBeskrivelse.VIL_BYTTE_JOBB,
+                            BeskrivelseMedDetaljerArbeidssoekerregisteretDtoBeskrivelse.IKKE_VAERT_I_JOBB_SISTE_2_AAR
+                        ]),
+                        detaljer: {}
+                    }
+                ]
+            }
+        },
+        profilering: {
+            type: ProfileringArbeidssoekerregisteretDtoType.PROFILERING_V1,
+            id: profileringId,
+            opplysningerOmArbeidssokerId: opplysningId,
+            sendtInnAv: getMetadata(),
+            profilertTil: faker.helpers.arrayElement([
+                ProfileringArbeidssoekerregisteretDtoProfilertTil.ANTATT_GODE_MULIGHETER,
+                ProfileringArbeidssoekerregisteretDtoProfilertTil.ANTATT_BEHOV_FOR_VEILEDNING,
+                ProfileringArbeidssoekerregisteretDtoProfilertTil.OPPGITT_HINDRINGER
+            ]),
+            jobbetSammenhengendeSeksAvTolvSisteMnd: faker.datatype.boolean(),
+            tidspunkt: dayjs(faker.date.recent({ days: 45 })).toISOString(),
+            alder: faker.number.int({ min: 18, max: 67 })
+        },
+        egenvurdering: {
+            type: EgenvurderingArbeidssoekerregisteretDtoType.EGENVURDERING_V1,
+            id: faker.string.uuid(),
+            profileringId: profileringId,
+            sendtInnAv: getMetadata(),
+            profilertTil: faker.helpers.arrayElement([
+                EgenvurderingArbeidssoekerregisteretDtoProfilertTil.ANTATT_GODE_MULIGHETER,
+                EgenvurderingArbeidssoekerregisteretDtoProfilertTil.ANTATT_BEHOV_FOR_VEILEDNING
+            ]),
+            egenvurdering: faker.helpers.arrayElement([
+                EgenvurderingArbeidssoekerregisteretDtoEgenvurdering.ANTATT_GODE_MULIGHETER,
+                EgenvurderingArbeidssoekerregisteretDtoEgenvurdering.ANTATT_BEHOV_FOR_VEILEDNING
+            ]),
+            tidspunkt: dayjs(faker.date.recent({ days: 40 })).toISOString()
+        },
+        bekreftelse: {
+            type: BekreftelseArbeidssoekerregisteretDtoType.BEKREFTELSE_V1,
+            id: faker.string.uuid(),
+            bekreftelsesloesning: BekreftelseArbeidssoekerregisteretDtoBekreftelsesloesning.ARBEIDSSOEKERREGISTERET,
+            status: BekreftelseArbeidssoekerregisteretDtoStatus.GYLDIG,
+            svar: {
+                sendtInnAv: getMetadata(),
+                gjelderFra: dayjs(faker.date.recent({ days: 14 })).toISOString(),
+                gjelderTil: dayjs(faker.date.soon({ days: 14 })).toISOString(),
+                harJobbetIDennePerioden: faker.datatype.boolean(),
+                vilFortsetteSomArbeidssoeker: true
+            },
+            tidspunkt: dayjs(faker.date.recent({ days: 7 })).toISOString()
+        }
     };
 }

--- a/src/test/testStore.ts
+++ b/src/test/testStore.ts
@@ -78,6 +78,7 @@ export function setupReactQueryMocks() {
     vi.spyOn(gsaktemaResource, 'useFetch');
     vi.spyOn(oppfolgingResource, 'useFetch');
     vi.spyOn(modiapersonoversiktApiClient, 'useSakerDokumenter');
+    vi.spyOn(modiapersonoversiktApiClient, 'useOppslagArbeidssoekerregisteret');
     vi.spyOn(utbetalingerResource, 'useFetch');
     vi.spyOn(persondataResource, 'useFetch');
     vi.spyOn(aktoridResource, 'useFetch');

--- a/src/test/testStore.ts
+++ b/src/test/testStore.ts
@@ -2,6 +2,7 @@ import type { UseQueryResult } from '@tanstack/react-query';
 import { applyMiddleware, createStore, type Dispatch, type Store } from 'redux';
 import thunkMiddleware from 'redux-thunk';
 import * as modiapersonoversiktApiClient from 'src/lib/clients/modiapersonoversikt-api';
+import { getMockOppslagArbeidssoekerregisteret } from 'src/mock/oppfolging-mock';
 import { statiskArbeidsavklaringspengerMock } from 'src/mock/ytelse/statiskArbeidsavklaringspengerMock';
 import { statiskEngangstonadMock, statiskForeldrepengerMock } from 'src/mock/ytelse/statiskForeldrepengerMock';
 import { statiskPensjonMock } from 'src/mock/ytelse/statiskPensjonMock';
@@ -123,4 +124,8 @@ export function setupReactQueryMocks() {
         varsler: [...statiskVarselMock, ...statiskVarselMock, ...statiskVarselMock]
     });
     mockReactQuery(sykepengerSpokelseResource.useSykepengerSpokelse, statiskSykepengerSpokelseMock);
+    mockReactQuery(
+        modiapersonoversiktApiClient.useOppslagArbeidssoekerregisteret,
+        getMockOppslagArbeidssoekerregisteret(aremark.personIdent)
+    );
 }

--- a/src/test/testStore.ts
+++ b/src/test/testStore.ts
@@ -91,7 +91,6 @@ export function setupReactQueryMocks() {
     mockReactQuery(featuretogglesResource.useFetch, {
         [FeatureToggles.JournalforUtenSvar]: true,
         [FeatureToggles.VisPromptMeldingSending]: true,
-        [FeatureToggles.VisSiste14aVedtak]: true,
         [FeatureToggles.NyModiaKnapp]: true,
         [FeatureToggles.InfotrygdSykepenger]: true,
         [FeatureToggles.SpokelseSykepenger]: true


### PR DESCRIPTION
Feltet er lagt til under arbeidsoppfølging. Prøver å ligne mest mulig på Modia arbeidsoppfølging demo: https://navikt.github.io/veilarbdetaljerfs/

Har fjernet feltene meldeplikt og formidlingsgruppe frå detaljer. Dette er data frå Arena som heller ikkje Modia arbeidsoppfølging viser. Fjerna også feltet oppfølgingsvedtak, for dette er den samme dataen som 14a vedtak.

Litt småfikser i designet også. Endra frå Alert til inlinemessage.

<img width="870" height="180" alt="image" src="https://github.com/user-attachments/assets/b2049cdf-a817-46e2-ad5e-562aac8b9cc4" />

