### PR TITLE
Arbeidsoppfolging forbedringer

### DIFF
--- a/src/app/personside/infotabs/oppfolging/GetVeileder.test.ts
+++ b/src/app/personside/infotabs/oppfolging/GetVeileder.test.ts
@@ -2,6 +2,8 @@ import { getVeileder } from './oppfolging-utils';
 
 test('Viser informasjon om veileder dersom veileder finnes med navn og ident', () => {
     const veilederMedTommeFelter = {
+        fornavn: 'Ident',
+        etternavn: 'Identesen',
         navn: 'Ident Identesen',
         ident: 'Z999999'
     };
@@ -10,6 +12,8 @@ test('Viser informasjon om veileder dersom veileder finnes med navn og ident', (
 
 test('Viser informasjon om veileder dersom veileder finnes med bare ident', () => {
     const veilederMedTommeFelter = {
+        fornavn: '',
+        etternavn: '',
         navn: '',
         ident: 'Z999999'
     };
@@ -18,6 +22,8 @@ test('Viser informasjon om veileder dersom veileder finnes med bare ident', () =
 
 test('Viser ikke informasjon om veileder med et veilederobjekt med tomme feilter', () => {
     const veilederMedTommeFelter = {
+        fornavn: '',
+        etternavn: '',
         navn: '',
         ident: ''
     };

--- a/src/app/personside/infotabs/oppfolging/OppfolgingContainer.tsx
+++ b/src/app/personside/infotabs/oppfolging/OppfolgingContainer.tsx
@@ -1,12 +1,11 @@
-import { useOppslagArbeidssoekerregisteret } from 'src/lib/clients/modiapersonoversikt-api';
-import type { DetaljertOppfolging } from 'src/models/oppfolging';
-import { useOppfolgingFilter } from 'src/redux/oppfolging/reducer';
+import {
+    useArbeidsoppfolging,
+    useOppslagArbeidssoekerregisteret,
+    useSykefravaersoppfolging
+} from 'src/lib/clients/modiapersonoversikt-api';
 import styled from 'styled-components';
-import oppfolgingResource from '../../../../rest/resources/oppfolgingResource';
 import theme from '../../../../styles/personOversiktTheme';
 import VisOppfolgingDetaljer from './OppfolgingDetaljerKomponent';
-import OppfolgingFilter from './OppfolgingFilter';
-import OppfolgingYtelserEkspanderbartPanel from './OppfolgingYtelserEkspanderbartPanel';
 import SykefraversoppfolgingEkspanderbartPanel from './SykefraversoppfolgingEkspanderbartPanel';
 
 const OppfolgingStyle = styled.div`
@@ -16,36 +15,22 @@ const OppfolgingStyle = styled.div`
     padding: ${theme.margin.layout};
 `;
 
-const DetaljertInfoWrapper = styled.div`
-    display: flex;
-    flex-direction: row;
-    > *:last-child {
-        margin-left: ${theme.margin.layout};
-        flex-basis: 75%;
-    }
-`;
-
 function OppfolgingContainer() {
-    const periode = useOppfolgingFilter();
-    const fraTilDato = periode.egendefinertPeriode;
-    const oppfolgingResponse = oppfolgingResource.useFetch(fraTilDato.fra, fraTilDato.til);
-    const oppfolging = oppfolgingResponse.data as DetaljertOppfolging;
-
-    const { data, isError } = useOppslagArbeidssoekerregisteret();
+    const { data: arbeidsoppfolging, isError } = useArbeidsoppfolging();
+    const { data: syfraversData } = useSykefravaersoppfolging();
+    const { data: arbeidssoekerData, isError: isErrorArbeidssoekerRegisteret } = useOppslagArbeidssoekerregisteret();
 
     return (
         <OppfolgingStyle>
-            <DetaljertInfoWrapper>
-                <OppfolgingFilter />
-                <VisOppfolgingDetaljer
-                    detaljertOppfolging={oppfolging ?? {}}
-                    isErrorOppfolging={oppfolgingResponse.isError}
-                    isErrorArbeidssoekerRegisteret={isError}
-                    oppslagArbeidssoekerRegisteret={data}
-                />
-            </DetaljertInfoWrapper>
-            <SykefraversoppfolgingEkspanderbartPanel syfoPunkter={oppfolging?.sykefravaersoppfolging ?? []} />
-            <OppfolgingYtelserEkspanderbartPanel ytelser={oppfolging?.ytelser ?? []} />
+            <VisOppfolgingDetaljer
+                detaljertOppfolging={arbeidsoppfolging}
+                isErrorOppfolging={isError}
+                isErrorArbeidssoekerRegisteret={isErrorArbeidssoekerRegisteret}
+                oppslagArbeidssoekerRegisteret={arbeidssoekerData}
+            />
+            <SykefraversoppfolgingEkspanderbartPanel
+                syfoPunkter={syfraversData?.sykefravaersoppfolging ?? []}
+            />
         </OppfolgingStyle>
     );
 }

--- a/src/app/personside/infotabs/oppfolging/OppfolgingContainer.tsx
+++ b/src/app/personside/infotabs/oppfolging/OppfolgingContainer.tsx
@@ -31,7 +31,7 @@ const DetaljertInfoWrapper = styled.div`
 function OppfolgingContainer() {
     const periode = useOppfolgingFilter();
     const fraTilDato = periode.egendefinertPeriode;
-    const { data: ytelsesData } = oppfolgingResource.useFetch(fraTilDato.fra, fraTilDato.til);
+    const { data: ytelsesData, isLoading } = oppfolgingResource.useFetch(fraTilDato.fra, fraTilDato.til);
 
     const { data: arbeidsoppfolging, isError } = useArbeidsoppfolging();
     const { data: sykefravaersData } = useSykefravaersoppfolging();
@@ -49,7 +49,7 @@ function OppfolgingContainer() {
                 />
             </DetaljertInfoWrapper>
             <SykefraversoppfolgingEkspanderbartPanel syfoPunkter={sykefravaersData?.sykefravaersoppfolging ?? []} />
-            <OppfolgingYtelserEkspanderbartPanel ytelser={ytelsesData?.ytelser ?? []} />
+            <OppfolgingYtelserEkspanderbartPanel ytelser={ytelsesData?.ytelser ?? []} isLoading={isLoading} />
         </OppfolgingStyle>
     );
 }

--- a/src/app/personside/infotabs/oppfolging/OppfolgingContainer.tsx
+++ b/src/app/personside/infotabs/oppfolging/OppfolgingContainer.tsx
@@ -3,9 +3,13 @@ import {
     useOppslagArbeidssoekerregisteret,
     useSykefravaersoppfolging
 } from 'src/lib/clients/modiapersonoversikt-api';
+import { useOppfolgingFilter } from 'src/redux/oppfolging/reducer';
 import styled from 'styled-components';
+import oppfolgingResource from '../../../../rest/resources/oppfolgingResource';
 import theme from '../../../../styles/personOversiktTheme';
 import VisOppfolgingDetaljer from './OppfolgingDetaljerKomponent';
+import OppfolgingFilter from './OppfolgingFilter';
+import OppfolgingYtelserEkspanderbartPanel from './OppfolgingYtelserEkspanderbartPanel';
 import SykefraversoppfolgingEkspanderbartPanel from './SykefraversoppfolgingEkspanderbartPanel';
 
 const OppfolgingStyle = styled.div`
@@ -15,22 +19,39 @@ const OppfolgingStyle = styled.div`
     padding: ${theme.margin.layout};
 `;
 
+const DetaljertInfoWrapper = styled.div`
+    display: flex;
+    flex-direction: row;
+    > *:last-child {
+        margin-left: ${theme.margin.layout};
+        flex-basis: 75%;
+    }
+`;
+
 function OppfolgingContainer() {
+    const periode = useOppfolgingFilter();
+    const fraTilDato = periode.egendefinertPeriode;
+    const { data: ytelsesData } = oppfolgingResource.useFetch(fraTilDato.fra, fraTilDato.til);
+
     const { data: arbeidsoppfolging, isError } = useArbeidsoppfolging();
     const { data: syfraversData } = useSykefravaersoppfolging();
     const { data: arbeidssoekerData, isError: isErrorArbeidssoekerRegisteret } = useOppslagArbeidssoekerregisteret();
 
     return (
         <OppfolgingStyle>
-            <VisOppfolgingDetaljer
-                detaljertOppfolging={arbeidsoppfolging}
-                isErrorOppfolging={isError}
-                isErrorArbeidssoekerRegisteret={isErrorArbeidssoekerRegisteret}
-                oppslagArbeidssoekerRegisteret={arbeidssoekerData}
-            />
+            <DetaljertInfoWrapper>
+                <OppfolgingFilter />
+                <VisOppfolgingDetaljer
+                    detaljertOppfolging={arbeidsoppfolging}
+                    isErrorOppfolging={isError}
+                    isErrorArbeidssoekerRegisteret={isErrorArbeidssoekerRegisteret}
+                    oppslagArbeidssoekerRegisteret={arbeidssoekerData}
+                />
+            </DetaljertInfoWrapper>
             <SykefraversoppfolgingEkspanderbartPanel
                 syfoPunkter={syfraversData?.sykefravaersoppfolging ?? []}
             />
+            <OppfolgingYtelserEkspanderbartPanel ytelser={ytelsesData?.ytelser ?? []} />
         </OppfolgingStyle>
     );
 }

--- a/src/app/personside/infotabs/oppfolging/OppfolgingContainer.tsx
+++ b/src/app/personside/infotabs/oppfolging/OppfolgingContainer.tsx
@@ -34,7 +34,7 @@ function OppfolgingContainer() {
     const { data: ytelsesData } = oppfolgingResource.useFetch(fraTilDato.fra, fraTilDato.til);
 
     const { data: arbeidsoppfolging, isError } = useArbeidsoppfolging();
-    const { data: syfraversData } = useSykefravaersoppfolging();
+    const { data: sykefravaersData } = useSykefravaersoppfolging();
     const { data: arbeidssoekerData, isError: isErrorArbeidssoekerRegisteret } = useOppslagArbeidssoekerregisteret();
 
     return (
@@ -48,7 +48,7 @@ function OppfolgingContainer() {
                     oppslagArbeidssoekerRegisteret={arbeidssoekerData}
                 />
             </DetaljertInfoWrapper>
-            <SykefraversoppfolgingEkspanderbartPanel syfoPunkter={syfraversData?.sykefravaersoppfolging ?? []} />
+            <SykefraversoppfolgingEkspanderbartPanel syfoPunkter={sykefravaersData?.sykefravaersoppfolging ?? []} />
             <OppfolgingYtelserEkspanderbartPanel ytelser={ytelsesData?.ytelser ?? []} />
         </OppfolgingStyle>
     );

--- a/src/app/personside/infotabs/oppfolging/OppfolgingContainer.tsx
+++ b/src/app/personside/infotabs/oppfolging/OppfolgingContainer.tsx
@@ -48,9 +48,7 @@ function OppfolgingContainer() {
                     oppslagArbeidssoekerRegisteret={arbeidssoekerData}
                 />
             </DetaljertInfoWrapper>
-            <SykefraversoppfolgingEkspanderbartPanel
-                syfoPunkter={syfraversData?.sykefravaersoppfolging ?? []}
-            />
+            <SykefraversoppfolgingEkspanderbartPanel syfoPunkter={syfraversData?.sykefravaersoppfolging ?? []} />
             <OppfolgingYtelserEkspanderbartPanel ytelser={ytelsesData?.ytelser ?? []} />
         </OppfolgingStyle>
     );

--- a/src/app/personside/infotabs/oppfolging/OppfolgingDetaljerKomponent.tsx
+++ b/src/app/personside/infotabs/oppfolging/OppfolgingDetaljerKomponent.tsx
@@ -5,10 +5,12 @@ import Panel from 'nav-frontend-paneler';
 import { Undertittel } from 'nav-frontend-typografi';
 import { useRef } from 'react';
 import Siste14aVedtakDetaljer from 'src/app/personside/infotabs/oppfolging/Gjeldende14aVedtakDetaljer';
+import LazySpinner from 'src/components/LazySpinner';
 import type {
     AggregertPeriodeArbeidssoekerregisteretDto,
     ArbeidsOppfolgingDto
 } from 'src/generated/modiapersonoversikt-api';
+import { useArbeidsoppfolging, useOppslagArbeidssoekerregisteret } from 'src/lib/clients/modiapersonoversikt-api';
 import { pxToRem } from 'src/styles/personOversiktTheme';
 import { formatterDato } from 'src/utils/date-utils';
 import styled from 'styled-components';
@@ -30,6 +32,9 @@ interface Props {
 }
 
 function VisOppfolgingDetaljer(props: Props) {
+    const { isLoading } = useArbeidsoppfolging();
+    const { isLoading: isLoadingArbeidssoekerRegisteret } = useOppslagArbeidssoekerregisteret();
+
     const headerId = useRef(guid());
     const detaljer = props.detaljertOppfolging;
     const oppslagArbeidssoekerRegisteret = props.oppslagArbeidssoekerRegisteret;
@@ -76,15 +81,19 @@ function VisOppfolgingDetaljer(props: Props) {
 
     return (
         <StyledPanel aria-labelledby={headerId.current}>
-            <article>
-                {errorLoadingData}
-                {errorLoadingDataArbeidssoekerRegisteret}
-                {ikkeFullstendigData}
-                <Undertittel id={headerId.current}>Arbeidsoppfølging</Undertittel>
-                <DescriptionList entries={descriptionListProps} />
-                <br />
-                <Siste14aVedtakDetaljer />
-            </article>
+            {isLoading || isLoadingArbeidssoekerRegisteret ? (
+                <LazySpinner type="L" />
+            ) : (
+                <article>
+                    {errorLoadingData}
+                    {errorLoadingDataArbeidssoekerRegisteret}
+                    {ikkeFullstendigData}
+                    <Undertittel id={headerId.current}>Arbeidsoppfølging</Undertittel>
+                    <DescriptionList entries={descriptionListProps} />
+                    <br />
+                    <Siste14aVedtakDetaljer />
+                </article>
+            )}
         </StyledPanel>
     );
 }

--- a/src/app/personside/infotabs/oppfolging/OppfolgingDetaljerKomponent.tsx
+++ b/src/app/personside/infotabs/oppfolging/OppfolgingDetaljerKomponent.tsx
@@ -50,7 +50,7 @@ function VisOppfolgingDetaljer(props: Props) {
     const arbeidssoekerregisteretOpplysinger = oppslagArbeidssoekerRegisteret?.opplysning;
 
     const descriptionListProps = {
-        'Er under oppfølging': getErUnderOppfolging(detaljer?.oppfolging),
+        'Er under arbeidsrettet oppfølging': getErUnderOppfolging(detaljer?.oppfolging),
         Oppfølgingsenhet: getOppfolgingEnhet(detaljer?.oppfolging),
         Veileder: getVeileder(detaljer?.oppfolging?.veileder),
         ...(!errorLoadingDataArbeidssoekerRegisteret

--- a/src/app/personside/infotabs/oppfolging/OppfolgingDetaljerKomponent.tsx
+++ b/src/app/personside/infotabs/oppfolging/OppfolgingDetaljerKomponent.tsx
@@ -5,8 +5,10 @@ import Panel from 'nav-frontend-paneler';
 import { Undertittel } from 'nav-frontend-typografi';
 import { useRef } from 'react';
 import Siste14aVedtakDetaljer from 'src/app/personside/infotabs/oppfolging/Gjeldende14aVedtakDetaljer';
-import type { AggregertPeriodeArbeidssoekerregisteretDto } from 'src/generated/modiapersonoversikt-api';
-import type { DetaljertOppfolging } from 'src/models/oppfolging';
+import type {
+    AggregertPeriodeArbeidssoekerregisteretDto,
+    ArbeidsOppfolgingDto
+} from 'src/generated/modiapersonoversikt-api';
 import { pxToRem } from 'src/styles/personOversiktTheme';
 import { formatterDato } from 'src/utils/date-utils';
 import styled from 'styled-components';
@@ -21,7 +23,7 @@ const StyledPanel = styled(Panel)`
 `;
 
 interface Props {
-    detaljertOppfolging: DetaljertOppfolging;
+    detaljertOppfolging?: ArbeidsOppfolgingDto;
     oppslagArbeidssoekerRegisteret?: AggregertPeriodeArbeidssoekerregisteretDto;
     isErrorOppfolging?: boolean;
     isErrorArbeidssoekerRegisteret?: boolean;
@@ -33,7 +35,7 @@ function VisOppfolgingDetaljer(props: Props) {
     const oppslagArbeidssoekerRegisteret = props.oppslagArbeidssoekerRegisteret;
 
     const ikkeFullstendigData =
-        detaljer.oppfolging === null ? (
+        detaljer?.oppfolging == null ? (
             <AlertStripeAdvarsel>Kunne ikke hente ut all oppfølgings-informasjon</AlertStripeAdvarsel>
         ) : null;
     const errorLoadingData = props.isErrorOppfolging ? (
@@ -48,9 +50,9 @@ function VisOppfolgingDetaljer(props: Props) {
     const arbeidssoekerregisteretOpplysinger = oppslagArbeidssoekerRegisteret?.opplysning;
 
     const descriptionListProps = {
-        'Er under oppfølging': getErUnderOppfolging(detaljer.oppfolging),
-        Oppfølgingsenhet: getOppfolgingEnhet(detaljer.oppfolging),
-        Veileder: getVeileder(detaljer.oppfolging?.veileder),
+        'Er under oppfølging': getErUnderOppfolging(detaljer?.oppfolging),
+        Oppfølgingsenhet: getOppfolgingEnhet(detaljer?.oppfolging),
+        Veileder: getVeileder(detaljer?.oppfolging?.veileder),
         ...(!errorLoadingDataArbeidssoekerRegisteret
             ? {
                   Arbeidssøkerstatus: (

--- a/src/app/personside/infotabs/oppfolging/OppfolgingFilter.tsx
+++ b/src/app/personside/infotabs/oppfolging/OppfolgingFilter.tsx
@@ -51,7 +51,7 @@ function OppfolgingFilter() {
         <StyledPanel aria-labelledby={headerId.current}>
             <article>
                 <TittelWrapper>
-                    <Undertittel id={headerId.current}>Oppfølging og ytelser vises for perioden:</Undertittel>
+                    <Undertittel id={headerId.current}>Ytelser vises for perioden:</Undertittel>
                 </TittelWrapper>
                 <InputPanel>
                     <FiltreringPeriode

--- a/src/app/personside/infotabs/oppfolging/OppfolgingYtelserEkspanderbartPanel.tsx
+++ b/src/app/personside/infotabs/oppfolging/OppfolgingYtelserEkspanderbartPanel.tsx
@@ -15,6 +15,7 @@ import OppfolgingsVedtakTabell from './OppfolgingVedtakKomponent';
 
 interface Props {
     ytelser: OppfolgingsYtelse[];
+    isLoading?: boolean;
 }
 
 const ListeStyle = styled.ol`
@@ -84,7 +85,7 @@ function dersomDagpengerLeggTilFelter(ytelse: OppfolgingsYtelse): DescriptionLis
 function OppfolgingYtelserEkspanderbartPanel(props: Props) {
     const [open, setOpen] = useState(false);
 
-    if (props.ytelser.length === 0) {
+    if (props.ytelser.length === 0 && !props.isLoading) {
         return <AlertStripeInfo>Det finnes ikke informasjon om ytelser for valgt periode i Arena</AlertStripeInfo>;
     }
 

--- a/src/app/personside/infotabs/oppfolging/SykefraversoppfolgingEkspanderbartPanel.tsx
+++ b/src/app/personside/infotabs/oppfolging/SykefraversoppfolgingEkspanderbartPanel.tsx
@@ -1,7 +1,7 @@
 import { AlertStripeInfo } from 'nav-frontend-alertstriper';
 import { useState } from 'react';
-import { trackAccordionClosed, trackAccordionOpened } from 'src/utils/analytics';
 import type { SyfoPunktDto } from 'src/generated/modiapersonoversikt-api';
+import { trackAccordionClosed, trackAccordionOpened } from 'src/utils/analytics';
 import { datoSynkende, formatterDato } from '../../../../utils/date-utils';
 import { StyledTable } from '../../../../utils/table/StyledTable';
 import EkspanderbartYtelserPanel from '../ytelser/felles-styling/EkspanderbartYtelserPanel';

--- a/src/app/personside/infotabs/oppfolging/SykefraversoppfolgingEkspanderbartPanel.tsx
+++ b/src/app/personside/infotabs/oppfolging/SykefraversoppfolgingEkspanderbartPanel.tsx
@@ -1,22 +1,22 @@
 import { AlertStripeInfo } from 'nav-frontend-alertstriper';
 import { useState } from 'react';
 import { trackAccordionClosed, trackAccordionOpened } from 'src/utils/analytics';
-import type { SyfoPunkt } from '../../../../models/oppfolging';
+import type { SyfoPunktDto } from 'src/generated/modiapersonoversikt-api';
 import { datoSynkende, formatterDato } from '../../../../utils/date-utils';
 import { StyledTable } from '../../../../utils/table/StyledTable';
 import EkspanderbartYtelserPanel from '../ytelser/felles-styling/EkspanderbartYtelserPanel';
 
 interface Props {
-    syfoPunkter: SyfoPunkt[];
+    syfoPunkter: SyfoPunktDto[];
 }
 
-function SykefraversoppfolgingTabell(props: { syfoPunkter: SyfoPunkt[] }) {
-    const sortertPaDato = props.syfoPunkter.sort(datoSynkende((syfoPunkt) => syfoPunkt.dato));
+function SykefraversoppfolgingTabell(props: { syfoPunkter: SyfoPunktDto[] }) {
+    const sortertPaDato = props.syfoPunkter.sort(datoSynkende((syfoPunkt) => syfoPunkt.dato ?? ''));
 
     const tableHeaders = ['Innen', 'Hendelse', 'Status'];
 
     const tableRows = sortertPaDato.map((syfopunkt) => [
-        formatterDato(syfopunkt.dato),
+        syfopunkt.dato ? formatterDato(syfopunkt.dato) : undefined,
         syfopunkt.syfoHendelse,
         syfopunkt.status
     ]);

--- a/src/app/personside/infotabs/oppfolging/SykefraversoppfolgingEkspanderbartPanel.tsx
+++ b/src/app/personside/infotabs/oppfolging/SykefraversoppfolgingEkspanderbartPanel.tsx
@@ -1,6 +1,7 @@
 import { AlertStripeInfo } from 'nav-frontend-alertstriper';
 import { useState } from 'react';
 import type { SyfoPunktDto } from 'src/generated/modiapersonoversikt-api';
+import { useSykefravaersoppfolging } from 'src/lib/clients/modiapersonoversikt-api';
 import { trackAccordionClosed, trackAccordionOpened } from 'src/utils/analytics';
 import { datoSynkende, formatterDato } from '../../../../utils/date-utils';
 import { StyledTable } from '../../../../utils/table/StyledTable';
@@ -30,8 +31,9 @@ function SykefraversoppfolgingEkspanderbartPanel(props: Props) {
         setOpen(open);
         return open ? trackAccordionOpened('Sykefraværsoppfølging') : trackAccordionClosed('Sykefraværsoppfølging');
     };
+    const { isLoading } = useSykefravaersoppfolging();
 
-    if (props.syfoPunkter.length === 0) {
+    if (props.syfoPunkter.length === 0 && !isLoading) {
         return (
             <AlertStripeInfo>
                 Det finnes ikke informasjon om sykefraværsoppfølging for valgt periode i Arena

--- a/src/app/personside/infotabs/oppfolging/SykefraversoppfolgingEkspanderbartPanel.tsx
+++ b/src/app/personside/infotabs/oppfolging/SykefraversoppfolgingEkspanderbartPanel.tsx
@@ -11,7 +11,7 @@ interface Props {
 }
 
 function SykefraversoppfolgingTabell(props: { syfoPunkter: SyfoPunktDto[] }) {
-    const sortertPaDato = props.syfoPunkter.sort(datoSynkende((syfoPunkt) => syfoPunkt.dato ?? ''));
+    const sortertPaDato = [...props.syfoPunkter].sort(datoSynkende((syfoPunkt) => syfoPunkt.dato ?? ''));
 
     const tableHeaders = ['Innen', 'Hendelse', 'Status'];
 

--- a/src/app/personside/infotabs/oppfolging/__snapshots__/OppfolgingContainer.test.tsx.snap
+++ b/src/app/personside/infotabs/oppfolging/__snapshots__/OppfolgingContainer.test.tsx.snap
@@ -2,130 +2,28 @@
 
 exports[`Viser oppfølgingcontainer med alt innhold 1`] = `
 <DocumentFragment>
-  .c10 {
+  .c2 {
   display: flex;
   flex-wrap: wrap;
 }
 
-.c10 dt {
+.c2 dt {
   color: #645f5a;
 }
 
-.c10 >div {
+.c2 >div {
   margin: 0.5625rem 0;
   padding-right: 0.7rem;
   width: 13rem;
   overflow-wrap: break-word;
 }
 
-.c9 {
+.c1 {
   padding: 0.9375rem;
 }
 
-.c9 >*:first-child {
+.c1 >*:first-child {
   margin-bottom: 1rem;
-}
-
-.c8 {
-  display: flex;
-  gap: 20px;
-}
-
-.c5 {
-  display: flex;
-  flex-direction: column;
-  margin-top: 1.5rem;
-}
-
-.c5 >*:first-child {
-  margin-bottom: 0.5rem;
-}
-
-.c5 >* {
-  margin-top: 0.5rem;
-}
-
-.c5 .skjemaelement--horisontal {
-  margin-bottom: 0.4rem;
-}
-
-.c7 {
-  margin-bottom: 0.5rem;
-}
-
-.c6 {
-  border: none;
-  margin: 0;
-  padding: 0;
-}
-
-.c6 >*:first-child {
-  margin-bottom: 0.8rem;
-}
-
-.c6 >*:last-child {
-  margin-bottom: 0;
-}
-
-.c2 {
-  padding: 0.9375rem;
-}
-
-.c3 {
-  margin-bottom: .5rem;
-}
-
-.c3:focus {
-  outline: none;
-}
-
-.c4 {
-  display: flex;
-  flex-direction: column;
-  margin-top: 1.5rem;
-}
-
-.c4 >*:first-child {
-  margin-bottom: 0.5rem;
-}
-
-.c4 >* {
-  margin-top: 0.5rem;
-}
-
-.c4 .skjemaelement--horisontal {
-  margin-bottom: 0.4rem;
-}
-
-.c12 {
-  display: flex;
-  flex-wrap: wrap;
-  width: 100%;
-}
-
-.c12 >*:first-child {
-  flex-basis: 10em;
-  flex-shrink: 0;
-}
-
-.c12 >* {
-  white-space: nowrap;
-}
-
-.c12 >*:not(:last-child) {
-  margin-right: 2rem;
-}
-
-.c11 {
-  padding: 0rem;
-}
-
-.c11 .ekspanderbartPanel__hode {
-  position: sticky;
-  top: 0;
-  border-bottom: solid 0.0625rem #b7b1a9;
-  z-index: 10;
-  background-color: white;
 }
 
 .c0 {
@@ -136,442 +34,273 @@ exports[`Viser oppfølgingcontainer med alt innhold 1`] = `
   margin-bottom: .5rem;
 }
 
-.c1 {
-  display: flex;
-  flex-direction: row;
-}
-
-.c1 >*:last-child {
-  margin-left: .5rem;
-  flex-basis: 75%;
-}
-
 <div
     class="c0"
   >
     <div
-      class="c1"
+      aria-labelledby="Helt tilfeldig ID"
+      class="panel c1"
     >
-      <div
-        aria-labelledby="Helt tilfeldig ID"
-        class="panel c2"
-      >
-        <article>
+      <article>
+        <div
+          class="alertstripe alertstripe--advarsel"
+        >
+          <span
+            class="alertstripe__ikon"
+          >
+            <span
+              class="sr-only"
+            >
+              advarsel
+            </span>
+            <svg
+              aria-label="advarsel-ikon"
+              focusable="false"
+              height="1.5em"
+              kind="advarsel-sirkel-fyll"
+              role="img"
+              viewBox="0 0 24 24"
+              width="1.5em"
+            >
+              <g
+                fill="none"
+                fill-rule="evenodd"
+              >
+                <path
+                  d="M12.205-.004l-.214.002a12.225 12.225 0 0 0-8.517 3.659C1.179 5.977-.053 9.013.002 12.208c.115 6.613 5.296 11.793 11.795 11.793l.212-.002c6.726-.116 12.105-5.595 11.99-12.21C23.883 5.178 18.702-.003 12.204-.003z"
+                  fill="#FFA733"
+                  fill-rule="nonzero"
+                />
+                <path
+                  d="M12.027 19H12A1.499 1.499 0 0 1 11.973 16L12 16a1.501 1.501 0 0 1 .027 3z"
+                  fill="#3E3832"
+                />
+                <path
+                  d="M12 5a1 1 0 0 1 1 1v7a1 1 0 0 1-2 0V6a1 1 0 0 1 1-1z"
+                  fill="#3E3832"
+                  fill-rule="nonzero"
+                />
+              </g>
+            </svg>
+          </span>
           <div
-            class="c3"
+            class="typo-normal alertstripe__tekst"
           >
-            <h2
-              class="typo-undertittel"
-              id="Helt tilfeldig ID"
-            >
-              Oppfølging og ytelser vises for perioden:
-            </h2>
+            Kunne ikke laste inn informasjon om brukers oppfølging
           </div>
-          <form
-            class="c4"
+        </div>
+        <div
+          class="alertstripe alertstripe--advarsel"
+        >
+          <span
+            class="alertstripe__ikon"
           >
-            <form
-              class="c5"
+            <span
+              class="sr-only"
             >
-              <fieldset
-                class="c6"
+              advarsel
+            </span>
+            <svg
+              aria-label="advarsel-ikon"
+              focusable="false"
+              height="1.5em"
+              kind="advarsel-sirkel-fyll"
+              role="img"
+              viewBox="0 0 24 24"
+              width="1.5em"
+            >
+              <g
+                fill="none"
+                fill-rule="evenodd"
               >
-                <legend
-                  class="typo-element"
-                >
-                  Velg periode
-                </legend>
-                <div
-                  class="c7"
-                >
-                  <div
-                    class="skjemaelement"
-                  >
-                    <input
-                      aria-invalid="false"
-                      class="skjemaelement__input radioknapp"
-                      id="Helt tilfeldig ID"
-                      name="FiltreringsvalgGruppe"
-                      type="radio"
-                    />
-                    <label
-                      class="skjemaelement__label"
-                      for="Helt tilfeldig ID"
-                    >
-                      Siste 30 dager
-                    </label>
-                  </div>
-                </div>
-                <div
-                  class="c7"
-                >
-                  <div
-                    class="skjemaelement"
-                  >
-                    <input
-                      aria-invalid="false"
-                      class="skjemaelement__input radioknapp"
-                      id="Helt tilfeldig ID"
-                      name="FiltreringsvalgGruppe"
-                      type="radio"
-                    />
-                    <label
-                      class="skjemaelement__label"
-                      for="Helt tilfeldig ID"
-                    >
-                      Inneværende år
-                    </label>
-                  </div>
-                </div>
-                <div
-                  class="c7"
-                >
-                  <div
-                    class="skjemaelement"
-                  >
-                    <input
-                      aria-invalid="false"
-                      class="skjemaelement__input radioknapp"
-                      id="Helt tilfeldig ID"
-                      name="FiltreringsvalgGruppe"
-                      type="radio"
-                    />
-                    <label
-                      class="skjemaelement__label"
-                      for="Helt tilfeldig ID"
-                    >
-                      I fjor
-                    </label>
-                  </div>
-                </div>
-                <div
-                  class="c7"
-                >
-                  <div
-                    class="skjemaelement"
-                  >
-                    <input
-                      aria-invalid="false"
-                      checked=""
-                      class="skjemaelement__input radioknapp"
-                      id="Helt tilfeldig ID"
-                      name="FiltreringsvalgGruppe"
-                      type="radio"
-                    />
-                    <label
-                      class="skjemaelement__label"
-                      for="Helt tilfeldig ID"
-                    >
-                      Egendefinert
-                    </label>
-                  </div>
-                </div>
-              </fieldset>
-              <div
-                class="c8"
+                <path
+                  d="M12.205-.004l-.214.002a12.225 12.225 0 0 0-8.517 3.659C1.179 5.977-.053 9.013.002 12.208c.115 6.613 5.296 11.793 11.795 11.793l.212-.002c6.726-.116 12.105-5.595 11.99-12.21C23.883 5.178 18.702-.003 12.204-.003z"
+                  fill="#FFA733"
+                  fill-rule="nonzero"
+                />
+                <path
+                  d="M12.027 19H12A1.499 1.499 0 0 1 11.973 16L12 16a1.501 1.501 0 0 1 .027 3z"
+                  fill="#3E3832"
+                />
+                <path
+                  d="M12 5a1 1 0 0 1 1 1v7a1 1 0 0 1-2 0V6a1 1 0 0 1 1-1z"
+                  fill="#3E3832"
+                  fill-rule="nonzero"
+                />
+              </g>
+            </svg>
+          </span>
+          <div
+            class="typo-normal alertstripe__tekst"
+          >
+            Kunne ikke hente ut all oppfølgings-informasjon
+          </div>
+        </div>
+        <h2
+          class="typo-undertittel"
+          id="Helt tilfeldig ID"
+        >
+          Arbeidsoppfølging
+        </h2>
+        <dl
+          class="c2"
+        >
+          <div>
+            <dt
+              class="typo-normal"
+            >
+              Er under oppfølging
+            </dt>
+            <dd
+              class="typo-element"
+            >
+              —
+            </dd>
+          </div>
+          <div>
+            <dt
+              class="typo-normal"
+            >
+              Oppfølgingsenhet
+            </dt>
+            <dd
+              class="typo-element"
+            >
+              —
+            </dd>
+          </div>
+          <div>
+            <dt
+              class="typo-normal"
+            >
+              Veileder
+            </dt>
+            <dd
+              class="typo-element"
+            >
+              —
+            </dd>
+          </div>
+          <div>
+            <dt
+              class="typo-normal"
+            >
+              Arbeidssøkerstatus
+            </dt>
+            <dd
+              class="typo-element"
+            >
+              Er registrert som arbeidssøker
+              <p
+                class="aksel-detail"
               >
-                <div
-                  class="aksel-date__wrapper"
-                >
-                  <div
-                    class="aksel-form-field aksel-form-field--small aksel-date__field"
-                  >
-                    <label
-                      class="aksel-form-field__label aksel-label aksel-label--small"
-                      for="datepicker-input-_r_2_"
-                    >
-                      Fra
-                    </label>
-                    <div
-                      class="aksel-date__field-wrapper"
-                    >
-                      <input
-                        autocomplete="off"
-                        class="aksel-date__field-input aksel-text-field__input aksel-body-short aksel-body-short--small"
-                        id="datepicker-input-_r_2_"
-                        size="11"
-                        value="01.01.1968"
-                      />
-                      <button
-                        class="aksel-date__field-button"
-                        tabindex="0"
-                        type="button"
-                      >
-                        <svg
-                          aria-labelledby="title-_r_3_"
-                          fill="none"
-                          focusable="false"
-                          height="1em"
-                          role="img"
-                          viewBox="0 0 24 24"
-                          width="1em"
-                          xmlns="http://www.w3.org/2000/svg"
-                        >
-                          <title
-                            id="title-_r_3_"
-                          >
-                            Åpne datovelger
-                          </title>
-                          <path
-                            clip-rule="evenodd"
-                            d="M9 2.25a.75.75 0 0 1 .75.75v1.25h4.5V3a.75.75 0 0 1 1.5 0v1.25h3.75c.69 0 1.25.56 1.25 1.25v13c0 .69-.56 1.25-1.25 1.25h-15c-.69 0-1.25-.56-1.25-1.25v-13c0-.69.56-1.25 1.25-1.25h3.75V3A.75.75 0 0 1 9 2.25M15.75 7a.75.75 0 0 1-1.5 0V5.75h-4.5V7a.75.75 0 0 1-1.5 0V5.75h-3.5v3.5h14.5v-3.5h-3.5zm-11 11.25v-7.5h14.5v7.5zm2-5.25a.75.75 0 0 1 .75-.75h1a.75.75 0 0 1 0 1.5h-1a.75.75 0 0 1-.75-.75m4 0a.75.75 0 0 1 .75-.75h1a.75.75 0 0 1 0 1.5h-1a.75.75 0 0 1-.75-.75m4.75-.75a.75.75 0 0 0 0 1.5h1a.75.75 0 0 0 0-1.5zM10.75 16a.75.75 0 0 1 .75-.75h1a.75.75 0 0 1 0 1.5h-1a.75.75 0 0 1-.75-.75m4.75-.75a.75.75 0 0 0 0 1.5h1a.75.75 0 0 0 0-1.5zM6.75 16a.75.75 0 0 1 .75-.75h1a.75.75 0 0 1 0 1.5h-1a.75.75 0 0 1-.75-.75"
-                            fill="currentColor"
-                            fill-rule="evenodd"
-                          />
-                        </svg>
-                      </button>
-                    </div>
-                    <div
-                      aria-live="polite"
-                      aria-relevant="additions removals"
-                      class="aksel-form-field__error"
-                      id="datepicker-input-error-_r_2_"
-                    />
-                  </div>
-                </div>
-                <div
-                  class="aksel-date__wrapper"
-                >
-                  <div
-                    class="aksel-form-field aksel-form-field--small aksel-date__field"
-                  >
-                    <label
-                      class="aksel-form-field__label aksel-label aksel-label--small"
-                      for="datepicker-input-_r_6_"
-                    >
-                      Til
-                    </label>
-                    <div
-                      class="aksel-date__field-wrapper"
-                    >
-                      <input
-                        autocomplete="off"
-                        class="aksel-date__field-input aksel-text-field__input aksel-body-short aksel-body-short--small"
-                        id="datepicker-input-_r_6_"
-                        size="11"
-                        value="01.01.1970"
-                      />
-                      <button
-                        class="aksel-date__field-button"
-                        tabindex="0"
-                        type="button"
-                      >
-                        <svg
-                          aria-labelledby="title-_r_7_"
-                          fill="none"
-                          focusable="false"
-                          height="1em"
-                          role="img"
-                          viewBox="0 0 24 24"
-                          width="1em"
-                          xmlns="http://www.w3.org/2000/svg"
-                        >
-                          <title
-                            id="title-_r_7_"
-                          >
-                            Åpne datovelger
-                          </title>
-                          <path
-                            clip-rule="evenodd"
-                            d="M9 2.25a.75.75 0 0 1 .75.75v1.25h4.5V3a.75.75 0 0 1 1.5 0v1.25h3.75c.69 0 1.25.56 1.25 1.25v13c0 .69-.56 1.25-1.25 1.25h-15c-.69 0-1.25-.56-1.25-1.25v-13c0-.69.56-1.25 1.25-1.25h3.75V3A.75.75 0 0 1 9 2.25M15.75 7a.75.75 0 0 1-1.5 0V5.75h-4.5V7a.75.75 0 0 1-1.5 0V5.75h-3.5v3.5h14.5v-3.5h-3.5zm-11 11.25v-7.5h14.5v7.5zm2-5.25a.75.75 0 0 1 .75-.75h1a.75.75 0 0 1 0 1.5h-1a.75.75 0 0 1-.75-.75m4 0a.75.75 0 0 1 .75-.75h1a.75.75 0 0 1 0 1.5h-1a.75.75 0 0 1-.75-.75m4.75-.75a.75.75 0 0 0 0 1.5h1a.75.75 0 0 0 0-1.5zM10.75 16a.75.75 0 0 1 .75-.75h1a.75.75 0 0 1 0 1.5h-1a.75.75 0 0 1-.75-.75m4.75-.75a.75.75 0 0 0 0 1.5h1a.75.75 0 0 0 0-1.5zM6.75 16a.75.75 0 0 1 .75-.75h1a.75.75 0 0 1 0 1.5h-1a.75.75 0 0 1-.75-.75"
-                            fill="currentColor"
-                            fill-rule="evenodd"
-                          />
-                        </svg>
-                      </button>
-                    </div>
-                    <div
-                      aria-live="polite"
-                      aria-relevant="additions removals"
-                      class="aksel-form-field__error"
-                      id="datepicker-input-error-_r_6_"
-                    />
-                  </div>
-                </div>
-              </div>
-            </form>
-          </form>
-        </article>
-      </div>
-      <div
-        aria-labelledby="Helt tilfeldig ID"
-        class="panel c9"
-      >
+                Dato: 03.12.1969
+              </p>
+               
+            </dd>
+          </div>
+        </dl>
+        <br />
         <article>
           <h2
             class="typo-undertittel"
             id="Helt tilfeldig ID"
           >
-            Arbeidsoppfølging
+            14a vedtak
           </h2>
           <dl
-            class="c10"
+            class="c2"
           >
             <div>
               <dt
                 class="typo-normal"
               >
-                Er under oppfølging
+                Har 14a vedtak
               </dt>
               <dd
                 class="typo-element"
               >
-                Nei
+                Ja
               </dd>
             </div>
             <div>
               <dt
                 class="typo-normal"
               >
-                Oppfølgingsenhet
+                Innsatsgruppe
               </dt>
               <dd
                 class="typo-element"
               >
-                E0001 Tangen AS
+                Innsatsgruppe 3
               </dd>
             </div>
             <div>
               <dt
                 class="typo-normal"
               >
-                Veileder
+                Hovedmål
               </dt>
               <dd
                 class="typo-element"
               >
-                Testident Testidentesen (Z0000001)
+                —
               </dd>
             </div>
             <div>
               <dt
                 class="typo-normal"
               >
-                Arbeidssøkerstatus
+                Vedtaksdato
               </dt>
               <dd
                 class="typo-element"
               >
-                Er registrert som arbeidssøker
-                <p
-                  class="aksel-detail"
-                >
-                  Dato: 03.12.1969
-                </p>
-                 
+                15.01.2023
               </dd>
             </div>
           </dl>
-          <br />
-          <article>
-            <h2
-              class="typo-undertittel"
-              id="Helt tilfeldig ID"
-            >
-              14a vedtak
-            </h2>
-            <dl
-              class="c10"
-            >
-              <div>
-                <dt
-                  class="typo-normal"
-                >
-                  Har 14a vedtak
-                </dt>
-                <dd
-                  class="typo-element"
-                >
-                  Nei
-                </dd>
-              </div>
-            </dl>
-          </article>
         </article>
-      </div>
+      </article>
     </div>
     <div
-      class="panel c11"
+      class="alertstripe alertstripe--info"
     >
-      <div
-        class="ekspanderbartPanel test-ytelse-ytelselamell ekspanderbartPanel--lukket ekspanderbartPanel--border"
+      <span
+        class="alertstripe__ikon"
       >
-        <button
-          aria-controls="Helt tilfeldig ID"
-          aria-expanded="false"
-          aria-label="Sykefraværsoppfølging"
-          class="ekspanderbartPanel__hode"
-          id="Helt tilfeldig ID"
-          type="button"
+        <span
+          class="sr-only"
         >
-          <div
-            class="ekspanderbartPanel__flex-wrapper"
+          info
+        </span>
+        <svg
+          aria-label="info-ikon"
+          focusable="false"
+          height="1.5em"
+          kind="info-sirkel-fyll"
+          role="img"
+          viewBox="0 0 24 24"
+          width="1.5em"
+        >
+          <g
+            fill="none"
           >
-            <span
-              class="ekspanderbartPanel__tittel"
-            >
-              <div
-                class="c12"
-              >
-                <h2
-                  class="typo-undertittel"
-                >
-                  Sykefraværsoppfølging
-                </h2>
-              </div>
-            </span>
-            <span
-              class="ekspanderbartPanel__indikator"
+            <path
+              d="M12 0C5.382 0 0 5.382 0 12s5.382 12 12 12c6.617 0 12-5.382 12-12S18.617 0 12 0z"
+              fill="#337C9B"
             />
-          </div>
-        </button>
-        <div
-          aria-labelledby="Helt tilfeldig ID"
-          id="Helt tilfeldig ID"
-          role="region"
-        />
-      </div>
-    </div>
-    <div
-      class="panel c11"
-    >
+            <path
+              d="M12 5a1.566 1.566 0 1 1 .11 3.13A1.566 1.566 0 0 1 12 5zm2.976 12.01c.563 0 1.043.431 1.043.991s-.48.992-1.043.992H9.39c-.564 0-1.043-.431-1.043-.992 0-.56.479-.99 1.043-.99h1.6v-5.016h-.986c-.565 0-1.044-.43-1.044-.991 0-.56.48-.991 1.044-.991h2.03c.563 0 1.043.43 1.043.99v6.007h1.899z"
+              fill="#FFF"
+            />
+          </g>
+        </svg>
+      </span>
       <div
-        class="ekspanderbartPanel test-ytelse-ytelselamell ekspanderbartPanel--lukket ekspanderbartPanel--border"
+        class="typo-normal alertstripe__tekst"
       >
-        <button
-          aria-controls="Helt tilfeldig ID"
-          aria-expanded="false"
-          aria-label="Ytelser"
-          class="ekspanderbartPanel__hode"
-          id="Helt tilfeldig ID"
-          type="button"
-        >
-          <div
-            class="ekspanderbartPanel__flex-wrapper"
-          >
-            <span
-              class="ekspanderbartPanel__tittel"
-            >
-              <div
-                class="c12"
-              >
-                <h2
-                  class="typo-undertittel"
-                >
-                  Ytelser
-                </h2>
-              </div>
-            </span>
-            <span
-              class="ekspanderbartPanel__indikator"
-            />
-          </div>
-        </button>
-        <div
-          aria-labelledby="Helt tilfeldig ID"
-          id="Helt tilfeldig ID"
-          role="region"
-        />
+        Det finnes ikke informasjon om sykefraværsoppfølging for valgt periode i Arena
       </div>
     </div>
   </div>

--- a/src/app/personside/infotabs/oppfolging/__snapshots__/OppfolgingContainer.test.tsx.snap
+++ b/src/app/personside/infotabs/oppfolging/__snapshots__/OppfolgingContainer.test.tsx.snap
@@ -164,7 +164,7 @@ exports[`Viser oppfølgingcontainer med alt innhold 1`] = `
               class="typo-undertittel"
               id="Helt tilfeldig ID"
             >
-              Oppfølging og ytelser vises for perioden:
+              Ytelser vises for perioden:
             </h2>
           </div>
           <form

--- a/src/app/personside/infotabs/oppfolging/__snapshots__/OppfolgingContainer.test.tsx.snap
+++ b/src/app/personside/infotabs/oppfolging/__snapshots__/OppfolgingContainer.test.tsx.snap
@@ -398,100 +398,6 @@ exports[`Viser oppfølgingcontainer med alt innhold 1`] = `
         class="panel c9"
       >
         <article>
-          <div
-            class="alertstripe alertstripe--advarsel"
-          >
-            <span
-              class="alertstripe__ikon"
-            >
-              <span
-                class="sr-only"
-              >
-                advarsel
-              </span>
-              <svg
-                aria-label="advarsel-ikon"
-                focusable="false"
-                height="1.5em"
-                kind="advarsel-sirkel-fyll"
-                role="img"
-                viewBox="0 0 24 24"
-                width="1.5em"
-              >
-                <g
-                  fill="none"
-                  fill-rule="evenodd"
-                >
-                  <path
-                    d="M12.205-.004l-.214.002a12.225 12.225 0 0 0-8.517 3.659C1.179 5.977-.053 9.013.002 12.208c.115 6.613 5.296 11.793 11.795 11.793l.212-.002c6.726-.116 12.105-5.595 11.99-12.21C23.883 5.178 18.702-.003 12.204-.003z"
-                    fill="#FFA733"
-                    fill-rule="nonzero"
-                  />
-                  <path
-                    d="M12.027 19H12A1.499 1.499 0 0 1 11.973 16L12 16a1.501 1.501 0 0 1 .027 3z"
-                    fill="#3E3832"
-                  />
-                  <path
-                    d="M12 5a1 1 0 0 1 1 1v7a1 1 0 0 1-2 0V6a1 1 0 0 1 1-1z"
-                    fill="#3E3832"
-                    fill-rule="nonzero"
-                  />
-                </g>
-              </svg>
-            </span>
-            <div
-              class="typo-normal alertstripe__tekst"
-            >
-              Kunne ikke laste inn informasjon om brukers oppfølging
-            </div>
-          </div>
-          <div
-            class="alertstripe alertstripe--advarsel"
-          >
-            <span
-              class="alertstripe__ikon"
-            >
-              <span
-                class="sr-only"
-              >
-                advarsel
-              </span>
-              <svg
-                aria-label="advarsel-ikon"
-                focusable="false"
-                height="1.5em"
-                kind="advarsel-sirkel-fyll"
-                role="img"
-                viewBox="0 0 24 24"
-                width="1.5em"
-              >
-                <g
-                  fill="none"
-                  fill-rule="evenodd"
-                >
-                  <path
-                    d="M12.205-.004l-.214.002a12.225 12.225 0 0 0-8.517 3.659C1.179 5.977-.053 9.013.002 12.208c.115 6.613 5.296 11.793 11.795 11.793l.212-.002c6.726-.116 12.105-5.595 11.99-12.21C23.883 5.178 18.702-.003 12.204-.003z"
-                    fill="#FFA733"
-                    fill-rule="nonzero"
-                  />
-                  <path
-                    d="M12.027 19H12A1.499 1.499 0 0 1 11.973 16L12 16a1.501 1.501 0 0 1 .027 3z"
-                    fill="#3E3832"
-                  />
-                  <path
-                    d="M12 5a1 1 0 0 1 1 1v7a1 1 0 0 1-2 0V6a1 1 0 0 1 1-1z"
-                    fill="#3E3832"
-                    fill-rule="nonzero"
-                  />
-                </g>
-              </svg>
-            </span>
-            <div
-              class="typo-normal alertstripe__tekst"
-            >
-              Kunne ikke hente ut all oppfølgings-informasjon
-            </div>
-          </div>
           <h2
             class="typo-undertittel"
             id="Helt tilfeldig ID"
@@ -510,7 +416,7 @@ exports[`Viser oppfølgingcontainer med alt innhold 1`] = `
               <dd
                 class="typo-element"
               >
-                —
+                Ja
               </dd>
             </div>
             <div>
@@ -522,7 +428,7 @@ exports[`Viser oppfølgingcontainer med alt innhold 1`] = `
               <dd
                 class="typo-element"
               >
-                —
+                E0001 Test Enhet
               </dd>
             </div>
             <div>
@@ -534,7 +440,7 @@ exports[`Viser oppfølgingcontainer med alt innhold 1`] = `
               <dd
                 class="typo-element"
               >
-                —
+                Test Veileder (Z0000001)
               </dd>
             </div>
             <div>

--- a/src/app/personside/infotabs/oppfolging/__snapshots__/OppfolgingContainer.test.tsx.snap
+++ b/src/app/personside/infotabs/oppfolging/__snapshots__/OppfolgingContainer.test.tsx.snap
@@ -2,28 +2,130 @@
 
 exports[`Viser oppfølgingcontainer med alt innhold 1`] = `
 <DocumentFragment>
-  .c2 {
+  .c10 {
   display: flex;
   flex-wrap: wrap;
 }
 
-.c2 dt {
+.c10 dt {
   color: #645f5a;
 }
 
-.c2 >div {
+.c10 >div {
   margin: 0.5625rem 0;
   padding-right: 0.7rem;
   width: 13rem;
   overflow-wrap: break-word;
 }
 
-.c1 {
+.c9 {
   padding: 0.9375rem;
 }
 
-.c1 >*:first-child {
+.c9 >*:first-child {
   margin-bottom: 1rem;
+}
+
+.c8 {
+  display: flex;
+  gap: 20px;
+}
+
+.c5 {
+  display: flex;
+  flex-direction: column;
+  margin-top: 1.5rem;
+}
+
+.c5 >*:first-child {
+  margin-bottom: 0.5rem;
+}
+
+.c5 >* {
+  margin-top: 0.5rem;
+}
+
+.c5 .skjemaelement--horisontal {
+  margin-bottom: 0.4rem;
+}
+
+.c7 {
+  margin-bottom: 0.5rem;
+}
+
+.c6 {
+  border: none;
+  margin: 0;
+  padding: 0;
+}
+
+.c6 >*:first-child {
+  margin-bottom: 0.8rem;
+}
+
+.c6 >*:last-child {
+  margin-bottom: 0;
+}
+
+.c2 {
+  padding: 0.9375rem;
+}
+
+.c3 {
+  margin-bottom: .5rem;
+}
+
+.c3:focus {
+  outline: none;
+}
+
+.c4 {
+  display: flex;
+  flex-direction: column;
+  margin-top: 1.5rem;
+}
+
+.c4 >*:first-child {
+  margin-bottom: 0.5rem;
+}
+
+.c4 >* {
+  margin-top: 0.5rem;
+}
+
+.c4 .skjemaelement--horisontal {
+  margin-bottom: 0.4rem;
+}
+
+.c12 {
+  display: flex;
+  flex-wrap: wrap;
+  width: 100%;
+}
+
+.c12 >*:first-child {
+  flex-basis: 10em;
+  flex-shrink: 0;
+}
+
+.c12 >* {
+  white-space: nowrap;
+}
+
+.c12 >*:not(:last-child) {
+  margin-right: 2rem;
+}
+
+.c11 {
+  padding: 0rem;
+}
+
+.c11 .ekspanderbartPanel__hode {
+  position: sticky;
+  top: 0;
+  border-bottom: solid 0.0625rem #b7b1a9;
+  z-index: 10;
+  background-color: white;
 }
 
 .c0 {
@@ -34,212 +136,376 @@ exports[`Viser oppfølgingcontainer med alt innhold 1`] = `
   margin-bottom: .5rem;
 }
 
+.c1 {
+  display: flex;
+  flex-direction: row;
+}
+
+.c1 >*:last-child {
+  margin-left: .5rem;
+  flex-basis: 75%;
+}
+
 <div
     class="c0"
   >
     <div
-      aria-labelledby="Helt tilfeldig ID"
-      class="panel c1"
+      class="c1"
     >
-      <article>
-        <div
-          class="alertstripe alertstripe--advarsel"
-        >
-          <span
-            class="alertstripe__ikon"
-          >
-            <span
-              class="sr-only"
-            >
-              advarsel
-            </span>
-            <svg
-              aria-label="advarsel-ikon"
-              focusable="false"
-              height="1.5em"
-              kind="advarsel-sirkel-fyll"
-              role="img"
-              viewBox="0 0 24 24"
-              width="1.5em"
-            >
-              <g
-                fill="none"
-                fill-rule="evenodd"
-              >
-                <path
-                  d="M12.205-.004l-.214.002a12.225 12.225 0 0 0-8.517 3.659C1.179 5.977-.053 9.013.002 12.208c.115 6.613 5.296 11.793 11.795 11.793l.212-.002c6.726-.116 12.105-5.595 11.99-12.21C23.883 5.178 18.702-.003 12.204-.003z"
-                  fill="#FFA733"
-                  fill-rule="nonzero"
-                />
-                <path
-                  d="M12.027 19H12A1.499 1.499 0 0 1 11.973 16L12 16a1.501 1.501 0 0 1 .027 3z"
-                  fill="#3E3832"
-                />
-                <path
-                  d="M12 5a1 1 0 0 1 1 1v7a1 1 0 0 1-2 0V6a1 1 0 0 1 1-1z"
-                  fill="#3E3832"
-                  fill-rule="nonzero"
-                />
-              </g>
-            </svg>
-          </span>
-          <div
-            class="typo-normal alertstripe__tekst"
-          >
-            Kunne ikke laste inn informasjon om brukers oppfølging
-          </div>
-        </div>
-        <div
-          class="alertstripe alertstripe--advarsel"
-        >
-          <span
-            class="alertstripe__ikon"
-          >
-            <span
-              class="sr-only"
-            >
-              advarsel
-            </span>
-            <svg
-              aria-label="advarsel-ikon"
-              focusable="false"
-              height="1.5em"
-              kind="advarsel-sirkel-fyll"
-              role="img"
-              viewBox="0 0 24 24"
-              width="1.5em"
-            >
-              <g
-                fill="none"
-                fill-rule="evenodd"
-              >
-                <path
-                  d="M12.205-.004l-.214.002a12.225 12.225 0 0 0-8.517 3.659C1.179 5.977-.053 9.013.002 12.208c.115 6.613 5.296 11.793 11.795 11.793l.212-.002c6.726-.116 12.105-5.595 11.99-12.21C23.883 5.178 18.702-.003 12.204-.003z"
-                  fill="#FFA733"
-                  fill-rule="nonzero"
-                />
-                <path
-                  d="M12.027 19H12A1.499 1.499 0 0 1 11.973 16L12 16a1.501 1.501 0 0 1 .027 3z"
-                  fill="#3E3832"
-                />
-                <path
-                  d="M12 5a1 1 0 0 1 1 1v7a1 1 0 0 1-2 0V6a1 1 0 0 1 1-1z"
-                  fill="#3E3832"
-                  fill-rule="nonzero"
-                />
-              </g>
-            </svg>
-          </span>
-          <div
-            class="typo-normal alertstripe__tekst"
-          >
-            Kunne ikke hente ut all oppfølgings-informasjon
-          </div>
-        </div>
-        <h2
-          class="typo-undertittel"
-          id="Helt tilfeldig ID"
-        >
-          Arbeidsoppfølging
-        </h2>
-        <dl
-          class="c2"
-        >
-          <div>
-            <dt
-              class="typo-normal"
-            >
-              Er under oppfølging
-            </dt>
-            <dd
-              class="typo-element"
-            >
-              —
-            </dd>
-          </div>
-          <div>
-            <dt
-              class="typo-normal"
-            >
-              Oppfølgingsenhet
-            </dt>
-            <dd
-              class="typo-element"
-            >
-              —
-            </dd>
-          </div>
-          <div>
-            <dt
-              class="typo-normal"
-            >
-              Veileder
-            </dt>
-            <dd
-              class="typo-element"
-            >
-              —
-            </dd>
-          </div>
-          <div>
-            <dt
-              class="typo-normal"
-            >
-              Arbeidssøkerstatus
-            </dt>
-            <dd
-              class="typo-element"
-            >
-              Er registrert som arbeidssøker
-              <p
-                class="aksel-detail"
-              >
-                Dato: 03.12.1969
-              </p>
-               
-            </dd>
-          </div>
-        </dl>
-        <br />
+      <div
+        aria-labelledby="Helt tilfeldig ID"
+        class="panel c2"
+      >
         <article>
+          <div
+            class="c3"
+          >
+            <h2
+              class="typo-undertittel"
+              id="Helt tilfeldig ID"
+            >
+              Oppfølging og ytelser vises for perioden:
+            </h2>
+          </div>
+          <form
+            class="c4"
+          >
+            <form
+              class="c5"
+            >
+              <fieldset
+                class="c6"
+              >
+                <legend
+                  class="typo-element"
+                >
+                  Velg periode
+                </legend>
+                <div
+                  class="c7"
+                >
+                  <div
+                    class="skjemaelement"
+                  >
+                    <input
+                      aria-invalid="false"
+                      class="skjemaelement__input radioknapp"
+                      id="Helt tilfeldig ID"
+                      name="FiltreringsvalgGruppe"
+                      type="radio"
+                    />
+                    <label
+                      class="skjemaelement__label"
+                      for="Helt tilfeldig ID"
+                    >
+                      Siste 30 dager
+                    </label>
+                  </div>
+                </div>
+                <div
+                  class="c7"
+                >
+                  <div
+                    class="skjemaelement"
+                  >
+                    <input
+                      aria-invalid="false"
+                      class="skjemaelement__input radioknapp"
+                      id="Helt tilfeldig ID"
+                      name="FiltreringsvalgGruppe"
+                      type="radio"
+                    />
+                    <label
+                      class="skjemaelement__label"
+                      for="Helt tilfeldig ID"
+                    >
+                      Inneværende år
+                    </label>
+                  </div>
+                </div>
+                <div
+                  class="c7"
+                >
+                  <div
+                    class="skjemaelement"
+                  >
+                    <input
+                      aria-invalid="false"
+                      class="skjemaelement__input radioknapp"
+                      id="Helt tilfeldig ID"
+                      name="FiltreringsvalgGruppe"
+                      type="radio"
+                    />
+                    <label
+                      class="skjemaelement__label"
+                      for="Helt tilfeldig ID"
+                    >
+                      I fjor
+                    </label>
+                  </div>
+                </div>
+                <div
+                  class="c7"
+                >
+                  <div
+                    class="skjemaelement"
+                  >
+                    <input
+                      aria-invalid="false"
+                      checked=""
+                      class="skjemaelement__input radioknapp"
+                      id="Helt tilfeldig ID"
+                      name="FiltreringsvalgGruppe"
+                      type="radio"
+                    />
+                    <label
+                      class="skjemaelement__label"
+                      for="Helt tilfeldig ID"
+                    >
+                      Egendefinert
+                    </label>
+                  </div>
+                </div>
+              </fieldset>
+              <div
+                class="c8"
+              >
+                <div
+                  class="aksel-date__wrapper"
+                >
+                  <div
+                    class="aksel-form-field aksel-form-field--small aksel-date__field"
+                  >
+                    <label
+                      class="aksel-form-field__label aksel-label aksel-label--small"
+                      for="datepicker-input-_r_2_"
+                    >
+                      Fra
+                    </label>
+                    <div
+                      class="aksel-date__field-wrapper"
+                    >
+                      <input
+                        autocomplete="off"
+                        class="aksel-date__field-input aksel-text-field__input aksel-body-short aksel-body-short--small"
+                        id="datepicker-input-_r_2_"
+                        size="11"
+                        value="01.01.1968"
+                      />
+                      <button
+                        class="aksel-date__field-button"
+                        tabindex="0"
+                        type="button"
+                      >
+                        <svg
+                          aria-labelledby="title-_r_3_"
+                          fill="none"
+                          focusable="false"
+                          height="1em"
+                          role="img"
+                          viewBox="0 0 24 24"
+                          width="1em"
+                          xmlns="http://www.w3.org/2000/svg"
+                        >
+                          <title
+                            id="title-_r_3_"
+                          >
+                            Åpne datovelger
+                          </title>
+                          <path
+                            clip-rule="evenodd"
+                            d="M9 2.25a.75.75 0 0 1 .75.75v1.25h4.5V3a.75.75 0 0 1 1.5 0v1.25h3.75c.69 0 1.25.56 1.25 1.25v13c0 .69-.56 1.25-1.25 1.25h-15c-.69 0-1.25-.56-1.25-1.25v-13c0-.69.56-1.25 1.25-1.25h3.75V3A.75.75 0 0 1 9 2.25M15.75 7a.75.75 0 0 1-1.5 0V5.75h-4.5V7a.75.75 0 0 1-1.5 0V5.75h-3.5v3.5h14.5v-3.5h-3.5zm-11 11.25v-7.5h14.5v7.5zm2-5.25a.75.75 0 0 1 .75-.75h1a.75.75 0 0 1 0 1.5h-1a.75.75 0 0 1-.75-.75m4 0a.75.75 0 0 1 .75-.75h1a.75.75 0 0 1 0 1.5h-1a.75.75 0 0 1-.75-.75m4.75-.75a.75.75 0 0 0 0 1.5h1a.75.75 0 0 0 0-1.5zM10.75 16a.75.75 0 0 1 .75-.75h1a.75.75 0 0 1 0 1.5h-1a.75.75 0 0 1-.75-.75m4.75-.75a.75.75 0 0 0 0 1.5h1a.75.75 0 0 0 0-1.5zM6.75 16a.75.75 0 0 1 .75-.75h1a.75.75 0 0 1 0 1.5h-1a.75.75 0 0 1-.75-.75"
+                            fill="currentColor"
+                            fill-rule="evenodd"
+                          />
+                        </svg>
+                      </button>
+                    </div>
+                    <div
+                      aria-live="polite"
+                      aria-relevant="additions removals"
+                      class="aksel-form-field__error"
+                      id="datepicker-input-error-_r_2_"
+                    />
+                  </div>
+                </div>
+                <div
+                  class="aksel-date__wrapper"
+                >
+                  <div
+                    class="aksel-form-field aksel-form-field--small aksel-date__field"
+                  >
+                    <label
+                      class="aksel-form-field__label aksel-label aksel-label--small"
+                      for="datepicker-input-_r_6_"
+                    >
+                      Til
+                    </label>
+                    <div
+                      class="aksel-date__field-wrapper"
+                    >
+                      <input
+                        autocomplete="off"
+                        class="aksel-date__field-input aksel-text-field__input aksel-body-short aksel-body-short--small"
+                        id="datepicker-input-_r_6_"
+                        size="11"
+                        value="01.01.1970"
+                      />
+                      <button
+                        class="aksel-date__field-button"
+                        tabindex="0"
+                        type="button"
+                      >
+                        <svg
+                          aria-labelledby="title-_r_7_"
+                          fill="none"
+                          focusable="false"
+                          height="1em"
+                          role="img"
+                          viewBox="0 0 24 24"
+                          width="1em"
+                          xmlns="http://www.w3.org/2000/svg"
+                        >
+                          <title
+                            id="title-_r_7_"
+                          >
+                            Åpne datovelger
+                          </title>
+                          <path
+                            clip-rule="evenodd"
+                            d="M9 2.25a.75.75 0 0 1 .75.75v1.25h4.5V3a.75.75 0 0 1 1.5 0v1.25h3.75c.69 0 1.25.56 1.25 1.25v13c0 .69-.56 1.25-1.25 1.25h-15c-.69 0-1.25-.56-1.25-1.25v-13c0-.69.56-1.25 1.25-1.25h3.75V3A.75.75 0 0 1 9 2.25M15.75 7a.75.75 0 0 1-1.5 0V5.75h-4.5V7a.75.75 0 0 1-1.5 0V5.75h-3.5v3.5h14.5v-3.5h-3.5zm-11 11.25v-7.5h14.5v7.5zm2-5.25a.75.75 0 0 1 .75-.75h1a.75.75 0 0 1 0 1.5h-1a.75.75 0 0 1-.75-.75m4 0a.75.75 0 0 1 .75-.75h1a.75.75 0 0 1 0 1.5h-1a.75.75 0 0 1-.75-.75m4.75-.75a.75.75 0 0 0 0 1.5h1a.75.75 0 0 0 0-1.5zM10.75 16a.75.75 0 0 1 .75-.75h1a.75.75 0 0 1 0 1.5h-1a.75.75 0 0 1-.75-.75m4.75-.75a.75.75 0 0 0 0 1.5h1a.75.75 0 0 0 0-1.5zM6.75 16a.75.75 0 0 1 .75-.75h1a.75.75 0 0 1 0 1.5h-1a.75.75 0 0 1-.75-.75"
+                            fill="currentColor"
+                            fill-rule="evenodd"
+                          />
+                        </svg>
+                      </button>
+                    </div>
+                    <div
+                      aria-live="polite"
+                      aria-relevant="additions removals"
+                      class="aksel-form-field__error"
+                      id="datepicker-input-error-_r_6_"
+                    />
+                  </div>
+                </div>
+              </div>
+            </form>
+          </form>
+        </article>
+      </div>
+      <div
+        aria-labelledby="Helt tilfeldig ID"
+        class="panel c9"
+      >
+        <article>
+          <div
+            class="alertstripe alertstripe--advarsel"
+          >
+            <span
+              class="alertstripe__ikon"
+            >
+              <span
+                class="sr-only"
+              >
+                advarsel
+              </span>
+              <svg
+                aria-label="advarsel-ikon"
+                focusable="false"
+                height="1.5em"
+                kind="advarsel-sirkel-fyll"
+                role="img"
+                viewBox="0 0 24 24"
+                width="1.5em"
+              >
+                <g
+                  fill="none"
+                  fill-rule="evenodd"
+                >
+                  <path
+                    d="M12.205-.004l-.214.002a12.225 12.225 0 0 0-8.517 3.659C1.179 5.977-.053 9.013.002 12.208c.115 6.613 5.296 11.793 11.795 11.793l.212-.002c6.726-.116 12.105-5.595 11.99-12.21C23.883 5.178 18.702-.003 12.204-.003z"
+                    fill="#FFA733"
+                    fill-rule="nonzero"
+                  />
+                  <path
+                    d="M12.027 19H12A1.499 1.499 0 0 1 11.973 16L12 16a1.501 1.501 0 0 1 .027 3z"
+                    fill="#3E3832"
+                  />
+                  <path
+                    d="M12 5a1 1 0 0 1 1 1v7a1 1 0 0 1-2 0V6a1 1 0 0 1 1-1z"
+                    fill="#3E3832"
+                    fill-rule="nonzero"
+                  />
+                </g>
+              </svg>
+            </span>
+            <div
+              class="typo-normal alertstripe__tekst"
+            >
+              Kunne ikke laste inn informasjon om brukers oppfølging
+            </div>
+          </div>
+          <div
+            class="alertstripe alertstripe--advarsel"
+          >
+            <span
+              class="alertstripe__ikon"
+            >
+              <span
+                class="sr-only"
+              >
+                advarsel
+              </span>
+              <svg
+                aria-label="advarsel-ikon"
+                focusable="false"
+                height="1.5em"
+                kind="advarsel-sirkel-fyll"
+                role="img"
+                viewBox="0 0 24 24"
+                width="1.5em"
+              >
+                <g
+                  fill="none"
+                  fill-rule="evenodd"
+                >
+                  <path
+                    d="M12.205-.004l-.214.002a12.225 12.225 0 0 0-8.517 3.659C1.179 5.977-.053 9.013.002 12.208c.115 6.613 5.296 11.793 11.795 11.793l.212-.002c6.726-.116 12.105-5.595 11.99-12.21C23.883 5.178 18.702-.003 12.204-.003z"
+                    fill="#FFA733"
+                    fill-rule="nonzero"
+                  />
+                  <path
+                    d="M12.027 19H12A1.499 1.499 0 0 1 11.973 16L12 16a1.501 1.501 0 0 1 .027 3z"
+                    fill="#3E3832"
+                  />
+                  <path
+                    d="M12 5a1 1 0 0 1 1 1v7a1 1 0 0 1-2 0V6a1 1 0 0 1 1-1z"
+                    fill="#3E3832"
+                    fill-rule="nonzero"
+                  />
+                </g>
+              </svg>
+            </span>
+            <div
+              class="typo-normal alertstripe__tekst"
+            >
+              Kunne ikke hente ut all oppfølgings-informasjon
+            </div>
+          </div>
           <h2
             class="typo-undertittel"
             id="Helt tilfeldig ID"
           >
-            14a vedtak
+            Arbeidsoppfølging
           </h2>
           <dl
-            class="c2"
+            class="c10"
           >
             <div>
               <dt
                 class="typo-normal"
               >
-                Har 14a vedtak
-              </dt>
-              <dd
-                class="typo-element"
-              >
-                Ja
-              </dd>
-            </div>
-            <div>
-              <dt
-                class="typo-normal"
-              >
-                Innsatsgruppe
-              </dt>
-              <dd
-                class="typo-element"
-              >
-                Innsatsgruppe 3
-              </dd>
-            </div>
-            <div>
-              <dt
-                class="typo-normal"
-              >
-                Hovedmål
+                Er under arbeidsrettet oppfølging
               </dt>
               <dd
                 class="typo-element"
@@ -251,17 +517,108 @@ exports[`Viser oppfølgingcontainer med alt innhold 1`] = `
               <dt
                 class="typo-normal"
               >
-                Vedtaksdato
+                Oppfølgingsenhet
               </dt>
               <dd
                 class="typo-element"
               >
-                15.01.2023
+                —
+              </dd>
+            </div>
+            <div>
+              <dt
+                class="typo-normal"
+              >
+                Veileder
+              </dt>
+              <dd
+                class="typo-element"
+              >
+                —
+              </dd>
+            </div>
+            <div>
+              <dt
+                class="typo-normal"
+              >
+                Arbeidssøkerstatus
+              </dt>
+              <dd
+                class="typo-element"
+              >
+                Er registrert som arbeidssøker
+                <p
+                  class="aksel-detail"
+                >
+                  Dato: 03.12.1969
+                </p>
+                 
               </dd>
             </div>
           </dl>
+          <br />
+          <article>
+            <h2
+              class="typo-undertittel"
+              id="Helt tilfeldig ID"
+            >
+              14a vedtak
+            </h2>
+            <dl
+              class="c10"
+            >
+              <div>
+                <dt
+                  class="typo-normal"
+                >
+                  Har 14a vedtak
+                </dt>
+                <dd
+                  class="typo-element"
+                >
+                  Ja
+                </dd>
+              </div>
+              <div>
+                <dt
+                  class="typo-normal"
+                >
+                  Innsatsgruppe
+                </dt>
+                <dd
+                  class="typo-element"
+                >
+                  Innsatsgruppe 3
+                </dd>
+              </div>
+              <div>
+                <dt
+                  class="typo-normal"
+                >
+                  Hovedmål
+                </dt>
+                <dd
+                  class="typo-element"
+                >
+                  —
+                </dd>
+              </div>
+              <div>
+                <dt
+                  class="typo-normal"
+                >
+                  Vedtaksdato
+                </dt>
+                <dd
+                  class="typo-element"
+                >
+                  15.01.2023
+                </dd>
+              </div>
+            </dl>
+          </article>
         </article>
-      </article>
+      </div>
     </div>
     <div
       class="alertstripe alertstripe--info"
@@ -301,6 +658,48 @@ exports[`Viser oppfølgingcontainer med alt innhold 1`] = `
         class="typo-normal alertstripe__tekst"
       >
         Det finnes ikke informasjon om sykefraværsoppfølging for valgt periode i Arena
+      </div>
+    </div>
+    <div
+      class="panel c11"
+    >
+      <div
+        class="ekspanderbartPanel test-ytelse-ytelselamell ekspanderbartPanel--lukket ekspanderbartPanel--border"
+      >
+        <button
+          aria-controls="Helt tilfeldig ID"
+          aria-expanded="false"
+          aria-label="Ytelser"
+          class="ekspanderbartPanel__hode"
+          id="Helt tilfeldig ID"
+          type="button"
+        >
+          <div
+            class="ekspanderbartPanel__flex-wrapper"
+          >
+            <span
+              class="ekspanderbartPanel__tittel"
+            >
+              <div
+                class="c12"
+              >
+                <h2
+                  class="typo-undertittel"
+                >
+                  Ytelser
+                </h2>
+              </div>
+            </span>
+            <span
+              class="ekspanderbartPanel__indikator"
+            />
+          </div>
+        </button>
+        <div
+          aria-labelledby="Helt tilfeldig ID"
+          id="Helt tilfeldig ID"
+          role="region"
+        />
       </div>
     </div>
   </div>

--- a/src/app/personside/infotabs/oppfolging/oppfolging-utils.ts
+++ b/src/app/personside/infotabs/oppfolging/oppfolging-utils.ts
@@ -1,20 +1,20 @@
-import type { Oppfolging, Saksbehandler } from '../../../../models/oppfolging';
+import type { OppfolgingDto, Veileder } from 'src/generated/modiapersonoversikt-api';
 
-export function getErUnderOppfolging(oppfolging: Oppfolging | null): string {
+export function getErUnderOppfolging(oppfolging: OppfolgingDto | null | undefined): string {
     if (oppfolging == null) {
         return '\u2014';
     }
     return oppfolging.erUnderOppfolging ? 'Ja' : 'Nei';
 }
 
-export function getOppfolgingEnhet(oppfolging: Oppfolging | null): string {
+export function getOppfolgingEnhet(oppfolging?: OppfolgingDto | null | undefined): string {
     if (oppfolging == null) {
         return '\u2014';
     }
     return oppfolging.enhet ? `${oppfolging.enhet.enhetId} ${oppfolging.enhet.navn}` : 'Ikke angitt';
 }
 
-export function getVeileder(veileder: Saksbehandler | null | undefined): string {
+export function getVeileder(veileder: Veileder | null | undefined): string {
     if (veileder === null || veileder === undefined || veileder.ident === '') {
         return '\u2014';
     }

--- a/src/app/personside/infotabs/oversikt/OppfolgingOversikt.tsx
+++ b/src/app/personside/infotabs/oversikt/OppfolgingOversikt.tsx
@@ -67,7 +67,9 @@ function YtelserForBruker({ ytelser }: { ytelser: OppfolgingsYtelse[] }) {
         .filter((ytelse) => ytelse.status !== 'Avsluttet')
         .filter((ytelse) => ytelse.status !== 'Lukket')
         .map((ytelse) => `${ytelse.type} : ${ytelse.status}`);
-    const filtrerteYtelser = ytelserStrenger.filter((item, index) => ytelserStrenger.indexOf(item) === index).join(', ');
+    const filtrerteYtelser = ytelserStrenger
+        .filter((item, index) => ytelserStrenger.indexOf(item) === index)
+        .join(', ');
     return (
         <>
             <Element>Ytelser:</Element>

--- a/src/app/personside/infotabs/oversikt/OppfolgingOversikt.tsx
+++ b/src/app/personside/infotabs/oversikt/OppfolgingOversikt.tsx
@@ -1,31 +1,34 @@
-import { AlertStripeInfo } from 'nav-frontend-alertstriper';
+import { AlertStripeAdvarsel, AlertStripeInfo } from 'nav-frontend-alertstriper';
 import { Element, Normaltekst } from 'nav-frontend-typografi';
 import { usePaths } from 'src/app/routes/routing';
 import { CenteredLazySpinner } from 'src/components/LazySpinner';
-import type { DetaljertOppfolging } from 'src/models/oppfolging';
+import type { ArbeidsOppfolgingDto } from 'src/generated/modiapersonoversikt-api';
+import { useArbeidsoppfolging } from 'src/lib/clients/modiapersonoversikt-api';
 import { trackingEvents } from 'src/utils/analytics';
 import VisMerKnapp from '../../../../components/VisMerKnapp';
-import oppfolgingResource from '../../../../rest/resources/oppfolgingResource';
 import theme from '../../../../styles/personOversiktTheme';
 import CopyToClipboard from '../../visittkort-v2/header/status/CopyToClipboard';
 import { getOppfolgingEnhet, getVeileder } from '../oppfolging/oppfolging-utils';
 
 interface Props {
-    detaljertOppfolging: DetaljertOppfolging;
+    data: ArbeidsOppfolgingDto | undefined;
 }
 
 function OppfolgingOversikt() {
-    return oppfolgingResource.useOversiktRenderer({
-        ifPending: <CenteredLazySpinner padding={theme.margin.layout} />,
-        ifData: (data: DetaljertOppfolging) => <OppfolgingPanel detaljertOppfolging={data} />
-    });
+    const { data, isLoading, isError } = useArbeidsoppfolging();
+
+    if (isLoading) return <CenteredLazySpinner padding={theme.margin.layout} />;
+    if (isError)
+        return <AlertStripeAdvarsel>Kunne ikke laste inn informasjon om brukers oppfølging</AlertStripeAdvarsel>;
+
+    return <OppfolgingPanel data={data} />;
 }
 
 function OppfolgingPanel(props: Props) {
     const paths = usePaths();
 
-    if (props.detaljertOppfolging.oppfolging !== null && !props.detaljertOppfolging.oppfolging.erUnderOppfolging) {
-        return <AlertStripeInfo>Er ikke i arbeidsrettet oppfølging</AlertStripeInfo>;
+    if (props.data?.oppfolging != null && !props.data.oppfolging.erUnderOppfolging) {
+        return <AlertStripeInfo>Er ikke under arbeidsrettet oppfølging</AlertStripeInfo>;
     }
 
     return (
@@ -41,52 +44,34 @@ function OppfolgingPanel(props: Props) {
             ariaDescription="Gå til oppfølging"
             valgt={false}
         >
-            <OppfolgingVisning detaljertOppfolging={props.detaljertOppfolging} />
+            <OppfolgingVisning data={props.data} />
         </VisMerKnapp>
     );
 }
 
-function YtelserForBruker({ detaljertOppfolging }: { detaljertOppfolging: DetaljertOppfolging }) {
-    if (detaljertOppfolging.ytelser.length === 0) {
-        return null;
-    }
-    const ytelser = detaljertOppfolging.ytelser
-        .filter((ytelse) => ytelse.status !== 'Avsluttet')
-        .filter((ytelse) => ytelse.status !== 'Lukket')
-        .map((ytelse) => `${ytelse.type} : ${ytelse.status}`);
-    const filtrerteYtelser = ytelser.filter((item, index) => ytelser.indexOf(item) === index).join(', ');
-    return (
-        <>
-            <Element>Ytelser:</Element>
-            <Normaltekst>{filtrerteYtelser}</Normaltekst>
-        </>
-    );
-}
-
-function Veileder({ detaljertOppfolging }: { detaljertOppfolging: DetaljertOppfolging }) {
-    const clipboard = detaljertOppfolging.oppfolging?.veileder?.ident ? (
+function Veileder({ data }: { data: ArbeidsOppfolgingDto | undefined }) {
+    const clipboard = data?.oppfolging?.veileder?.ident ? (
         <CopyToClipboard
             ariaLabel="Kopier veileder"
-            stringToCopy={`${detaljertOppfolging.oppfolging.veileder.navn} (${detaljertOppfolging.oppfolging.veileder.ident})`}
+            stringToCopy={`${data.oppfolging.veileder.navn} (${data.oppfolging.veileder.ident})`}
         />
     ) : null;
 
     return (
         <>
             <Element>Veileder:</Element>
-            <Normaltekst>{getVeileder(detaljertOppfolging.oppfolging?.veileder)}</Normaltekst>
+            <Normaltekst>{getVeileder(data?.oppfolging?.veileder)}</Normaltekst>
             {clipboard}
         </>
     );
 }
 
-function OppfolgingVisning({ detaljertOppfolging }: { detaljertOppfolging: DetaljertOppfolging }) {
+function OppfolgingVisning({ data }: { data: ArbeidsOppfolgingDto | undefined }) {
     return (
         <>
             <Element>Oppfølgende enhet:</Element>
-            <Normaltekst>{getOppfolgingEnhet(detaljertOppfolging.oppfolging)}</Normaltekst>
-            <Veileder detaljertOppfolging={detaljertOppfolging} />
-            <YtelserForBruker detaljertOppfolging={detaljertOppfolging} />
+            <Normaltekst>{getOppfolgingEnhet(data?.oppfolging)}</Normaltekst>
+            <Veileder data={data} />
         </>
     );
 }

--- a/src/app/personside/infotabs/oversikt/OppfolgingOversikt.tsx
+++ b/src/app/personside/infotabs/oversikt/OppfolgingOversikt.tsx
@@ -1,27 +1,37 @@
+import dayjs from 'dayjs';
 import { AlertStripeAdvarsel, AlertStripeInfo } from 'nav-frontend-alertstriper';
 import { Element, Normaltekst } from 'nav-frontend-typografi';
+import { getUtbetalingerForSiste30DagerDatoer } from 'src/app/personside/infotabs/utbetalinger/utils/utbetalinger-utils';
 import { usePaths } from 'src/app/routes/routing';
 import { CenteredLazySpinner } from 'src/components/LazySpinner';
 import type { ArbeidsOppfolgingDto } from 'src/generated/modiapersonoversikt-api';
 import { useArbeidsoppfolging } from 'src/lib/clients/modiapersonoversikt-api';
+import type { OppfolgingsYtelse } from 'src/models/oppfolging';
 import { trackingEvents } from 'src/utils/analytics';
 import VisMerKnapp from '../../../../components/VisMerKnapp';
+import oppfolgingResource from '../../../../rest/resources/oppfolgingResource';
 import theme from '../../../../styles/personOversiktTheme';
 import CopyToClipboard from '../../visittkort-v2/header/status/CopyToClipboard';
 import { getOppfolgingEnhet, getVeileder } from '../oppfolging/oppfolging-utils';
 
 interface Props {
     data: ArbeidsOppfolgingDto | undefined;
+    ytelser: OppfolgingsYtelse[];
 }
 
 function OppfolgingOversikt() {
     const { data, isLoading, isError } = useArbeidsoppfolging();
 
+    const periode = getUtbetalingerForSiste30DagerDatoer();
+    const fom = dayjs(periode.fra).format('YYYY-MM-DD');
+    const tom = dayjs(periode.til).format('YYYY-MM-DD');
+    const { data: ytelsesData } = oppfolgingResource.useFetch(fom, tom);
+
     if (isLoading) return <CenteredLazySpinner padding={theme.margin.layout} />;
     if (isError)
         return <AlertStripeAdvarsel>Kunne ikke laste inn informasjon om brukers oppfølging</AlertStripeAdvarsel>;
 
-    return <OppfolgingPanel data={data} />;
+    return <OppfolgingPanel data={data} ytelser={ytelsesData?.ytelser ?? []} />;
 }
 
 function OppfolgingPanel(props: Props) {
@@ -44,8 +54,25 @@ function OppfolgingPanel(props: Props) {
             ariaDescription="Gå til oppfølging"
             valgt={false}
         >
-            <OppfolgingVisning data={props.data} />
+            <OppfolgingVisning data={props.data} ytelser={props.ytelser} />
         </VisMerKnapp>
+    );
+}
+
+function YtelserForBruker({ ytelser }: { ytelser: OppfolgingsYtelse[] }) {
+    if (ytelser.length === 0) {
+        return null;
+    }
+    const ytelserStrenger = ytelser
+        .filter((ytelse) => ytelse.status !== 'Avsluttet')
+        .filter((ytelse) => ytelse.status !== 'Lukket')
+        .map((ytelse) => `${ytelse.type} : ${ytelse.status}`);
+    const filtrerteYtelser = ytelserStrenger.filter((item, index) => ytelserStrenger.indexOf(item) === index).join(', ');
+    return (
+        <>
+            <Element>Ytelser:</Element>
+            <Normaltekst>{filtrerteYtelser}</Normaltekst>
+        </>
     );
 }
 
@@ -66,12 +93,19 @@ function Veileder({ data }: { data: ArbeidsOppfolgingDto | undefined }) {
     );
 }
 
-function OppfolgingVisning({ data }: { data: ArbeidsOppfolgingDto | undefined }) {
+function OppfolgingVisning({
+    data,
+    ytelser
+}: {
+    data: ArbeidsOppfolgingDto | undefined;
+    ytelser: OppfolgingsYtelse[];
+}) {
     return (
         <>
             <Element>Oppfølgende enhet:</Element>
             <Normaltekst>{getOppfolgingEnhet(data?.oppfolging)}</Normaltekst>
             <Veileder data={data} />
+            <YtelserForBruker ytelser={ytelser} />
         </>
     );
 }

--- a/src/app/personside/infotabs/oversikt/__snapshots__/Oversikt.test.tsx.snap
+++ b/src/app/personside/infotabs/oversikt/__snapshots__/Oversikt.test.tsx.snap
@@ -392,7 +392,7 @@ exports[`Viser oversikt med alt innhold 1`] = `
             class="c6"
           >
             <div
-              class="alertstripe alertstripe--info"
+              class="alertstripe alertstripe--advarsel"
             >
               <span
                 class="alertstripe__ikon"
@@ -400,27 +400,34 @@ exports[`Viser oversikt med alt innhold 1`] = `
                 <span
                   class="sr-only"
                 >
-                  info
+                  advarsel
                 </span>
                 <svg
-                  aria-label="info-ikon"
+                  aria-label="advarsel-ikon"
                   focusable="false"
                   height="1.5em"
-                  kind="info-sirkel-fyll"
+                  kind="advarsel-sirkel-fyll"
                   role="img"
                   viewBox="0 0 24 24"
                   width="1.5em"
                 >
                   <g
                     fill="none"
+                    fill-rule="evenodd"
                   >
                     <path
-                      d="M12 0C5.382 0 0 5.382 0 12s5.382 12 12 12c6.617 0 12-5.382 12-12S18.617 0 12 0z"
-                      fill="#337C9B"
+                      d="M12.205-.004l-.214.002a12.225 12.225 0 0 0-8.517 3.659C1.179 5.977-.053 9.013.002 12.208c.115 6.613 5.296 11.793 11.795 11.793l.212-.002c6.726-.116 12.105-5.595 11.99-12.21C23.883 5.178 18.702-.003 12.204-.003z"
+                      fill="#FFA733"
+                      fill-rule="nonzero"
                     />
                     <path
-                      d="M12 5a1.566 1.566 0 1 1 .11 3.13A1.566 1.566 0 0 1 12 5zm2.976 12.01c.563 0 1.043.431 1.043.991s-.48.992-1.043.992H9.39c-.564 0-1.043-.431-1.043-.992 0-.56.479-.99 1.043-.99h1.6v-5.016h-.986c-.565 0-1.044-.43-1.044-.991 0-.56.48-.991 1.044-.991h2.03c.563 0 1.043.43 1.043.99v6.007h1.899z"
-                      fill="#FFF"
+                      d="M12.027 19H12A1.499 1.499 0 0 1 11.973 16L12 16a1.501 1.501 0 0 1 .027 3z"
+                      fill="#3E3832"
+                    />
+                    <path
+                      d="M12 5a1 1 0 0 1 1 1v7a1 1 0 0 1-2 0V6a1 1 0 0 1 1-1z"
+                      fill="#3E3832"
+                      fill-rule="nonzero"
                     />
                   </g>
                 </svg>
@@ -428,7 +435,7 @@ exports[`Viser oversikt med alt innhold 1`] = `
               <div
                 class="typo-normal alertstripe__tekst"
               >
-                Er ikke i arbeidsrettet oppfølging
+                Kunne ikke laste inn informasjon om brukers oppfølging
               </div>
             </div>
           </div>

--- a/src/app/personside/infotabs/oversikt/__snapshots__/Oversikt.test.tsx.snap
+++ b/src/app/personside/infotabs/oversikt/__snapshots__/Oversikt.test.tsx.snap
@@ -2,7 +2,29 @@
 
 exports[`Viser oversikt med alt innhold 1`] = `
 <DocumentFragment>
-  .c8 {
+  .c7 {
+  flex-grow: 1;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  animation: edHiKw 0.3s ease-out;
+}
+
+.c7 >* {
+  flex: 0 1 25rem;
+  display: flex;
+  justify-content: center;
+}
+
+.c8 {
+  overflow: hidden;
+  display: flex;
+  justify-content: center;
+  animation: edHiKw 0.3s ease-out;
+  padding: .5rem;
+}
+
+.c10 {
   position: relative;
   padding: .5rem;
   display: flex;
@@ -10,19 +32,19 @@ exports[`Viser oversikt med alt innhold 1`] = `
   cursor: pointer;
 }
 
-.c8:hover {
+.c10:hover {
   box-shadow: inset 0 0 0 0.1rem #0067c5,0 0.1rem 0.1rem rgba(0, 0, 0, 0.2);
 }
 
-.c8:hover >button:last-child {
+.c10:hover >button:last-child {
   padding-left: 0.5rem;
 }
 
-.c8 >*:first-child {
+.c10 >*:first-child {
   flex-grow: 1;
 }
 
-.c10 {
+.c12 {
   border: none;
   padding: 0;
   height: 2rem;
@@ -33,16 +55,16 @@ exports[`Viser oversikt med alt innhold 1`] = `
   transition: padding-left 0.3s;
 }
 
-.c10 .nav-frontend-chevron {
+.c12 .nav-frontend-chevron {
   width: 1.5625rem;
 }
 
-.c10:focus {
+.c12:focus {
   outline: none;
   box-shadow: none;
 }
 
-.c10:focus::after {
+.c12:focus::after {
   position: absolute;
   top: 0;
   left: 0;
@@ -53,17 +75,17 @@ exports[`Viser oversikt med alt innhold 1`] = `
   pointer-events: none;
 }
 
-.c14 {
+.c16 {
   position: relative;
 }
 
-.c14 svg {
+.c16 svg {
   height: 1.5625rem;
   width: 1.5625rem;
   opacity: 0.4;
 }
 
-.c15 {
+.c17 {
   position: absolute;
   top: -0.1875rem;
   right: -0.5rem;
@@ -77,7 +99,7 @@ exports[`Viser oversikt med alt innhold 1`] = `
   border-radius: 50%;
 }
 
-.c16 {
+.c18 {
   display: flex;
   flex-direction: column;
   flex-grow: 1;
@@ -86,58 +108,58 @@ exports[`Viser oversikt med alt innhold 1`] = `
   overflow-wrap: break-word;
 }
 
-.c16 .order-first {
+.c18 .order-first {
   order: 0;
 }
 
-.c16 .order-second {
+.c18 .order-second {
   order: 1;
 }
 
-.c16 .order-third {
+.c18 .order-third {
   order: 3;
 }
 
-.c18 {
+.c20 {
   display: flex;
   flex-wrap: wrap;
   align-items: flex-start;
   margin-top: 0.2rem;
 }
 
-.c18 >*:not(:last-child) {
+.c20 >*:not(:last-child) {
   margin-bottom: 0.2rem;
   margin-right: 0.2rem;
 }
 
-.c17 {
+.c19 {
   display: flex;
   flex-direction: column;
 }
 
-.c17 .order-first {
+.c19 .order-first {
   order: 0;
 }
 
-.c17 .order-second {
+.c19 .order-second {
   order: 1;
 }
 
-.c13 {
+.c15 {
   display: flex;
 }
 
-.c13 >*:last-child {
+.c15 >*:last-child {
   flex-grow: 1;
 }
 
-.c19 {
+.c21 {
   text-overflow: ellipsis;
   overflow: hidden;
   white-space: nowrap;
 }
 
-.c12 >*:not(:first-child) {
+.c14 >*:not(:first-child) {
   border-top: solid 0.0625rem #78706a;
 }
 
@@ -175,19 +197,19 @@ exports[`Viser oversikt med alt innhold 1`] = `
   padding: 0 1rem;
 }
 
-.c11 >*:not(:first-child) {
+.c13 >*:not(:first-child) {
   border-top: solid 0.0625rem #78706a;
 }
 
-.c9 {
+.c11 {
   font-weight: 600;
 }
 
-.c7 >*:not(:first-child) {
+.c9 >*:not(:first-child) {
   border-top: solid 0.0625rem #78706a;
 }
 
-.c28 {
+.c30 {
   border: none;
   cursor: pointer;
   background-color: transparent;
@@ -195,17 +217,17 @@ exports[`Viser oversikt med alt innhold 1`] = `
   border-radius: 0.5em;
 }
 
-.c28:focus {
+.c30:focus {
   outline: none;
   box-shadow: 0 0 0 0.1875rem #254b6d;
 }
 
-.c28:focus {
+.c30:focus {
   outline: none;
   box-shadow: none;
 }
 
-.c28:focus::after {
+.c30:focus::after {
   position: absolute;
   top: 0;
   left: 0;
@@ -216,11 +238,11 @@ exports[`Viser oversikt med alt innhold 1`] = `
   pointer-events: none;
 }
 
-.c22 {
+.c24 {
   padding: 0rem;
 }
 
-.c23 {
+.c25 {
   position: relative;
   display: -ms-grid;
   display: grid;
@@ -231,64 +253,64 @@ exports[`Viser oversikt med alt innhold 1`] = `
   cursor: pointer;
 }
 
-.c23 >*:nth-child(1) {
+.c25 >*:nth-child(1) {
   -ms-grid-column: 1;
 }
 
-.c23 >*:nth-child(2) {
+.c25 >*:nth-child(2) {
   -ms-grid-column: 2;
 }
 
-.c23 >*:nth-child(3) {
+.c25 >*:nth-child(3) {
   -ms-grid-column: 3;
 }
 
-.c23 >*:nth-child(4) {
+.c25 >*:nth-child(4) {
   -ms-grid-column: 4;
 }
 
-.c23:hover {
+.c25:hover {
   box-shadow: inset 0 0 0 0.1rem #0067c5,0 0.1rem 0.1rem rgba(0, 0, 0, 0.2);
 }
 
-.c23 >* {
+.c25 >* {
   padding: 0.7rem;
 }
 
-.c27 li {
+.c29 li {
   display: inline-block;
 }
 
-.c27 li:not(:last-child):after {
+.c29 li:not(:last-child):after {
   content: ',';
   margin-right: 0.5em;
 }
 
-.c24 {
+.c26 {
   display: flex;
 }
 
-.c26 {
+.c28 {
   text-overflow: ellipsis;
   overflow: hidden;
   white-space: nowrap;
 }
 
-.c25 {
+.c27 {
   width: 100%;
   display: flex;
   align-items: center;
   justify-content: center;
 }
 
-.c29 {
+.c31 {
   border-radius: 0.5rem;
   background-color: #f1f0f0;
   box-shadow: inset 0 0 0 0.3rem white,inset 0 0 0 0.37rem rgba(0, 0, 0, 0.15);
   padding: 1.25rem;
 }
 
-.c29 dt {
+.c31 dt {
   float: left;
   clear: left;
   font-weight: bold;
@@ -296,29 +318,29 @@ exports[`Viser oversikt med alt innhold 1`] = `
   width: 7rem;
 }
 
-.c29 dd {
+.c31 dd {
   margin-bottom: 0.5rem;
   margin-left: 7.125rem;
 }
 
-.c31 {
+.c33 {
   font-weight: bold;
 }
 
-.c32 {
+.c34 {
   margin-top: 0.5rem;
 }
 
-.c30 {
+.c32 {
   margin-top: 1rem;
   margin-bottom: 1rem;
 }
 
-.c21 >*:not(:first-child) {
+.c23 >*:not(:first-child) {
   border-top: solid 0.0625rem #78706a;
 }
 
-.c20 >*:not(:first-child) {
+.c22 >*:not(:first-child) {
   border-top: solid 0.0625rem #78706a;
 }
 
@@ -392,51 +414,46 @@ exports[`Viser oversikt med alt innhold 1`] = `
             class="c6"
           >
             <div
-              class="alertstripe alertstripe--advarsel"
+              class="c7"
             >
               <span
-                class="alertstripe__ikon"
+                class="c8"
+                padding=".5rem"
               >
-                <span
-                  class="sr-only"
-                >
-                  advarsel
-                </span>
                 <svg
-                  aria-label="advarsel-ikon"
+                  aria-label="Laster innhold"
+                  class="spinner spinner--l"
                   focusable="false"
-                  height="1.5em"
-                  kind="advarsel-sirkel-fyll"
-                  role="img"
-                  viewBox="0 0 24 24"
-                  width="1.5em"
+                  height="32"
+                  kind="spinner-negativ"
+                  preserveAspectRatio="xMidYMid"
+                  viewBox="0 0 50 50"
+                  width="32"
                 >
-                  <g
+                  <title>
+                    Venter...
+                  </title>
+                  <circle
+                    cx="25"
+                    cy="25"
                     fill="none"
-                    fill-rule="evenodd"
-                  >
-                    <path
-                      d="M12.205-.004l-.214.002a12.225 12.225 0 0 0-8.517 3.659C1.179 5.977-.053 9.013.002 12.208c.115 6.613 5.296 11.793 11.795 11.793l.212-.002c6.726-.116 12.105-5.595 11.99-12.21C23.883 5.178 18.702-.003 12.204-.003z"
-                      fill="#FFA733"
-                      fill-rule="nonzero"
-                    />
-                    <path
-                      d="M12.027 19H12A1.499 1.499 0 0 1 11.973 16L12 16a1.501 1.501 0 0 1 .027 3z"
-                      fill="#3E3832"
-                    />
-                    <path
-                      d="M12 5a1 1 0 0 1 1 1v7a1 1 0 0 1-2 0V6a1 1 0 0 1 1-1z"
-                      fill="#3E3832"
-                      fill-rule="nonzero"
-                    />
-                  </g>
+                    r="20"
+                    stroke="#eee"
+                    stroke-width="5"
+                    xmlns="http://www.w3.org/2000/svg"
+                  />
+                  <circle
+                    cx="25"
+                    cy="25"
+                    fill="none"
+                    r="20"
+                    stroke="#888"
+                    stroke-dasharray="50 155"
+                    stroke-linecap="round"
+                    stroke-width="5"
+                  />
                 </svg>
               </span>
-              <div
-                class="typo-normal alertstripe__tekst"
-              >
-                Kunne ikke laste inn informasjon om brukers oppfølging
-              </div>
             </div>
           </div>
         </div>
@@ -475,13 +492,13 @@ exports[`Viser oversikt med alt innhold 1`] = `
           >
             <ol
               aria-label="Oversikt brukers utbetalinger"
-              class="c7"
+              class="c9"
             >
               <li
                 class="test-utbetalinger-oversikt"
               >
                 <div
-                  class="c8"
+                  class="c10"
                 >
                   <div>
                     <p
@@ -493,7 +510,7 @@ exports[`Viser oversikt med alt innhold 1`] = `
                       class="typo-normal"
                     >
                       <span
-                        class="c9"
+                        class="c11"
                       >
                         Barnetrygd
                       </span>
@@ -517,7 +534,7 @@ exports[`Viser oversikt med alt innhold 1`] = `
                   <button
                     aria-label="Vis utbetaling"
                     aria-selected="false"
-                    class="c10"
+                    class="c12"
                   >
                     <span
                       class="nav-frontend-chevron chevronboks chevron--hoyre"
@@ -529,7 +546,7 @@ exports[`Viser oversikt med alt innhold 1`] = `
                 class="test-utbetalinger-oversikt"
               >
                 <div
-                  class="c8"
+                  class="c10"
                 >
                   <div>
                     <p
@@ -541,7 +558,7 @@ exports[`Viser oversikt med alt innhold 1`] = `
                       class="typo-normal"
                     >
                       <span
-                        class="c9"
+                        class="c11"
                       >
                         Diverse ytelser
                       </span>
@@ -565,7 +582,7 @@ exports[`Viser oversikt med alt innhold 1`] = `
                   <button
                     aria-label="Vis utbetaling"
                     aria-selected="false"
-                    class="c10"
+                    class="c12"
                   >
                     <span
                       class="nav-frontend-chevron chevronboks chevron--hoyre"
@@ -616,13 +633,13 @@ exports[`Viser oversikt med alt innhold 1`] = `
             class="c6"
           >
             <ol
-              class="c11"
+              class="c13"
             >
               <li
                 class="test-sakstema-list"
               >
                 <div
-                  class="c8"
+                  class="c10"
                 >
                   <div>
                     <p
@@ -634,7 +651,7 @@ exports[`Viser oversikt med alt innhold 1`] = `
                   <button
                     aria-label="Vis Medlemskap"
                     aria-selected="false"
-                    class="c10"
+                    class="c12"
                   >
                     <span
                       class="nav-frontend-chevron chevronboks chevron--hoyre"
@@ -646,7 +663,7 @@ exports[`Viser oversikt med alt innhold 1`] = `
                 class="test-sakstema-list"
               >
                 <div
-                  class="c8"
+                  class="c10"
                 >
                   <div>
                     <p
@@ -658,7 +675,7 @@ exports[`Viser oversikt med alt innhold 1`] = `
                   <button
                     aria-label="Vis Mobilitetsfremmende stønad"
                     aria-selected="false"
-                    class="c10"
+                    class="c12"
                   >
                     <span
                       class="nav-frontend-chevron chevronboks chevron--hoyre"
@@ -714,15 +731,15 @@ exports[`Viser oversikt med alt innhold 1`] = `
           >
             <ol
               aria-label="Oversikt brukers meldinger"
-              class="c12"
+              class="c14"
             >
               <li>
                 <div
-                  class="c8 test-meldinger-oversikt"
+                  class="c10 test-meldinger-oversikt"
                 >
                   <div>
                     <div
-                      class="c13"
+                      class="c15"
                     >
                       <span
                         class="sr-only"
@@ -730,7 +747,7 @@ exports[`Viser oversikt med alt innhold 1`] = `
                         (4)
                       </span>
                       <span
-                        class="c14"
+                        class="c16"
                       >
                         <svg
                           viewBox="0 0 24 24"
@@ -749,16 +766,16 @@ exports[`Viser oversikt med alt innhold 1`] = `
                         </svg>
                         <p
                           aria-hidden="true"
-                          class="typo-undertekst c15"
+                          class="typo-undertekst c17"
                         >
                           4
                         </p>
                       </span>
                       <div
-                        class="c16"
+                        class="c18"
                       >
                         <div
-                          class="c17 order-first"
+                          class="c19 order-first"
                         >
                           <p
                             class="typo-element order-second"
@@ -772,7 +789,7 @@ exports[`Viser oversikt med alt innhold 1`] = `
                           </p>
                         </div>
                         <div
-                          class="c18 order-third"
+                          class="c20 order-third"
                         >
                           <div
                             class="etikett etikett--fokus"
@@ -785,7 +802,7 @@ exports[`Viser oversikt med alt innhold 1`] = `
                           </div>
                         </div>
                         <p
-                          class="typo-normal c19 order-second"
+                          class="typo-normal c21 order-second"
                         >
                           Dolores omnis ea voluptatem corrupti odit incidunt enim. Unde fugiat sed animi explicabo maiores. Nihil cum accusamus omnis officiis deserunt est. Qui quisquam unde aut magni dignissimos.
                         </p>
@@ -795,7 +812,7 @@ exports[`Viser oversikt med alt innhold 1`] = `
                   <button
                     aria-label="Vis meldinger for Spørsmål fra NAV - Arbeid"
                     aria-selected="false"
-                    class="c10"
+                    class="c12"
                   >
                     <span
                       class="nav-frontend-chevron chevronboks chevron--hoyre"
@@ -840,10 +857,10 @@ exports[`Viser oversikt med alt innhold 1`] = `
             class="c6"
           >
             <div
-              class="c20"
+              class="c22"
             >
               <div
-                class="c8 test-ytelse-oversikt"
+                class="c10 test-ytelse-oversikt"
               >
                 <div>
                   <p
@@ -865,7 +882,7 @@ exports[`Viser oversikt med alt innhold 1`] = `
                 <button
                   aria-label="Vis engangsstønad"
                   aria-selected="false"
-                  class="c10"
+                  class="c12"
                 >
                   <span
                     class="nav-frontend-chevron chevronboks chevron--hoyre"
@@ -873,7 +890,7 @@ exports[`Viser oversikt med alt innhold 1`] = `
                 </button>
               </div>
               <div
-                class="c8 test-ytelse-oversikt"
+                class="c10 test-ytelse-oversikt"
               >
                 <div>
                   <p
@@ -895,7 +912,7 @@ exports[`Viser oversikt med alt innhold 1`] = `
                 <button
                   aria-label="Vis engangsstønad"
                   aria-selected="false"
-                  class="c10"
+                  class="c12"
                 >
                   <span
                     class="nav-frontend-chevron chevronboks chevron--hoyre"
@@ -945,34 +962,34 @@ exports[`Viser oversikt med alt innhold 1`] = `
             class="c6"
           >
             <ol
-              class="c21"
+              class="c23"
             >
               <li>
                 <div
-                  class="panel c22"
+                  class="panel c24"
                 >
                   <article
                     aria-labelledby="Helt tilfeldig ID"
                   >
                     <div
-                      class="c23"
+                      class="c25"
                     >
                       <p
                         class="typo-normal"
                       >
                         <span
-                          class="c24"
+                          class="c26"
                         >
                           05.01.2026
                         </span>
                         <span
-                          class="c24"
+                          class="c26"
                         >
                           12.01.2026
                         </span>
                       </p>
                       <div
-                        class="c25"
+                        class="c27"
                       >
                         <svg
                           focusable="false"
@@ -991,14 +1008,14 @@ exports[`Viser oversikt med alt innhold 1`] = `
                         </svg>
                       </div>
                       <h4
-                        class="typo-element c26"
+                        class="typo-element c28"
                         id="Helt tilfeldig ID"
                       >
                         Et nytt samtalereferat er tilgjengelig i din innboks
                       </h4>
                       <ul
                         aria-label="Kommunikasjonskanaler"
-                        class="c27"
+                        class="c29"
                       >
                         <li
                           class="typo-normal"
@@ -1019,7 +1036,7 @@ exports[`Viser oversikt med alt innhold 1`] = `
                       <button
                         aria-expanded="false"
                         aria-label="Vis mer informasjon om varsel/notifikasjon"
-                        class="c28"
+                        class="c30"
                         title="Vis mer informasjon om varsel/notifikasjon"
                       >
                         <span
@@ -1028,7 +1045,7 @@ exports[`Viser oversikt med alt innhold 1`] = `
                       </button>
                     </div>
                     <dl
-                      class="c29"
+                      class="c31"
                     >
                       <div>
                         <dt>
@@ -1063,15 +1080,15 @@ exports[`Viser oversikt med alt innhold 1`] = `
                         </dd>
                         <hr />
                         <div
-                          class="c30"
+                          class="c32"
                         >
                           <span
-                            class="c31"
+                            class="c33"
                           >
                             Varslingsfeil
                           </span>
                           <div
-                            class="c32"
+                            class="c34"
                           >
                             <li>
                               05.01.2026: Det oppsto en feil
@@ -1085,30 +1102,30 @@ exports[`Viser oversikt med alt innhold 1`] = `
               </li>
               <li>
                 <div
-                  class="panel c22"
+                  class="panel c24"
                 >
                   <article
                     aria-labelledby="Helt tilfeldig ID"
                   >
                     <div
-                      class="c23"
+                      class="c25"
                     >
                       <p
                         class="typo-normal"
                       >
                         <span
-                          class="c24"
+                          class="c26"
                         >
                           05.01.2026
                         </span>
                         <span
-                          class="c24"
+                          class="c26"
                         >
                           12.01.2026
                         </span>
                       </p>
                       <div
-                        class="c25"
+                        class="c27"
                       >
                         <svg
                           focusable="false"
@@ -1127,14 +1144,14 @@ exports[`Viser oversikt med alt innhold 1`] = `
                         </svg>
                       </div>
                       <h4
-                        class="typo-element c26"
+                        class="typo-element c28"
                         id="Helt tilfeldig ID"
                       >
                         Et nytt samtalereferat er tilgjengelig i din innboks
                       </h4>
                       <ul
                         aria-label="Kommunikasjonskanaler"
-                        class="c27"
+                        class="c29"
                       >
                         <li
                           class="typo-normal"
@@ -1155,7 +1172,7 @@ exports[`Viser oversikt med alt innhold 1`] = `
                       <button
                         aria-expanded="false"
                         aria-label="Vis mer informasjon om varsel/notifikasjon"
-                        class="c28"
+                        class="c30"
                         title="Vis mer informasjon om varsel/notifikasjon"
                       >
                         <span
@@ -1164,7 +1181,7 @@ exports[`Viser oversikt med alt innhold 1`] = `
                       </button>
                     </div>
                     <dl
-                      class="c29"
+                      class="c31"
                     >
                       <div>
                         <dt>
@@ -1199,15 +1216,15 @@ exports[`Viser oversikt med alt innhold 1`] = `
                         </dd>
                         <hr />
                         <div
-                          class="c30"
+                          class="c32"
                         >
                           <span
-                            class="c31"
+                            class="c33"
                           >
                             Varslingsfeil
                           </span>
                           <div
-                            class="c32"
+                            class="c34"
                           >
                             <li>
                               05.01.2026: Det oppsto en feil

--- a/src/app/personside/infotabs/oversikt/__snapshots__/Oversikt.test.tsx.snap
+++ b/src/app/personside/infotabs/oversikt/__snapshots__/Oversikt.test.tsx.snap
@@ -3,28 +3,6 @@
 exports[`Viser oversikt med alt innhold 1`] = `
 <DocumentFragment>
   .c7 {
-  flex-grow: 1;
-  display: flex;
-  justify-content: center;
-  align-items: center;
-  animation: edHiKw 0.3s ease-out;
-}
-
-.c7 >* {
-  flex: 0 1 25rem;
-  display: flex;
-  justify-content: center;
-}
-
-.c8 {
-  overflow: hidden;
-  display: flex;
-  justify-content: center;
-  animation: edHiKw 0.3s ease-out;
-  padding: .5rem;
-}
-
-.c10 {
   position: relative;
   padding: .5rem;
   display: flex;
@@ -32,19 +10,19 @@ exports[`Viser oversikt med alt innhold 1`] = `
   cursor: pointer;
 }
 
-.c10:hover {
+.c7:hover {
   box-shadow: inset 0 0 0 0.1rem #0067c5,0 0.1rem 0.1rem rgba(0, 0, 0, 0.2);
 }
 
-.c10:hover >button:last-child {
+.c7:hover >button:last-child {
   padding-left: 0.5rem;
 }
 
-.c10 >*:first-child {
+.c7 >*:first-child {
   flex-grow: 1;
 }
 
-.c12 {
+.c10 {
   border: none;
   padding: 0;
   height: 2rem;
@@ -55,16 +33,16 @@ exports[`Viser oversikt med alt innhold 1`] = `
   transition: padding-left 0.3s;
 }
 
-.c12 .nav-frontend-chevron {
+.c10 .nav-frontend-chevron {
   width: 1.5625rem;
 }
 
-.c12:focus {
+.c10:focus {
   outline: none;
   box-shadow: none;
 }
 
-.c12:focus::after {
+.c10:focus::after {
   position: absolute;
   top: 0;
   left: 0;
@@ -163,6 +141,49 @@ exports[`Viser oversikt med alt innhold 1`] = `
   border-top: solid 0.0625rem #78706a;
 }
 
+.c9 {
+  position: absolute;
+  position: absolute!important;
+  height: 1px;
+  width: 1px;
+  overflow: hidden;
+  clip: rect(1px 1px 1px 1px);
+  clip: rect(1px, 1px, 1px, 1px);
+}
+
+.c8 {
+  padding: 0 0 0 0.2rem;
+  border: none;
+  cursor: pointer;
+  background-color: transparent;
+  border-radius: 0.2rem;
+  transition: transform 0.2s;
+}
+
+.c8:focus {
+  outline: none;
+  box-shadow: 0 0 0 0.1875rem #254b6d;
+}
+
+.c8 svg {
+  width: 1rem;
+  color: #005b82;
+  stroke-width: 1.4;
+}
+
+.c8:hover {
+  transform: scale(1.2);
+}
+
+.c8:active {
+  opacity: 0.5;
+}
+
+.c8:focus {
+  outline: none;
+  box-shadow: 0 0 0 0.1875rem #254b6d;
+}
+
 .c2 {
   padding: 0rem 0rem 0.3rem 0rem;
 }
@@ -201,11 +222,11 @@ exports[`Viser oversikt med alt innhold 1`] = `
   border-top: solid 0.0625rem #78706a;
 }
 
-.c11 {
+.c12 {
   font-weight: 600;
 }
 
-.c9 >*:not(:first-child) {
+.c11 >*:not(:first-child) {
   border-top: solid 0.0625rem #78706a;
 }
 
@@ -416,44 +437,77 @@ exports[`Viser oversikt med alt innhold 1`] = `
             <div
               class="c7"
             >
-              <span
-                class="c8"
-                padding=".5rem"
-              >
-                <svg
-                  aria-label="Laster innhold"
-                  class="spinner spinner--l"
-                  focusable="false"
-                  height="32"
-                  kind="spinner-negativ"
-                  preserveAspectRatio="xMidYMid"
-                  viewBox="0 0 50 50"
-                  width="32"
+              <div>
+                <p
+                  class="typo-element"
                 >
-                  <title>
-                    Venter...
-                  </title>
-                  <circle
-                    cx="25"
-                    cy="25"
-                    fill="none"
-                    r="20"
-                    stroke="#eee"
-                    stroke-width="5"
-                    xmlns="http://www.w3.org/2000/svg"
-                  />
-                  <circle
-                    cx="25"
-                    cy="25"
-                    fill="none"
-                    r="20"
-                    stroke="#888"
-                    stroke-dasharray="50 155"
-                    stroke-linecap="round"
-                    stroke-width="5"
-                  />
-                </svg>
-              </span>
+                  Oppfølgende enhet:
+                </p>
+                <p
+                  class="typo-normal"
+                >
+                  E0001 Test Enhet
+                </p>
+                <p
+                  class="typo-element"
+                >
+                  Veileder:
+                </p>
+                <p
+                  class="typo-normal"
+                >
+                  Test Veileder (Z0000001)
+                </p>
+                <span>
+                  <button
+                    class="c8"
+                  >
+                    <svg
+                      viewBox="0 0 24 24"
+                      xmlns="http://www.w3.org/2000/svg"
+                    >
+                      <path
+                        d="M15.5 23.5h-14v-20h9l5 5zm-5-20v5h5m-8-5v-3h9l5 5v15h-6m1-20v5h5"
+                        fill="none"
+                        stroke="currentColor"
+                        stroke-linecap="round"
+                        stroke-linejoin="round"
+                        stroke-miterlimit="10"
+                      />
+                    </svg>
+                    <span
+                      class="sr-only"
+                    >
+                      Kopier veileder
+                    </span>
+                  </button>
+                  <textarea
+                    aria-hidden="true"
+                    class="c9"
+                    readonly=""
+                    tabindex="-1"
+                  >
+                    Test Veileder (Z0000001)
+                  </textarea>
+                </span>
+                <p
+                  class="typo-element"
+                >
+                  Ytelser:
+                </p>
+                <p
+                  class="typo-normal"
+                />
+              </div>
+              <button
+                aria-label="Gå til oppfølging"
+                aria-selected="false"
+                class="c10"
+              >
+                <span
+                  class="nav-frontend-chevron chevronboks chevron--hoyre"
+                />
+              </button>
             </div>
           </div>
         </div>
@@ -492,13 +546,13 @@ exports[`Viser oversikt med alt innhold 1`] = `
           >
             <ol
               aria-label="Oversikt brukers utbetalinger"
-              class="c9"
+              class="c11"
             >
               <li
                 class="test-utbetalinger-oversikt"
               >
                 <div
-                  class="c10"
+                  class="c7"
                 >
                   <div>
                     <p
@@ -510,7 +564,7 @@ exports[`Viser oversikt med alt innhold 1`] = `
                       class="typo-normal"
                     >
                       <span
-                        class="c11"
+                        class="c12"
                       >
                         Barnetrygd
                       </span>
@@ -534,7 +588,7 @@ exports[`Viser oversikt med alt innhold 1`] = `
                   <button
                     aria-label="Vis utbetaling"
                     aria-selected="false"
-                    class="c12"
+                    class="c10"
                   >
                     <span
                       class="nav-frontend-chevron chevronboks chevron--hoyre"
@@ -546,7 +600,7 @@ exports[`Viser oversikt med alt innhold 1`] = `
                 class="test-utbetalinger-oversikt"
               >
                 <div
-                  class="c10"
+                  class="c7"
                 >
                   <div>
                     <p
@@ -558,7 +612,7 @@ exports[`Viser oversikt med alt innhold 1`] = `
                       class="typo-normal"
                     >
                       <span
-                        class="c11"
+                        class="c12"
                       >
                         Diverse ytelser
                       </span>
@@ -582,7 +636,7 @@ exports[`Viser oversikt med alt innhold 1`] = `
                   <button
                     aria-label="Vis utbetaling"
                     aria-selected="false"
-                    class="c12"
+                    class="c10"
                   >
                     <span
                       class="nav-frontend-chevron chevronboks chevron--hoyre"
@@ -639,7 +693,7 @@ exports[`Viser oversikt med alt innhold 1`] = `
                 class="test-sakstema-list"
               >
                 <div
-                  class="c10"
+                  class="c7"
                 >
                   <div>
                     <p
@@ -651,7 +705,7 @@ exports[`Viser oversikt med alt innhold 1`] = `
                   <button
                     aria-label="Vis Medlemskap"
                     aria-selected="false"
-                    class="c12"
+                    class="c10"
                   >
                     <span
                       class="nav-frontend-chevron chevronboks chevron--hoyre"
@@ -663,7 +717,7 @@ exports[`Viser oversikt med alt innhold 1`] = `
                 class="test-sakstema-list"
               >
                 <div
-                  class="c10"
+                  class="c7"
                 >
                   <div>
                     <p
@@ -675,7 +729,7 @@ exports[`Viser oversikt med alt innhold 1`] = `
                   <button
                     aria-label="Vis Mobilitetsfremmende stønad"
                     aria-selected="false"
-                    class="c12"
+                    class="c10"
                   >
                     <span
                       class="nav-frontend-chevron chevronboks chevron--hoyre"
@@ -735,7 +789,7 @@ exports[`Viser oversikt med alt innhold 1`] = `
             >
               <li>
                 <div
-                  class="c10 test-meldinger-oversikt"
+                  class="c7 test-meldinger-oversikt"
                 >
                   <div>
                     <div
@@ -812,7 +866,7 @@ exports[`Viser oversikt med alt innhold 1`] = `
                   <button
                     aria-label="Vis meldinger for Spørsmål fra NAV - Arbeid"
                     aria-selected="false"
-                    class="c12"
+                    class="c10"
                   >
                     <span
                       class="nav-frontend-chevron chevronboks chevron--hoyre"
@@ -860,7 +914,7 @@ exports[`Viser oversikt med alt innhold 1`] = `
               class="c22"
             >
               <div
-                class="c10 test-ytelse-oversikt"
+                class="c7 test-ytelse-oversikt"
               >
                 <div>
                   <p
@@ -882,7 +936,7 @@ exports[`Viser oversikt med alt innhold 1`] = `
                 <button
                   aria-label="Vis engangsstønad"
                   aria-selected="false"
-                  class="c12"
+                  class="c10"
                 >
                   <span
                     class="nav-frontend-chevron chevronboks chevron--hoyre"
@@ -890,7 +944,7 @@ exports[`Viser oversikt med alt innhold 1`] = `
                 </button>
               </div>
               <div
-                class="c10 test-ytelse-oversikt"
+                class="c7 test-ytelse-oversikt"
               >
                 <div>
                   <p
@@ -912,7 +966,7 @@ exports[`Viser oversikt med alt innhold 1`] = `
                 <button
                   aria-label="Vis engangsstønad"
                   aria-selected="false"
-                  class="c12"
+                  class="c10"
                 >
                   <span
                     class="nav-frontend-chevron chevronboks chevron--hoyre"

--- a/src/components/Oppfolging/index.tsx
+++ b/src/components/Oppfolging/index.tsx
@@ -35,7 +35,7 @@ const OppfolgingDetaljer = () => {
     return (
         <>
             <Heading as="h3" size="small">
-                Arbeidsrettetoppfølging
+                Arbeidsrettet oppfølging
             </Heading>
             {!arbeidsOppfolging ? (
                 <Box paddingBlock="space-8">
@@ -49,8 +49,8 @@ const OppfolgingDetaljer = () => {
                         </BodyShort>
                         <BodyShort size="small">
                             {arbeidsOppfolging.oppfolging?.erUnderOppfolging
-                                ? 'Under arbeidsrettetoppfølging'
-                                : 'Ikke under arbeidsrettetoppfølging'}
+                                ? 'Under arbeidsrettet oppfølging'
+                                : 'Ikke under arbeidsrettet oppfølging'}
                         </BodyShort>
                     </VStack>
                     <VStack justify="space-between">

--- a/src/components/Oppfolging/index.tsx
+++ b/src/components/Oppfolging/index.tsx
@@ -35,7 +35,7 @@ const OppfolgingDetaljer = () => {
     return (
         <>
             <Heading as="h3" size="small">
-                Arbeidsoppfølging
+                Arbeidsrettetoppfølging
             </Heading>
             {!arbeidsOppfolging ? (
                 <Box paddingBlock="space-8">
@@ -49,8 +49,8 @@ const OppfolgingDetaljer = () => {
                         </BodyShort>
                         <BodyShort size="small">
                             {arbeidsOppfolging.oppfolging?.erUnderOppfolging
-                                ? 'Under oppfølging'
-                                : 'Ikke under oppfølging'}
+                                ? 'Under arbeidsrettetoppfølging'
+                                : 'Ikke under arbeidsrettetoppfølging'}
                         </BodyShort>
                     </VStack>
                     <VStack justify="space-between">
@@ -85,7 +85,7 @@ const Gjeldende14aVedtakDetaljer = () => {
     return (
         <>
             <Heading as="h3" size="small">
-                § 14 a-vedtak
+                Oppfølgingsvedtak § 14 a
             </Heading>
             <HGrid gap="space-16" columns={{ sm: 1, md: 2 }} className="mt-4">
                 <VStack justify="space-between">
@@ -93,7 +93,7 @@ const Gjeldende14aVedtakDetaljer = () => {
                         Status:
                     </BodyShort>
                     <BodyShort size="small">
-                        {gjeldende14aVedtak ? 'Har § 14 a-vedtak' : 'Har ikke § 14 a-vedtak'}
+                        {gjeldende14aVedtak ? 'Har oppfølgingsvedtak' : 'Har ikke oppfølgingsvedtak'}
                     </BodyShort>
                 </VStack>
                 {gjeldende14aVedtak && (

--- a/src/generated/modiapersonoversikt-api.ts
+++ b/src/generated/modiapersonoversikt-api.ts
@@ -3129,10 +3129,7 @@ export interface operations {
     };
     hentArbeidsOppfolging: {
         parameters: {
-            query?: {
-                startDato?: string;
-                sluttDato?: string;
-            };
+            query?: never;
             header?: never;
             path?: never;
             cookie?: never;

--- a/src/generated/modiapersonoversikt-api.ts
+++ b/src/generated/modiapersonoversikt-api.ts
@@ -244,22 +244,6 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
-    '/rest/person/kontaktinformasjon': {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        get?: never;
-        put?: never;
-        post: operations['hentKontaktinformasjon'];
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
     '/rest/person/identer': {
         parameters: {
             query?: never;
@@ -1328,6 +1312,10 @@ export interface components {
         LocalDate: {
             /** Format: date */
             value?: string;
+            /** Format: date */
+            value$kotlinx_datetime: string;
+            /** Format: int32 */
+            monthNumber: number;
             /** Format: int32 */
             year: number;
             /** Format: int32 */
@@ -1338,14 +1326,16 @@ export interface components {
             dayOfWeek: LocalDateDayOfWeek;
             /** Format: int32 */
             dayOfYear: number;
-            /** Format: date */
-            value$kotlinx_datetime: string;
-            /** Format: int32 */
-            monthNumber: number;
         };
         LocalDateTime: {
             /** Format: date-time */
             value?: string;
+            /** Format: date-time */
+            value$kotlinx_datetime: string;
+            /** Format: int32 */
+            monthNumber: number;
+            /** Format: int32 */
+            nanosecond: number;
             time: components['schemas']['LocalTime'];
             /** Format: int32 */
             year: number;
@@ -1364,24 +1354,18 @@ export interface components {
             /** Format: int32 */
             dayOfYear: number;
             date: components['schemas']['LocalDate'];
-            /** Format: date-time */
-            value$kotlinx_datetime: string;
-            /** Format: int32 */
-            monthNumber: number;
-            /** Format: int32 */
-            nanosecond: number;
         };
         LocalTime: {
             value?: string;
+            value$kotlinx_datetime: string;
+            /** Format: int32 */
+            nanosecond: number;
             /** Format: int32 */
             hour: number;
             /** Format: int32 */
             minute: number;
             /** Format: int32 */
             second: number;
-            value$kotlinx_datetime: string;
-            /** Format: int32 */
-            nanosecond: number;
         };
         ResultatSoknadsstatus: {
             resultat: components['schemas']['SoknadsstatusSakstema'][];
@@ -1756,11 +1740,6 @@ export interface components {
             embete?: string;
             gyldighetsPeriode?: components['schemas']['GyldighetsPeriode'];
         };
-        Kontaktinformasjon: {
-            epost?: components['schemas']['VerdiString'];
-            mobiltelefon?: components['schemas']['VerdiString'];
-            reservasjon?: components['schemas']['VerdiBoolean'];
-        };
         IdentInformasjon: {
             ident: string;
             /** @enum {string} */
@@ -2029,10 +2008,6 @@ export interface components {
         };
         ArbeidsOppfolgingDTO: {
             oppfolging?: components['schemas']['OppfolgingDTO'];
-            meldeplikt?: boolean;
-            formidlingsgruppe?: string;
-            vedtaksdato?: string;
-            rettighetsgruppe?: string;
         };
         JournalforingSak: {
             fnr?: string;
@@ -2436,7 +2411,6 @@ export type UtflyttingFraNorge = components['schemas']['UtflyttingFraNorge'];
 export type VerdiBoolean = components['schemas']['VerdiBoolean'];
 export type VerdiString = components['schemas']['VerdiString'];
 export type Verge = components['schemas']['Verge'];
-export type Kontaktinformasjon = components['schemas']['Kontaktinformasjon'];
 export type IdentInformasjon = components['schemas']['IdentInformasjon'];
 export type Identliste = components['schemas']['Identliste'];
 export type OppgaveDto = components['schemas']['OppgaveDTO'];
@@ -2901,30 +2875,6 @@ export interface operations {
                 };
                 content: {
                     '*/*': components['schemas']['Data'];
-                };
-            };
-        };
-    };
-    hentKontaktinformasjon: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        requestBody: {
-            content: {
-                'application/json': components['schemas']['FnrRequest'];
-            };
-        };
-        responses: {
-            /** @description OK */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    '*/*': components['schemas']['Kontaktinformasjon'];
                 };
             };
         };

--- a/src/lib/clients/modiapersonoversikt-api.ts
+++ b/src/lib/clients/modiapersonoversikt-api.ts
@@ -321,7 +321,7 @@ export const useArbeidsoppfolging = () => {
         body: { fnr }
     });
 
-    const errorMessages = [errorPlaceholder(response, responseErrorMessage('arbeidsoppfølging'))];
+    const errorMessages = [errorPlaceholder(response, responseErrorMessage('data om arbeidsrettet oppfølging'))];
     return {
         ...response,
         errorMessages: errorMessages.filter(Boolean)
@@ -333,7 +333,7 @@ export const useSykefravaersoppfolging = () => {
     const response = $api.useQuery('post', '/rest/oppfolging/sykefravaeroppfolging', {
         body: { fnr }
     });
-    const errorMessages = [errorPlaceholder(response, responseErrorMessage('sykefraværoppfølging'))];
+    const errorMessages = [errorPlaceholder(response, responseErrorMessage('data om sykefraværsoppfølging'))];
     return {
         ...response,
         errorMessages: errorMessages.filter(Boolean)

--- a/src/mock/oppfolging-mock.ts
+++ b/src/mock/oppfolging-mock.ts
@@ -3,6 +3,7 @@ import dayjs from 'dayjs';
 import navfaker from 'nav-faker';
 import type {
     AggregertPeriodeArbeidssoekerregisteretDto,
+    ArbeidsOppfolgingDto,
     Gjeldende14aVedtakResponse,
     MetadataArbeidssoekerregisteretDto,
     SykefravaerOppfolgingDto
@@ -153,6 +154,24 @@ function getVedtak(): OppfolgingsVedtak {
         aktivitetsfase: 'Ikke spesif. aktivitetsfase',
         vedtakstatus: faker.helpers.arrayElement(['Iverksatt', 'Avsluttet']),
         vedtakstype: 'Ordinære dagpenger'
+    };
+}
+
+export function getArbeidsoppfolgingDTO(): ArbeidsOppfolgingDto {
+    return {
+        oppfolging: {
+            erUnderOppfolging: true,
+            veileder: {
+                navn: 'Test Veileder',
+                ident: 'Z0000001',
+                fornavn: 'Test',
+                etternavn: 'Veileder'
+            },
+            enhet: {
+                enhetId: 'E0001',
+                navn: 'Test Enhet'
+            }
+        }
     };
 }
 

--- a/src/mock/oppfolging-mock.ts
+++ b/src/mock/oppfolging-mock.ts
@@ -3,7 +3,7 @@ import dayjs from 'dayjs';
 import navfaker from 'nav-faker';
 import type {
     AggregertPeriodeArbeidssoekerregisteretDto,
-    Gjeldende14aVedtak,
+    Gjeldende14aVedtakResponse,
     MetadataArbeidssoekerregisteretDto,
     SykefravaerOppfolgingDto
 } from 'src/generated/modiapersonoversikt-api';
@@ -80,15 +80,17 @@ export function getMockYtelserOgKontrakter(fodselsnummer: string): DetaljertOppf
     };
 }
 
-export function getMock14aVedtak(fodselsnummer: string): Gjeldende14aVedtak {
+export function getMock14aVedtak(fodselsnummer: string): Gjeldende14aVedtakResponse {
     faker.seed(Number(fodselsnummer));
     navfaker.seed(`${fodselsnummer}oppf`);
 
     return {
-        fattetDato: '2023-01-15',
-        innsatsgruppe: {
-            kode: 'INGRP3',
-            beskrivelse: 'Innsatsgruppe 3'
+        gjeldende14aVedtak: {
+            fattetDato: '2023-01-15',
+            innsatsgruppe: {
+                kode: 'INGRP3',
+                beskrivelse: 'Innsatsgruppe 3'
+            }
         }
     };
 }

--- a/src/test/testStore.ts
+++ b/src/test/testStore.ts
@@ -2,7 +2,7 @@ import type { UseQueryResult } from '@tanstack/react-query';
 import { applyMiddleware, createStore, type Dispatch, type Store } from 'redux';
 import thunkMiddleware from 'redux-thunk';
 import * as modiapersonoversiktApiClient from 'src/lib/clients/modiapersonoversikt-api';
-import { getMockOppslagArbeidssoekerregisteret } from 'src/mock/oppfolging-mock';
+import { getArbeidsoppfolgingDTO, getMockOppslagArbeidssoekerregisteret } from 'src/mock/oppfolging-mock';
 import { statiskArbeidsavklaringspengerMock } from 'src/mock/ytelse/statiskArbeidsavklaringspengerMock';
 import { statiskEngangstonadMock, statiskForeldrepengerMock } from 'src/mock/ytelse/statiskForeldrepengerMock';
 import { statiskPensjonMock } from 'src/mock/ytelse/statiskPensjonMock';
@@ -79,6 +79,7 @@ export function setupReactQueryMocks() {
     vi.spyOn(oppfolgingResource, 'useFetch');
     vi.spyOn(modiapersonoversiktApiClient, 'useSakerDokumenter');
     vi.spyOn(modiapersonoversiktApiClient, 'useOppslagArbeidssoekerregisteret');
+    vi.spyOn(modiapersonoversiktApiClient, 'useArbeidsoppfolging');
     vi.spyOn(utbetalingerResource, 'useFetch');
     vi.spyOn(persondataResource, 'useFetch');
     vi.spyOn(aktoridResource, 'useFetch');
@@ -129,4 +130,5 @@ export function setupReactQueryMocks() {
         modiapersonoversiktApiClient.useOppslagArbeidssoekerregisteret,
         getMockOppslagArbeidssoekerregisteret(aremark.personIdent)
     );
+    mockReactQuery(modiapersonoversiktApiClient.useArbeidsoppfolging, getArbeidsoppfolgingDTO());
 }


### PR DESCRIPTION
Bruker det nye endepunktet for arbeidsretta oppfølging i gamle modia også, slik at me på sikt kan fase ut arena-dataen som har med oppfølging å gjera. Måtte beholde endepunktet fortsatt då det inneholder arena-ytelser.
Litt forbedringer og fiksing av orddelingsfeil.