### PR TITLE
lowercase p in Modia personoversikt

### DIFF
--- a/e2e/smoketest.spec.ts
+++ b/e2e/smoketest.spec.ts
@@ -16,7 +16,7 @@ test.beforeEach(async ({ page }) => {
 test('smoketest', async ({ page }) => {
     await page.goto('/');
 
-    await expect(page).toHaveTitle(/Modia Personoversikt/);
+    await expect(page).toHaveTitle(/Modia personoversikt/);
 });
 
 test('User pages', async ({ page }) => {

--- a/index.html
+++ b/index.html
@@ -80,7 +80,7 @@
 
     <script type="module" src="/src/main.tsx"></script>
 
-    <title>Modia Personoversikt</title>
+    <title>Modia personoversikt</title>
 </head>
 <body>
 <noscript>

--- a/src/app/oppdateringslogg/config/config.tsx
+++ b/src/app/oppdateringslogg/config/config.tsx
@@ -691,7 +691,7 @@ export function lagOppdateringsloggConfig(): OppdateringsloggInnslag[] {
             beskrivelse: (
                 <>
                     <p className="font-ax-bold my-2">Oppdatering fra 13.januar er ikke lenger gjeldende.</p>
-                    Sykepenger fra Infotrygd vil fortsette å eksistere i Modia Personoversikt.
+                    Sykepenger fra Infotrygd vil fortsette å eksistere i Modia personoversikt.
                     <p>
                         Det er ikke satt bestemt dato når dette skal fases ut, men sykepenger fra Infotrygd forblir i
                         hvert fall ut året. Vi jobber med å få inn vedtak frå Speil også, men datagrunnlaget fra Speil
@@ -731,7 +731,7 @@ export function lagOppdateringsloggConfig(): OppdateringsloggInnslag[] {
             beskrivelse: (
                 <>
                     <p className="my-2">
-                        Fra og med 18.mai vil ikke meldings-panelet lenger åpne seg automatisk i Modia Personoversikt.
+                        Fra og med 18.mai vil ikke meldings-panelet lenger åpne seg automatisk i Modia personoversikt.
                         Bruk "Skriv ny melding" øverst i høyre hjørne for nye meldinger, eller "Svar" på en eksisterende
                         dialog under Kommunikasjon-fanen.
                     </p>

--- a/src/components/NyModia/HvaErNyttStep.tsx
+++ b/src/components/NyModia/HvaErNyttStep.tsx
@@ -84,7 +84,7 @@ export const HvaErNyttStep = () => {
         <HStack wrap={false} gap="space-24" align="start">
             <VStack
                 ref={listboxRef}
-                aria-label="Hva er nytt i Modia Personoversikt?"
+                aria-label="Hva er nytt i Modia personoversikt?"
                 aria-orientation="vertical"
                 className="flex flex-col min-w-1/3"
                 aria-activedescendant={activeItem.id}

--- a/src/routes/personvern.tsx
+++ b/src/routes/personvern.tsx
@@ -42,7 +42,7 @@ function PersonvernPage() {
                         <VStack gap="space-32">
                             <Section title="Personvern og sikkerhet i Modia">
                                 <BodyLong>
-                                    Modia Personoversikt er en intern arbeidsflate for veiledere og saksbehandlere i
+                                    Modia personoversikt er en intern arbeidsflate for veiledere og saksbehandlere i
                                     NAV. Denne personvernerklæringen er knyttet til behandlingen av personopplysninger
                                     på dette nettstedet. For utfyllende informasjon om hvordan NAV behandler
                                     personopplysninger, kan du lese mer i{' '}
@@ -89,7 +89,7 @@ function PersonvernPage() {
                                     tjenesten basert på tilbakemeldingene vi mottar.
                                 </SubSection>
                                 <SubSection title="Umami">
-                                    Umami brukes til statistikk og analyse av hvordan Modia Personoversikt brukes. Umami
+                                    Umami brukes til statistikk og analyse av hvordan Modia personoversikt brukes. Umami
                                     bruker ikke informasjonskapsler, men henter inn opplysninger om nettleseren din for
                                     å lage en unik ID. Denne ID-en brukes for å skille deg fra andre brukere. For å
                                     hindre identifisering, bruker vi en egenutviklet proxy som vasker bort deler av


### PR DESCRIPTION
    Modia Personoversikt is treated as a name and thus personally
    identifiable information (PII) by tracking proxy, avoid this.

    has the added benefit of making the title (<title>) match the title
    (<h1>), as well as most other uses of it.

    leave the old (<2026) changelogs and Open Graph stuff alone.