### PR TITLE
Diverse: dokumentertabell, mobilbrekkpunkt, avansert søk tracking

### DIFF
--- a/src/app/personside/infotabs/saksoversikt/saksdokumenter/DokumentLenke.tsx
+++ b/src/app/personside/infotabs/saksoversikt/saksdokumenter/DokumentLenke.tsx
@@ -2,7 +2,7 @@ import { Link, useLocation } from '@tanstack/react-router';
 import { Element, Undertekst } from 'nav-frontend-typografi';
 import type { Sakstema } from 'src/generated/modiapersonoversikt-api';
 import { type Dokument, DokumentDokumentStatus, type Dokumentmetadata } from 'src/generated/modiapersonoversikt-api';
-import { trackingEvents } from 'src/utils/analytics';
+import { trackVisDetaljvisning } from 'src/utils/analytics';
 import { erSakerFullscreen } from '../utils/erSakerFullscreen';
 
 interface Props {
@@ -46,9 +46,9 @@ function DokumentLenke(props: Props) {
             {apneDokumentINyttVindu ? (
                 <Link
                     to="/dokument"
-                    data-umami-event={trackingEvents.detaljvisningKlikket}
-                    data-umami-event-fane="saker"
-                    data-umami-event-tekst="åpnet dokument"
+                    onClick={() => {
+                        trackVisDetaljvisning('dokumenter', 'åpnet dokument i ny fane');
+                    }}
                     search={{ dokument: dokumentReferanse, journalpost: journalpostId }}
                     target="_blank"
                     className="lenke typo-element"

--- a/src/app/personside/infotabs/saksoversikt/saksdokumenter/DokumentLenke.tsx
+++ b/src/app/personside/infotabs/saksoversikt/saksdokumenter/DokumentLenke.tsx
@@ -47,7 +47,7 @@ function DokumentLenke(props: Props) {
                 <Link
                     to="/dokument"
                     onClick={() => {
-                        trackVisDetaljvisning('dokumenter', 'åpnet dokument i ny fane');
+                        trackVisDetaljvisning('saker', 'åpnet dokument');
                     }}
                     search={{ dokument: dokumentReferanse, journalpost: journalpostId }}
                     target="_blank"

--- a/src/components/Dokumenter/DokumentVisningExpandable.tsx
+++ b/src/components/Dokumenter/DokumentVisningExpandable.tsx
@@ -6,7 +6,7 @@ import Dokument from 'src/components/Dokumenter/Dokument';
 import { dokumentTekst } from 'src/components/Dokumenter/useSortedAndPaginatedDokumenter';
 import { dokumentKanVises } from 'src/components/Dokumenter/utils';
 import type { Dokumentmetadata, Dokument as DokumentType } from 'src/generated/modiapersonoversikt-api';
-import { trackingEvents } from 'src/utils/analytics';
+import { trackVisDetaljvisning } from 'src/utils/analytics';
 
 const DokumentTabInnhold = ({
     value,
@@ -60,9 +60,9 @@ const DokumentTab = ({
                     <Link
                         to="/new/dokument"
                         target="_blank"
-                        data-umami-event={trackingEvents.detaljvisningKlikket}
-                        data-umami-event-fane="dokumenter"
-                        data-umami-event-tekst="åpnet dokument i ny fane"
+                        onClick={() => {
+                            trackVisDetaljvisning('dokumenter', 'åpnet dokument i ny fane');
+                        }}
                         search={{
                             dokument: dokument.dokumentreferanse,
                             journalpost: journalpost.journalpostId

--- a/src/components/Dokumenter/DokumentVisningExpandable.tsx
+++ b/src/components/Dokumenter/DokumentVisningExpandable.tsx
@@ -70,7 +70,6 @@ const DokumentTab = ({
                         className="typo-element align-middle pl-2"
                     >
                         <ExternalLinkIcon
-                            aria-hidden
                             fontSize="1.2rem"
                             color="var(--ax-text-subtle)"
                             title="Åpne dokument i ny fane"

--- a/src/components/Dokumenter/DokumenterTabell.tsx
+++ b/src/components/Dokumenter/DokumenterTabell.tsx
@@ -1,5 +1,6 @@
-import { EyeSlashIcon, FilesIcon } from '@navikt/aksel-icons';
+import { ExternalLinkIcon, EyeSlashIcon, FilesIcon } from '@navikt/aksel-icons';
 import { Box, HStack, InlineMessage, Pagination, type SortState, Table, Tag } from '@navikt/ds-react';
+import { Link } from '@tanstack/react-router';
 import { useState } from 'react';
 import { DokumentVisningExpandable } from 'src/components/Dokumenter/DokumentVisningExpandable';
 import { useSortedAndPaginatedDokumenter } from 'src/components/Dokumenter/useSortedAndPaginatedDokumenter';
@@ -10,7 +11,7 @@ import {
     DokumentmetadataMottaker
 } from 'src/generated/modiapersonoversikt-api';
 import { usePersonData } from 'src/lib/clients/modiapersonoversikt-api';
-import { trackVisDetaljvisning } from 'src/utils/analytics';
+import { trackingEvents, trackVisDetaljvisning } from 'src/utils/analytics';
 import { capitalizeName, formaterDato } from 'src/utils/string-utils';
 
 interface DokumenterSortState extends SortState {
@@ -89,6 +90,7 @@ export const DokumenterTabell = () => {
             <Table
                 id="dokumentertabell"
                 size="medium"
+                zebraStripes
                 sort={sort as SortState | undefined}
                 onSortChange={(sortKey) => handleSort(sortKey as DokumenterSortState['orderBy'])}
             >
@@ -118,6 +120,9 @@ export const DokumenterTabell = () => {
                         <Table.ColumnHeader>
                             <span className="sr-only">Antall dokumenter</span>
                         </Table.ColumnHeader>
+                        <Table.ColumnHeader>
+                            <span className="sr-only">Åpne hoveddokument</span>
+                        </Table.ColumnHeader>
                     </Table.Row>
                 </Table.Header>
                 <Table.Body>
@@ -138,12 +143,13 @@ export const DokumenterTabell = () => {
                                         journalpost.beskrivelse
                                     ) : (
                                         <HStack wrap={false} gap="space-4" align="center">
-                                            <EyeSlashIcon
-                                                color="var(--ax-text-neutral-subtle)"
-                                                fontSize="1.3rem"
-                                                aria-hidden
-                                            />{' '}
-                                            <Box className="text-[var(--ax-text-neutral-subtle)]">Ingen tilgang</Box>
+                                            <Tag
+                                                variant="moderate"
+                                                data-color="danger"
+                                                icon={<EyeSlashIcon aria-hidden />}
+                                            >
+                                                Ingen tilgang
+                                            </Tag>
                                         </HStack>
                                     )}
                                 </Table.HeaderCell>
@@ -161,11 +167,31 @@ export const DokumenterTabell = () => {
                                         data-color="info"
                                         size="small"
                                         variant="moderate"
-                                        title="Antall vedlegg"
+                                        title="Antall dokumenter"
                                         icon={<FilesIcon aria-hidden />}
                                     >
                                         {countVedleggMedReferanse(journalpost)}
                                     </Tag>
+                                </Table.DataCell>
+                                <Table.DataCell>
+                                    <Link
+                                        to="/new/dokument"
+                                        target="_blank"
+                                        data-umami-event={trackingEvents.detaljvisningKlikket}
+                                        data-umami-event-fane="dokumenter"
+                                        data-umami-event-tekst="åpnet dokument i ny fane"
+                                        search={{
+                                            dokument: journalpost.hoveddokument.dokumentreferanse,
+                                            journalpost: journalpost.journalpostId
+                                        }}
+                                    >
+                                        <ExternalLinkIcon
+                                            aria-hidden
+                                            fontSize="1.5rem"
+                                            color="var(--ax-text-subtle)"
+                                            title="Åpne hoveddokument i ny fane"
+                                        ></ExternalLinkIcon>
+                                    </Link>
                                 </Table.DataCell>
                             </Table.ExpandableRow>
                         );

--- a/src/components/Dokumenter/DokumenterTabell.tsx
+++ b/src/components/Dokumenter/DokumenterTabell.tsx
@@ -174,24 +174,25 @@ export const DokumenterTabell = () => {
                                     </Tag>
                                 </Table.DataCell>
                                 <Table.DataCell>
-                                    <Link
-                                        to="/new/dokument"
-                                        target="_blank"
-                                        onClick={() => {
-                                            trackVisDetaljvisning('dokumenter', 'åpnet dokument i ny fane');
-                                        }}
-                                        search={{
-                                            dokument: journalpost.hoveddokument.dokumentreferanse,
-                                            journalpost: journalpost.journalpostId
-                                        }}
-                                    >
-                                        <ExternalLinkIcon
-                                            aria-hidden
-                                            fontSize="1.5rem"
-                                            color="var(--ax-text-subtle)"
-                                            title="Åpne hoveddokument i ny fane"
-                                        ></ExternalLinkIcon>
-                                    </Link>
+                                    {journalpost.harTilgang && journalpost.hoveddokument && (
+                                        <Link
+                                            to="/new/dokument"
+                                            target="_blank"
+                                            onClick={() => {
+                                                trackVisDetaljvisning('dokumenter', 'åpnet dokument i ny fane');
+                                            }}
+                                            search={{
+                                                dokument: journalpost.hoveddokument.dokumentreferanse,
+                                                journalpost: journalpost.journalpostId
+                                            }}
+                                        >
+                                            <ExternalLinkIcon
+                                                fontSize="1.5rem"
+                                                color="var(--ax-text-subtle)"
+                                                title="Åpne hoveddokument i ny fane"
+                                            ></ExternalLinkIcon>
+                                        </Link>
+                                    )}
                                 </Table.DataCell>
                             </Table.ExpandableRow>
                         );

--- a/src/components/Dokumenter/DokumenterTabell.tsx
+++ b/src/components/Dokumenter/DokumenterTabell.tsx
@@ -11,7 +11,7 @@ import {
     DokumentmetadataMottaker
 } from 'src/generated/modiapersonoversikt-api';
 import { usePersonData } from 'src/lib/clients/modiapersonoversikt-api';
-import { trackingEvents, trackVisDetaljvisning } from 'src/utils/analytics';
+import { trackVisDetaljvisning } from 'src/utils/analytics';
 import { capitalizeName, formaterDato } from 'src/utils/string-utils';
 
 interface DokumenterSortState extends SortState {
@@ -177,9 +177,9 @@ export const DokumenterTabell = () => {
                                     <Link
                                         to="/new/dokument"
                                         target="_blank"
-                                        data-umami-event={trackingEvents.detaljvisningKlikket}
-                                        data-umami-event-fane="dokumenter"
-                                        data-umami-event-tekst="åpnet dokument i ny fane"
+                                        onClick={() => {
+                                            trackVisDetaljvisning('dokumenter', 'åpnet dokument i ny fane');
+                                        }}
                                         search={{
                                             dokument: journalpost.hoveddokument.dokumentreferanse,
                                             journalpost: journalpost.journalpostId

--- a/src/components/personsok/index.tsx
+++ b/src/components/personsok/index.tsx
@@ -1,6 +1,7 @@
 import { BodyShort, Box, Heading, Modal } from '@navikt/ds-react';
 import { useCallback, useRef, useState } from 'react';
 import type { PersonsokRequest } from 'src/lib/types/modiapersonoversikt-api';
+import { trackGenereltUmamiEvent, trackingEvents } from 'src/utils/analytics';
 import useListener from 'src/utils/hooks/use-listener';
 import { PersonsokForm } from './form';
 import { PersonsokResult } from './PersonsokResult';
@@ -25,7 +26,16 @@ const Personsok = () => {
                 </BodyShort>
             </Modal.Header>
             <Modal.Body>
-                <PersonsokForm onSubmit={setSearchQuery} onReset={() => setSearchQuery(undefined)} />
+                <PersonsokForm
+                    onSubmit={(query) => {
+                        setSearchQuery(query);
+                        const queryKeys = query
+                            ? Object.keys(query).filter((key) => query[key as keyof PersonsokRequest] !== undefined)
+                            : [];
+                        trackGenereltUmamiEvent(trackingEvents.avansertSok, { queryKeys: queryKeys });
+                    }}
+                    onReset={() => setSearchQuery(undefined)}
+                />
                 {searchQuery && (
                     <Box marginBlock="space-16">
                         <PersonsokResult query={searchQuery} onClick={() => ref.current?.close()} />

--- a/src/routes/new/person.lazy.tsx
+++ b/src/routes/new/person.lazy.tsx
@@ -44,7 +44,7 @@ function PersonRouteMedTilgang() {
     return <PersonLayout />;
 }
 
-const MOBILE_BREAKPOINT = '(max-width: 767px)';
+const MOBILE_BREAKPOINT = '(max-width: 479px)';
 
 const useIsMobile = () => {
     const [isMobile, setIsMobile] = useState(() => window.matchMedia(MOBILE_BREAKPOINT).matches);
@@ -77,14 +77,14 @@ function PersonLayout() {
     const isMobile = useIsMobile();
 
     const listPanel = isMeldinger ? (
-        <VStack height={{ md: '100%' }} overflow={{ md: 'hidden' }}>
+        <VStack height={{ sm: '100%' }} overflow={{ sm: 'hidden' }}>
             <Heading size="small" visuallyHidden level="2">
                 Dialoger
             </Heading>
             <TraadList />
         </VStack>
     ) : isYtelser ? (
-        <VStack height={{ md: '100%' }} overflow={{ md: 'hidden' }}>
+        <VStack height={{ sm: '100%' }} overflow={{ sm: 'hidden' }}>
             <Heading size="small" visuallyHidden level="2">
                 Ytelser
             </Heading>

--- a/src/utils/analytics.ts
+++ b/src/utils/analytics.ts
@@ -39,7 +39,8 @@ export enum trackingEvents {
     startNyMelding = 'start ny melding',
     startSvar = 'start svar',
     avbrytMelding = 'avbryt melding',
-    notfoundRoute = 'route ikke funnet'
+    notfoundRoute = 'route ikke funnet',
+    avansertSok = 'avansert søk'
 }
 
 export enum filterType {


### PR DESCRIPTION
Tre småoppgaver i samme PR:

1. [Trello](https://trello.com/c/BT4TRAz5/360-ikke-legg-meldingene-under-meldingslisten-f%C3%B8r-skjermst%C3%B8rrelse-er-xs). Har endret liten skjerm-brekkpunkt til hakket mindre for meldinger og ytelsersiden. Dette gjer at innholdet ikkje blir wrappet under kvarandre før skjermstørrelsen < 479px
2. [Trello](https://trello.com/c/hcdRFwAq/374-nye-tags-og-zebra-for-dokumentertabell). Har lag til zebrastriper på dokumentertabell. Endret "ingen tilgang" til ein tag, og lagt til linkikon for å åpne hoveddokumentet i ny fane på sjølve dokumentraden. Her oppdaga eg også at tracking til umami ikkje fungerte, å eg oppdaterte det til den nye måten å tracke på.
3. [Trello](https://trello.com/c/S3zSfFjn/359-legg-inn-umami-tracking-p%C3%A5-avansert-s%C3%B8k). Har lagt til umami track på avansert søk. Sender også med query-nøkler slik at me kan undersøke kva nøkler som blir brukt mest under avansert søk.