### PR TITLE
Legg til scope på nav registry i dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,6 +6,7 @@ registries:
     url: https://npm.pkg.github.com
     token: ${{ secrets.READER_TOKEN }}
     replaces-base: false
+    scope: "@navikt"
 
 updates:
   - package-ecosystem: npm


### PR DESCRIPTION
Tidlegere i sommar/vår så fjerna  me `.npmrc` fila og flytta config til` pnpm-workcspace.yaml`. Før denne endringa så brukte dependabot denne fila for å finne config for npm private registry. Det har ikkje fungert etter me sletta fila, og dependabot har ikkje klart å lage nye PRs. Dette er løyst med å legge til scope i `dependabot.yml` og dependabot klarer å generere `.npmrc` basert på dette.
