### PR TITLE
Fjerner frontend-filtrering av dagpenger-data

### DIFF
--- a/src/components/ytelser/utils.ts
+++ b/src/components/ytelser/utils.ts
@@ -64,6 +64,8 @@ const filterYtelser = (ytelser: YtelseVedtak[], filters: YtelseFilter): YtelseVe
 
     if (dateRange?.from && dateRange?.to) {
         filteredList = filteredList.filter((ytelse) => {
+            // Dagpenger er allerede filtrert etter dato av backenden
+            if (ytelse.ytelseType === YtelseVedtakYtelseType.Dagpenger) return true;
             const ytelseDato = getYtelseIdDato(ytelse);
             const dato = dayjs(ytelseDato);
             return dato.isSameOrAfter(dayjs(dateRange.from), 'day') && dato.isSameOrBefore(dayjs(dateRange.to), 'day');


### PR DESCRIPTION
Ved henting av dagpenger sender vi allerede med ønsket fra- og til-dato for dataene til endepunktet, basert på filteret i frontenden. Dataene vi får tilbake fra integrasjonen kan i noen tilfeller returnere data som ligger utenfor dette tidsspennet, og med ekstra filtrering av responsen vil vi skjule data som egentlig burde vært synlig for bruker.

Med denne endringen hopper vi helt over det ekstra laget med filtrering i frontenden, og viser heller responsen som allerede er filtrert av backenden.