### PR TITLE
Fjern corepack, håndhev node og pnpm versjon i engines

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,11 +16,10 @@ jobs:
             - uses: actions/checkout@v7
             - uses: pnpm/action-setup@v6.0.10
               with:
-                version: 11.6.0
                 run_install: false
             - uses: actions/setup-node@v7
               with:
-                  node-version: '24'
+                  node-version: '26'
                   cache: 'pnpm'
                   registry-url: https://npm.pkg.github.com
             - name: Install dependencies

--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -20,11 +20,10 @@ jobs:
               uses: actions/checkout@v7
             - uses: pnpm/action-setup@v6.0.10
               with:
-                version: 11.6.0
                 run_install: false
             - uses: actions/setup-node@v7
               with:
-                  node-version: '24'
+                  node-version: '26'
                   registry-url: https://npm.pkg.github.com
 
             - name: Install dependencies

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -23,11 +23,10 @@ jobs:
             - uses: actions/checkout@v7
             - uses: pnpm/action-setup@v6.0.10
               with:
-                version: 11.6.0
                 run_install: false
             - uses: actions/setup-node@v7
               with:
-                  node-version: '24'
+                  node-version: '26'
                   cache: 'pnpm'
                   registry-url: https://npm.pkg.github.com
             - name: Install dependencies

--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -22,11 +22,10 @@ jobs:
     - uses: actions/checkout@v7
     - uses: pnpm/action-setup@v6.0.10
       with:
-        version: 11.6.0
         run_install: false
     - uses: actions/setup-node@v7
       with:
-        node-version: '24'
+        node-version: '26'
         registry-url: https://npm.pkg.github.com
 
     - name: Install dependencies

--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -21,12 +21,11 @@ jobs:
       - uses: actions/checkout@v7
       - uses: pnpm/action-setup@v6.0.10
         with:
-          version: 11.6.0
           run_install: false
 
       - uses: actions/setup-node@v7
         with:
-          node-version: '24'
+          node-version: '26'
           cache: 'pnpm'
           registry-url: https://npm.pkg.github.com
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,6 @@
 FROM node:26-slim AS builder
 
-ENV PNPM_HOME="/pnpm"
-ENV PATH="$PNPM_HOME:$PATH"
-RUN corepack enable && corepack prepare pnpm@11.6.0 --activate
+RUN npm install -g pnpm@11.6.0
 
 WORKDIR /app
 COPY pnpm-lock.yaml  /app

--- a/package.json
+++ b/package.json
@@ -3,14 +3,15 @@
     "version": "0.4.2",
     "private": false,
     "license": "MIT",
+    "packageManager": "pnpm@11.6.0",
     "main": "build/dist/index.js",
     "type": "module",
-    "packageManager": "pnpm@11.6.0",
     "files": [
         "build/dist/"
     ],
     "engines": {
-        "node": "^24.0 || ^26.0"
+        "node": ">=26.0",
+        "pnpm": ">=11.6.0"
     },
     "repository": {
         "type": "git",

--- a/package.json
+++ b/package.json
@@ -138,7 +138,7 @@
         "@testing-library/user-event": "^14.6.1",
         "@types/lodash": "^4.17.20",
         "@types/md5": "^2.3.6",
-        "@types/node": "^24.9.1",
+        "@types/node": "^26.2.0",
         "@types/prop-types": "^15.7.15",
         "@types/react": "19.2.1",
         "@types/react-collapse": "^5.0.4",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -49,7 +49,7 @@ importers:
         version: 1.125.6(react-dom@19.2.1(react@19.2.1))(react@19.2.1)
       '@vitejs/plugin-react':
         specifier: ^5.0.4
-        version: 5.0.4(supports-color@10.2.2)(vite@7.1.11(@types/node@24.9.1)(jiti@2.6.1)(less@4.4.2)(lightningcss@1.32.0)(tsx@4.20.6)(yaml@2.8.3))
+        version: 5.0.4(supports-color@10.2.2)(vite@7.1.11(@types/node@26.2.0)(jiti@2.6.1)(less@4.4.2)(lightningcss@1.32.0)(tsx@4.20.6)(yaml@2.8.3))
       classnames:
         specifier: ^2.5.1
         version: 2.5.1
@@ -232,10 +232,10 @@ importers:
         version: 3.5.0
       vite:
         specifier: ^7.1.11
-        version: 7.1.11(@types/node@24.9.1)(jiti@2.6.1)(less@4.4.2)(lightningcss@1.32.0)(tsx@4.20.6)(yaml@2.8.3)
+        version: 7.1.11(@types/node@26.2.0)(jiti@2.6.1)(less@4.4.2)(lightningcss@1.32.0)(tsx@4.20.6)(yaml@2.8.3)
       vite-plugin-svgr:
         specifier: ^4.5.0
-        version: 4.5.0(rollup@4.59.0)(typescript@5.8.3)(vite@7.1.11(@types/node@24.9.1)(jiti@2.6.1)(less@4.4.2)(lightningcss@1.32.0)(tsx@4.20.6)(yaml@2.8.3))
+        version: 4.5.0(rollup@4.59.0)(typescript@5.8.3)(vite@7.1.11(@types/node@26.2.0)(jiti@2.6.1)(less@4.4.2)(lightningcss@1.32.0)(tsx@4.20.6)(yaml@2.8.3))
       zod:
         specifier: ^3.25.76
         version: 3.25.76
@@ -266,7 +266,7 @@ importers:
         version: 1.124.0(@tanstack/react-router@1.125.6(react-dom@19.2.1(react@19.2.1))(react@19.2.1))(@tanstack/router-core@1.133.25)(csstype@3.2.3)(react-dom@19.2.1(react@19.2.1))(react@19.2.1)(solid-js@1.9.7)(tiny-invariant@1.3.3)
       '@tanstack/router-plugin':
         specifier: ^1.124.0
-        version: 1.124.0(@tanstack/react-router@1.125.6(react-dom@19.2.1(react@19.2.1))(react@19.2.1))(supports-color@10.2.2)(vite@7.1.11(@types/node@24.9.1)(jiti@2.6.1)(less@4.4.2)(lightningcss@1.32.0)(tsx@4.20.6)(yaml@2.8.3))
+        version: 1.124.0(@tanstack/react-router@1.125.6(react-dom@19.2.1(react@19.2.1))(react@19.2.1))(supports-color@10.2.2)(vite@7.1.11(@types/node@26.2.0)(jiti@2.6.1)(less@4.4.2)(lightningcss@1.32.0)(tsx@4.20.6)(yaml@2.8.3))
       '@testing-library/jest-dom':
         specifier: ^6.9.1
         version: 6.9.1
@@ -283,8 +283,8 @@ importers:
         specifier: ^2.3.6
         version: 2.3.6
       '@types/node':
-        specifier: ^24.9.1
-        version: 24.9.1
+        specifier: ^26.2.0
+        version: 26.2.0
       '@types/prop-types':
         specifier: ^15.7.15
         version: 15.7.15
@@ -320,7 +320,7 @@ importers:
         version: 7.2.0(styled-components@6.1.19(react-dom@19.2.1(react@19.2.1))(react@19.2.1))
       knip:
         specifier: ^5.66.3
-        version: 5.66.3(@types/node@24.9.1)(typescript@5.8.3)
+        version: 5.66.3(@types/node@26.2.0)(typescript@5.8.3)
       less:
         specifier: ^4.4.2
         version: 4.4.2
@@ -329,7 +329,7 @@ importers:
         version: 16.2.7
       msw:
         specifier: ^2.12.7
-        version: 2.12.7(@types/node@24.9.1)(typescript@5.8.3)
+        version: 2.12.7(@types/node@26.2.0)(typescript@5.8.3)
       nav-faker:
         specifier: ^3.2.4
         version: 3.2.4
@@ -362,7 +362,7 @@ importers:
         version: 0.2.3
       vitest:
         specifier: ^4.1.1
-        version: 4.1.1(@opentelemetry/api@1.9.0)(@types/node@24.9.1)(happy-dom@20.0.8)(msw@2.12.7(@types/node@24.9.1)(typescript@5.8.3))(vite@7.1.11(@types/node@24.9.1)(jiti@2.6.1)(less@4.4.2)(lightningcss@1.32.0)(tsx@4.20.6)(yaml@2.8.3))
+        version: 4.1.1(@opentelemetry/api@1.9.0)(@types/node@26.2.0)(happy-dom@20.0.8)(msw@2.12.7(@types/node@26.2.0)(typescript@5.8.3))(vite@7.1.11(@types/node@26.2.0)(jiti@2.6.1)(less@4.4.2)(lightningcss@1.32.0)(tsx@4.20.6)(yaml@2.8.3))
 
 packages:
 
@@ -2098,6 +2098,9 @@ packages:
 
   '@types/node@24.9.1':
     resolution: {integrity: sha512-QoiaXANRkSXK6p0Duvt56W208du4P9Uye9hWLWgGMDTEoKPhuenzNcC4vGUmrNkiOKTlIrBoyNQYNpSwfEZXSg==}
+
+  '@types/node@26.2.0':
+    resolution: {integrity: sha512-5IviulTZeRNp2vAJ514cc/HUlY5nZ9fCbq9DMyC52BrhFZACo3nI0R7qBxhQmo/d27NFe96ur/b7Wwxklda+kg==}
 
   '@types/prop-types@15.7.15':
     resolution: {integrity: sha512-F6bEyamV9jKGAFBEmlQnesRPGOQqS2+Uwi0Em15xenOxHaf2hv6L8YCVn3rPdPJOiJfPiCnLIRyvwVaqMY3MIw==}
@@ -4061,6 +4064,9 @@ packages:
   undici-types@7.16.0:
     resolution: {integrity: sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw==}
 
+  undici-types@8.3.0:
+    resolution: {integrity: sha512-j375ScV60dom+YkPFIfTLcOiPxkN/buHz5GobjLhixFuANaNs3C9l4GmrWqejgXWJ7BbJcFYpTEUkS1Ge8bpZQ==}
+
   undici@7.24.0:
     resolution: {integrity: sha512-jxytwMHhsbdpBXxLAcuu0fzlQeXCNnWdDyRHpvWsUl8vd98UwYdl9YTyn8/HcpcJPC3pwUveefsa3zTxyD/ERg==}
     engines: {node: '>=20.18.1'}
@@ -5139,31 +5145,31 @@ snapshots:
 
   '@inquirer/ansi@1.0.2': {}
 
-  '@inquirer/confirm@5.1.21(@types/node@24.9.1)':
+  '@inquirer/confirm@5.1.21(@types/node@26.2.0)':
     dependencies:
-      '@inquirer/core': 10.3.2(@types/node@24.9.1)
-      '@inquirer/type': 3.0.10(@types/node@24.9.1)
+      '@inquirer/core': 10.3.2(@types/node@26.2.0)
+      '@inquirer/type': 3.0.10(@types/node@26.2.0)
     optionalDependencies:
-      '@types/node': 24.9.1
+      '@types/node': 26.2.0
 
-  '@inquirer/core@10.3.2(@types/node@24.9.1)':
+  '@inquirer/core@10.3.2(@types/node@26.2.0)':
     dependencies:
       '@inquirer/ansi': 1.0.2
       '@inquirer/figures': 1.0.15
-      '@inquirer/type': 3.0.10(@types/node@24.9.1)
+      '@inquirer/type': 3.0.10(@types/node@26.2.0)
       cli-width: 4.1.0
       mute-stream: 2.0.0
       signal-exit: 4.1.0
       wrap-ansi: 6.2.0
       yoctocolors-cjs: 2.1.3
     optionalDependencies:
-      '@types/node': 24.9.1
+      '@types/node': 26.2.0
 
   '@inquirer/figures@1.0.15': {}
 
-  '@inquirer/type@3.0.10(@types/node@24.9.1)':
+  '@inquirer/type@3.0.10(@types/node@26.2.0)':
     optionalDependencies:
-      '@types/node': 24.9.1
+      '@types/node': 26.2.0
 
   '@jridgewell/gen-mapping@0.3.12':
     dependencies:
@@ -6014,7 +6020,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@tanstack/router-plugin@1.124.0(@tanstack/react-router@1.125.6(react-dom@19.2.1(react@19.2.1))(react@19.2.1))(supports-color@10.2.2)(vite@7.1.11(@types/node@24.9.1)(jiti@2.6.1)(less@4.4.2)(lightningcss@1.32.0)(tsx@4.20.6)(yaml@2.8.3))':
+  '@tanstack/router-plugin@1.124.0(@tanstack/react-router@1.125.6(react-dom@19.2.1(react@19.2.1))(react@19.2.1))(supports-color@10.2.2)(vite@7.1.11(@types/node@26.2.0)(jiti@2.6.1)(less@4.4.2)(lightningcss@1.32.0)(tsx@4.20.6)(yaml@2.8.3))':
     dependencies:
       '@babel/core': 7.28.0(supports-color@10.2.2)
       '@babel/plugin-syntax-jsx': 7.27.1(@babel/core@7.28.0(supports-color@10.2.2))
@@ -6032,7 +6038,7 @@ snapshots:
       zod: 3.25.76
     optionalDependencies:
       '@tanstack/react-router': 1.125.6(react-dom@19.2.1(react@19.2.1))(react@19.2.1)
-      vite: 7.1.11(@types/node@24.9.1)(jiti@2.6.1)(less@4.4.2)(lightningcss@1.32.0)(tsx@4.20.6)(yaml@2.8.3)
+      vite: 7.1.11(@types/node@26.2.0)(jiti@2.6.1)(less@4.4.2)(lightningcss@1.32.0)(tsx@4.20.6)(yaml@2.8.3)
     transitivePeerDependencies:
       - supports-color
 
@@ -6160,6 +6166,10 @@ snapshots:
     dependencies:
       undici-types: 7.16.0
 
+  '@types/node@26.2.0':
+    dependencies:
+      undici-types: 8.3.0
+
   '@types/prop-types@15.7.15': {}
 
   '@types/react-collapse@5.0.4':
@@ -6284,7 +6294,7 @@ snapshots:
       '@typescript-eslint/types': 8.57.1
       eslint-visitor-keys: 5.0.1
 
-  '@vitejs/plugin-react@5.0.4(supports-color@10.2.2)(vite@7.1.11(@types/node@24.9.1)(jiti@2.6.1)(less@4.4.2)(lightningcss@1.32.0)(tsx@4.20.6)(yaml@2.8.3))':
+  '@vitejs/plugin-react@5.0.4(supports-color@10.2.2)(vite@7.1.11(@types/node@26.2.0)(jiti@2.6.1)(less@4.4.2)(lightningcss@1.32.0)(tsx@4.20.6)(yaml@2.8.3))':
     dependencies:
       '@babel/core': 7.28.4(supports-color@10.2.2)
       '@babel/plugin-transform-react-jsx-self': 7.27.1(@babel/core@7.28.4(supports-color@10.2.2))
@@ -6292,7 +6302,7 @@ snapshots:
       '@rolldown/pluginutils': 1.0.0-beta.38
       '@types/babel__core': 7.20.5
       react-refresh: 0.17.0
-      vite: 7.1.11(@types/node@24.9.1)(jiti@2.6.1)(less@4.4.2)(lightningcss@1.32.0)(tsx@4.20.6)(yaml@2.8.3)
+      vite: 7.1.11(@types/node@26.2.0)(jiti@2.6.1)(less@4.4.2)(lightningcss@1.32.0)(tsx@4.20.6)(yaml@2.8.3)
     transitivePeerDependencies:
       - supports-color
 
@@ -6305,14 +6315,14 @@ snapshots:
       chai: 6.2.2
       tinyrainbow: 3.0.3
 
-  '@vitest/mocker@4.1.1(msw@2.12.7(@types/node@24.9.1)(typescript@5.8.3))(vite@7.1.11(@types/node@24.9.1)(jiti@2.6.1)(less@4.4.2)(lightningcss@1.32.0)(tsx@4.20.6)(yaml@2.8.3))':
+  '@vitest/mocker@4.1.1(msw@2.12.7(@types/node@26.2.0)(typescript@5.8.3))(vite@7.1.11(@types/node@26.2.0)(jiti@2.6.1)(less@4.4.2)(lightningcss@1.32.0)(tsx@4.20.6)(yaml@2.8.3))':
     dependencies:
       '@vitest/spy': 4.1.1
       estree-walker: 3.0.3
       magic-string: 0.30.21
     optionalDependencies:
-      msw: 2.12.7(@types/node@24.9.1)(typescript@5.8.3)
-      vite: 7.1.11(@types/node@24.9.1)(jiti@2.6.1)(less@4.4.2)(lightningcss@1.32.0)(tsx@4.20.6)(yaml@2.8.3)
+      msw: 2.12.7(@types/node@26.2.0)(typescript@5.8.3)
+      vite: 7.1.11(@types/node@26.2.0)(jiti@2.6.1)(less@4.4.2)(lightningcss@1.32.0)(tsx@4.20.6)(yaml@2.8.3)
 
   '@vitest/pretty-format@4.1.1':
     dependencies:
@@ -7009,10 +7019,10 @@ snapshots:
     dependencies:
       json-buffer: 3.0.1
 
-  knip@5.66.3(@types/node@24.9.1)(typescript@5.8.3):
+  knip@5.66.3(@types/node@26.2.0)(typescript@5.8.3):
     dependencies:
       '@nodelib/fs.walk': 1.2.8
-      '@types/node': 24.9.1
+      '@types/node': 26.2.0
       fast-glob: 3.3.3
       formatly: 0.3.0
       jiti: 2.6.1
@@ -7197,9 +7207,9 @@ snapshots:
 
   ms@2.1.3: {}
 
-  msw@2.12.7(@types/node@24.9.1)(typescript@5.8.3):
+  msw@2.12.7(@types/node@26.2.0)(typescript@5.8.3):
     dependencies:
-      '@inquirer/confirm': 5.1.21(@types/node@24.9.1)
+      '@inquirer/confirm': 5.1.21(@types/node@26.2.0)
       '@mswjs/interceptors': 0.40.0
       '@open-draft/deferred-promise': 2.2.0
       '@types/statuses': 2.0.6
@@ -8082,6 +8092,8 @@ snapshots:
 
   undici-types@7.16.0: {}
 
+  undici-types@8.3.0: {}
+
   undici@7.24.0: {}
 
   unplugin@2.3.5:
@@ -8125,12 +8137,12 @@ snapshots:
       fast-glob: 3.3.3
       magic-string: 0.30.21
 
-  vite-plugin-svgr@4.5.0(rollup@4.59.0)(typescript@5.8.3)(vite@7.1.11(@types/node@24.9.1)(jiti@2.6.1)(less@4.4.2)(lightningcss@1.32.0)(tsx@4.20.6)(yaml@2.8.3)):
+  vite-plugin-svgr@4.5.0(rollup@4.59.0)(typescript@5.8.3)(vite@7.1.11(@types/node@26.2.0)(jiti@2.6.1)(less@4.4.2)(lightningcss@1.32.0)(tsx@4.20.6)(yaml@2.8.3)):
     dependencies:
       '@rollup/pluginutils': 5.3.0(rollup@4.59.0)
       '@svgr/core': 8.1.0(supports-color@10.2.2)(typescript@5.8.3)
       '@svgr/plugin-jsx': 8.1.0(@svgr/core@8.1.0(typescript@5.8.3))
-      vite: 7.1.11(@types/node@24.9.1)(jiti@2.6.1)(less@4.4.2)(lightningcss@1.32.0)(tsx@4.20.6)(yaml@2.8.3)
+      vite: 7.1.11(@types/node@26.2.0)(jiti@2.6.1)(less@4.4.2)(lightningcss@1.32.0)(tsx@4.20.6)(yaml@2.8.3)
     transitivePeerDependencies:
       - rollup
       - supports-color
@@ -8141,7 +8153,7 @@ snapshots:
       fast-glob: 3.3.2
       vite-plugin-dynamic-import: 1.6.0
 
-  vite@7.1.11(@types/node@24.9.1)(jiti@2.6.1)(less@4.4.2)(lightningcss@1.32.0)(tsx@4.20.6)(yaml@2.8.3):
+  vite@7.1.11(@types/node@26.2.0)(jiti@2.6.1)(less@4.4.2)(lightningcss@1.32.0)(tsx@4.20.6)(yaml@2.8.3):
     dependencies:
       esbuild: 0.25.11
       fdir: 6.5.0(picomatch@4.0.4)
@@ -8150,7 +8162,7 @@ snapshots:
       rollup: 4.59.0
       tinyglobby: 0.2.15
     optionalDependencies:
-      '@types/node': 24.9.1
+      '@types/node': 26.2.0
       fsevents: 2.3.3
       jiti: 2.6.1
       less: 4.4.2
@@ -8158,10 +8170,10 @@ snapshots:
       tsx: 4.20.6
       yaml: 2.8.3
 
-  vitest@4.1.1(@opentelemetry/api@1.9.0)(@types/node@24.9.1)(happy-dom@20.0.8)(msw@2.12.7(@types/node@24.9.1)(typescript@5.8.3))(vite@7.1.11(@types/node@24.9.1)(jiti@2.6.1)(less@4.4.2)(lightningcss@1.32.0)(tsx@4.20.6)(yaml@2.8.3)):
+  vitest@4.1.1(@opentelemetry/api@1.9.0)(@types/node@26.2.0)(happy-dom@20.0.8)(msw@2.12.7(@types/node@26.2.0)(typescript@5.8.3))(vite@7.1.11(@types/node@26.2.0)(jiti@2.6.1)(less@4.4.2)(lightningcss@1.32.0)(tsx@4.20.6)(yaml@2.8.3)):
     dependencies:
       '@vitest/expect': 4.1.1
-      '@vitest/mocker': 4.1.1(msw@2.12.7(@types/node@24.9.1)(typescript@5.8.3))(vite@7.1.11(@types/node@24.9.1)(jiti@2.6.1)(less@4.4.2)(lightningcss@1.32.0)(tsx@4.20.6)(yaml@2.8.3))
+      '@vitest/mocker': 4.1.1(msw@2.12.7(@types/node@26.2.0)(typescript@5.8.3))(vite@7.1.11(@types/node@26.2.0)(jiti@2.6.1)(less@4.4.2)(lightningcss@1.32.0)(tsx@4.20.6)(yaml@2.8.3))
       '@vitest/pretty-format': 4.1.1
       '@vitest/runner': 4.1.1
       '@vitest/snapshot': 4.1.1
@@ -8178,11 +8190,11 @@ snapshots:
       tinyexec: 1.0.2
       tinyglobby: 0.2.15
       tinyrainbow: 3.0.3
-      vite: 7.1.11(@types/node@24.9.1)(jiti@2.6.1)(less@4.4.2)(lightningcss@1.32.0)(tsx@4.20.6)(yaml@2.8.3)
+      vite: 7.1.11(@types/node@26.2.0)(jiti@2.6.1)(less@4.4.2)(lightningcss@1.32.0)(tsx@4.20.6)(yaml@2.8.3)
       why-is-node-running: 2.3.0
     optionalDependencies:
       '@opentelemetry/api': 1.9.0
-      '@types/node': 24.9.1
+      '@types/node': 26.2.0
       happy-dom: 20.0.8
     transitivePeerDependencies:
       - msw

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -129,6 +129,7 @@ export default defineConfig({
         pool: 'threads',
         globals: true,
         environment: 'happy-dom',
+        execArgv: ['--no-experimental-webstorage'],
         setupFiles: './src/setupTests.ts',
         css: {
             modules: {


### PR DESCRIPTION
 - Oppgraderer Node fra 24 til 26 i alle GitHub Actions-workflows og Dockerfile
 - Erstattar `corepack enable && corepack prepare pnpm@11.6.0 activate ` med `npm install -g pnpm@11.6.0. `
    - corepack ble fjerna fra Node 25+. I staden installeres pnpm direkte via npm, som er den nye måten å gjera det på.
 - Legger til packageManager: "pnpm@11.6.0" i package.json slik at pnpm/action-setup leser versjonen 
derfraderifrå automatisk — og Dependabot held den oppdatert
     -  pnpm-versjonen er no definert kun ein stad (packageManager i package.json) og Dependabot oppdaterer den
automatisk. Workflows leser versjonen derfra via pnpm/action-setup. Ein må sjølv holde versjonen av pnpm oppdatert manuelt i Dockerfila.
 - Oppdaterer engines.node til >=26.0 og legger til engines.pnpm: ">=11.6.0"
    - Har lagt på pnpm i engines for då er det sikra at denne versjonen blir brukt ved lokal utvikling også.
 - Legger på flagget `--no-experimental-webstorage` i vite config for at testene skal køyre. Dette er pga at Node no også har localstore på serveren. Det applier ikkje oss sidan me ikkje har noko server side rendering.
 - Oppdatert node types til samme versjon som node - 26